### PR TITLE
Convert C++ style comments to C89

### DIFF
--- a/include/api/syscall.h
+++ b/include/api/syscall.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <config.h> // for arch/api/syscall.h
+#include <config.h> /* for arch/api/syscall.h */
 #include <machine.h>
 #include <api/failures.h>
 #include <model/statedata.h>

--- a/include/arch/arm/arch/64/mode/machine/registerset.h
+++ b/include/arch/arm/arch/64/mode/machine/registerset.h
@@ -32,21 +32,21 @@
 
 /* ESR register */
 #define ESR_EC_SHIFT            26
-#define ESR_EC_LEL_DABT         0x24    // Data abort from a lower EL
-#define ESR_EC_CEL_DABT         0x25    // Data abort from the current EL
-#define ESR_EC_LEL_IABT         0x20    // Instruction abort from a lower EL
-#define ESR_EC_CEL_IABT         0x21    // Instruction abort from the current EL
-#define ESR_EC_LEL_SVC64        0x15    // SVC from a lower EL in AArch64 state
-#define ESR_EC_LEL_HVC64        0x16    // HVC from EL1 in AArch64 state
-#define ESR_EL1_EC_ENFP         0x7     // Access to Advanced SIMD or floating-point registers
+#define ESR_EC_LEL_DABT         0x24    /* Data abort from a lower EL */
+#define ESR_EC_CEL_DABT         0x25    /* Data abort from the current EL */
+#define ESR_EC_LEL_IABT         0x20    /* Instruction abort from a lower EL */
+#define ESR_EC_CEL_IABT         0x21    /* Instruction abort from the current EL */
+#define ESR_EC_LEL_SVC64        0x15    /* SVC from a lower EL in AArch64 state */
+#define ESR_EC_LEL_HVC64        0x16    /* HVC from EL1 in AArch64 state */
+#define ESR_EL1_EC_ENFP         0x7     /* Access to Advanced SIMD or floating-point registers */
 
 
 /* ID_AA64PFR0_EL1 register */
-#define ID_AA64PFR0_EL1_FP      16     // HWCap for Floating Point
-#define ID_AA64PFR0_EL1_ASIMD   20     // HWCap for Advanced SIMD
+#define ID_AA64PFR0_EL1_FP      16     /* HWCap for Floating Point */
+#define ID_AA64PFR0_EL1_ASIMD   20     /* HWCap for Advanced SIMD */
 
 /* CPACR_EL1 register */
-#define CPACR_EL1_FPEN          20     // FP registers access
+#define CPACR_EL1_FPEN          20     /* FP registers access */
 
 /*
  * We cannot allow async aborts in the verified kernel, but they are useful

--- a/include/arch/arm/arch/machine/gic_v3.h
+++ b/include/arch/arm/arch/machine/gic_v3.h
@@ -329,7 +329,7 @@ static inline void ackInterrupt(irq_t irq)
     /* Perform priority drop for current IRQ */
     SYSTEM_WRITE_WORD(ICC_EOIR1_EL1, hw_irq);
 
-    // If the IRQ is not going to user level then we need to deactivate it too.
+    /* If the IRQ is not going to user level then we need to deactivate it too. */
     if (unlikely(hw_irq > maxIRQ) ||
         intStateIRQTable[IRQT_TO_IDX(irq)] != IRQSignal) {
         /* There needs to be an isb() to ensure completion of the system

--- a/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
+++ b/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
@@ -593,19 +593,19 @@ static inline void vcpu_init_vtcr(void)
     /* Set up the stage-2 translation control register for cores supporting 44-bit PA */
     uint32_t vtcr_el2;
 #ifdef CONFIG_ARM_PA_SIZE_BITS_40
-    vtcr_el2 = VTCR_EL2_T0SZ(24);                            // 40-bit input IPA
-    vtcr_el2 |= VTCR_EL2_PS(PS_1T);                          // 40-bit PA size
-    vtcr_el2 |= VTCR_EL2_SL0(SL0_4K_L1);                     // 4KiB, start at level 1
+    vtcr_el2 = VTCR_EL2_T0SZ(24);                            /* 40-bit input IPA */
+    vtcr_el2 |= VTCR_EL2_PS(PS_1T);                          /* 40-bit PA size */
+    vtcr_el2 |= VTCR_EL2_SL0(SL0_4K_L1);                     /* 4KiB, start at level 1 */
 #else
-    vtcr_el2 = VTCR_EL2_T0SZ(20);                            // 44-bit input IPA
-    vtcr_el2 |= VTCR_EL2_PS(PS_16T);                         // 44-bit PA size
-    vtcr_el2 |= VTCR_EL2_SL0(SL0_4K_L0);                     // 4KiB, start at level 0
+    vtcr_el2 = VTCR_EL2_T0SZ(20);                            /* 44-bit input IPA */
+    vtcr_el2 |= VTCR_EL2_PS(PS_16T);                         /* 44-bit PA size */
+    vtcr_el2 |= VTCR_EL2_SL0(SL0_4K_L0);                     /* 4KiB, start at level 0 */
 #endif
-    vtcr_el2 |= VTCR_EL2_IRGN0(NORMAL_WB_WA_CACHEABLE);      // inner write-back, read/write allocate
-    vtcr_el2 |= VTCR_EL2_ORGN0(NORMAL_WB_WA_CACHEABLE);      // outer write-back, read/write allocate
-    vtcr_el2 |= VTCR_EL2_SH0(SH0_INNER);                     // inner shareable
-    vtcr_el2 |= VTCR_EL2_TG0(TG0_4K);                        // 4KiB page size
-    vtcr_el2 |= BIT(31);                                     // reserved as 1
+    vtcr_el2 |= VTCR_EL2_IRGN0(NORMAL_WB_WA_CACHEABLE);      /* inner write-back, read/write allocate */
+    vtcr_el2 |= VTCR_EL2_ORGN0(NORMAL_WB_WA_CACHEABLE);      /* outer write-back, read/write allocate */
+    vtcr_el2 |= VTCR_EL2_SH0(SH0_INNER);                     /* inner shareable */
+    vtcr_el2 |= VTCR_EL2_TG0(TG0_4K);                        /* 4KiB page size */
+    vtcr_el2 |= BIT(31);                                     /* reserved as 1 */
 
     MSR(REG_VTCR_EL2, vtcr_el2);
     isb();

--- a/include/arch/riscv/arch/machine.h
+++ b/include/arch/riscv/arch/machine.h
@@ -299,4 +299,4 @@ static inline exception_t Arch_setTLSRegister(word_t tls_base)
     return EXCEPTION_NONE;
 }
 
-#endif // __ASSEMBLER__
+#endif /* __ASSEMBLER__ */

--- a/include/arch/x86/arch/32/mode/fastpath/fastpath.h
+++ b/include/arch/x86/arch/32/mode/fastpath/fastpath.h
@@ -116,7 +116,7 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
         "movl %%ecx, %%esp\n"
         "popl %%edi \n"
         "popl %%ebp \n"
-        // Skip FaultIP and Error
+        /* Skip FaultIP and Error */
         "addl $8, %%esp \n"
         "popl %%edx \n"
         "movl 8(%%esp), %%ecx \n"

--- a/include/arch/x86/arch/64/mode/fastpath/fastpath.h
+++ b/include/arch/x86/arch/64/mode/fastpath/fastpath.h
@@ -174,23 +174,23 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
             "popq %%r12\n"
             "popq %%r13\n"
             "popq %%r14\n"
-            // Skip RDX, we need to put NextIP into it
+            /* Skip RDX, we need to put NextIP into it */
             "addq $8, %%rsp\n"
             "popq %%r10\n"
             "popq %%r8\n"
             "popq %%r9\n"
             "popq %%r15\n"
-            // restore RFLAGS
+            /* restore RFLAGS */
             "popfq\n"
-            // reset interrupt bit
+            /* reset interrupt bit */
             "orq %[IF], -8(%%rsp)\n"
-            // Restore NextIP
+            /* Restore NextIP */
             "popq %%rdx\n"
-            // skip Error
+            /* skip Error */
             "addq $8, %%rsp\n"
-            // restore RSP
+            /* restore RSP */
             "popq %%rcx\n"
-            // Skip FaultIP
+            /* Skip FaultIP */
             "addq $8, %%rsp\n"
 #if defined(ENABLE_SMP_SUPPORT) && defined(CONFIG_KERNEL_SKIM_WINDOW)
             "popq %%rsp\n"
@@ -217,7 +217,7 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
         );
     } else {
         asm volatile(
-            // Set our stack pointer to the top of the tcb so we can efficiently pop
+            /* Set our stack pointer to the top of the tcb so we can efficiently pop */
             "movq %0, %%rsp\n"
             "popq %%rax\n"
             "popq %%rbx\n"
@@ -230,9 +230,9 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
             "popq %%r8\n"
             "popq %%r9\n"
             "popq %%r15\n"
-            //restore RFLAGS
+            /*restore RFLAGS */
             "popq %%r11\n"
-            // Restore NextIP
+            /* Restore NextIP */
 #if defined(ENABLE_SMP_SUPPORT) && defined(CONFIG_KERNEL_SKIM_WINDOW)
             "popq %%rsp\n"
             "movq %%rcx, %%cr3\n"
@@ -244,10 +244,10 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
             "movq %%rsp, %%cr3\n"
 #endif /* CONFIG_KERNEL_SKIM_WINDOW */
 #endif /* defined(ENABLE_SMP_SUPPORT) && defined(CONFIG_KERNEL_SKIM_WINDOW) */
-            // clear RSP to not leak information to the user
+            /* clear RSP to not leak information to the user */
             "xor %%rsp, %%rsp\n"
-            // More register but we can ignore and are done restoring
-            // enable interrupt disabled by sysenter
+            /* More register but we can ignore and are done restoring */
+            /* enable interrupt disabled by sysenter */
             "sysretq\n"
             :
             : "r"(&cur_thread->tcbArch.tcbContext.registers[RAX]),

--- a/include/arch/x86/arch/64/mode/machine.h
+++ b/include/arch/x86/arch/64/mode/machine.h
@@ -49,8 +49,8 @@ static inline cr3_t getCurrentCR3(void)
 static inline cr3_t getCurrentUserCR3(void)
 {
 #ifdef CONFIG_KERNEL_SKIM_WINDOW
-    // Construct a cr3_t from the state word, dropping any command information
-    // if needed
+    /* Construct a cr3_t from the state word, dropping any command information */
+    /* if needed */
     word_t cr3_word = MODE_NODE_STATE(x64KSCurrentUserCR3);
     cr3_t cr3_ret;
     if (config_set(CONFIG_SUPPORT_PCID)) {
@@ -95,9 +95,9 @@ static inline void setCurrentCR3(cr3_t cr3, word_t preserve_translation)
 static inline void setCurrentUserCR3(cr3_t cr3)
 {
 #ifdef CONFIG_KERNEL_SKIM_WINDOW
-    // To make the restore stubs more efficient we will set the preserve_translation
-    // command in the state. If we look at the cr3 later on we need to remember to
-    // remove that bit
+    /* To make the restore stubs more efficient we will set the preserve_translation */
+    /* command in the state. If we look at the cr3 later on we need to remember to */
+    /* remove that bit */
     word_t cr3_word = cr3.words[0];
     if (config_set(CONFIG_SUPPORT_PCID)) {
         cr3_word |= BIT(63);

--- a/include/arch/x86/arch/64/mode/machine/registerset.h
+++ b/include/arch/x86/arch/64/mode/machine/registerset.h
@@ -21,10 +21,10 @@
  * and sysenter have to do some juggling to make
  * things work */
 enum _register {
-    // User registers that will be preserved during syscall
-    // Deliberately place the cap and badge registers early
-    // So that when popping on the fastpath we can just not
-    // pop these
+    /* User registers that will be preserved during syscall */
+    /* Deliberately place the cap and badge registers early */
+    /* So that when popping on the fastpath we can just not */
+    /* pop these */
     RDI                     = 0,    /* 0x00 */
     capRegister             = 0,
     badgeRegister           = 0,
@@ -43,28 +43,28 @@ enum _register {
 #endif
     R14                     = 7,    /* 0x38 */
     RDX                     = 8,    /* 0x40 */
-    // Group the message registers so they can be efficiently copied
+    /* Group the message registers so they can be efficiently copied */
     R10                     = 9,    /* 0x48 */
     R8                      = 10,   /* 0x50 */
     R9                      = 11,   /* 0x58 */
     R15                     = 12,   /* 0x60 */
     FLAGS                   = 13,   /* 0x68 */
-    // Put the NextIP, which is a virtual register, here as we
-    // need to set this in the syscall path
+    /* Put the NextIP, which is a virtual register, here as we */
+    /* need to set this in the syscall path */
     NextIP                  = 14,   /* 0x70 */
-    // Same for the error code
+    /* Same for the error code */
     Error                   = 15,   /* 0x78 */
     /* Kernel stack points here on kernel entry */
     RSP                     = 16,   /* 0x80 */
     FaultIP                 = 17,   /* 0x88 */
-    // Now user Registers that get clobbered by syscall
+    /* Now user Registers that get clobbered by syscall */
     R11                     = 18,   /* 0x90 */
     RCX                     = 19,   /* 0x98 */
     CS                      = 20,   /* 0xa0 */
     SS                      = 21,   /* 0xa8 */
     n_immContextRegisters   = 22,   /* 0xb0 */
 
-    // For locality put these here as well
+    /* For locality put these here as well */
     FS_BASE                 = 22,   /* 0xb0 */
     TLS_BASE                = FS_BASE,
     GS_BASE                 = 23,   /* 0xb8 */

--- a/include/arch/x86/arch/64/mode/object/structures.h
+++ b/include/arch/x86/arch/64/mode/object/structures.h
@@ -15,7 +15,7 @@
 #define GDT_NULL    0
 #define GDT_CS_0    1
 #define GDT_DS_0    2
-#define GDT_TSS     3 //TSS is two slots in x86-64
+#define GDT_TSS     3 /*TSS is two slots in x86-64 */
 #define GDT_CS_3    5
 #define GDT_DS_3    6
 #define GDT_FS      7

--- a/include/arch/x86/arch/kernel/tlb_bitmap.h
+++ b/include/arch/x86/arch/kernel/tlb_bitmap.h
@@ -40,7 +40,7 @@ static inline word_t tlb_bitmap_get(vspace_root_t *root)
 
     for (int i = 0; i < TLBBITMAP_ROOT_ENTRIES; i++) {
         word_t entry = root[TLBBITMAP_ROOT_INDEX + i].words[0];
-        // skip present bit
+        /* skip present bit */
         entry >>= 1;
 
         int shift = i * TLBBITMAP_ENTRIES_PER_ROOT;

--- a/include/drivers/irq/bcm2836-armctrl-ic.h
+++ b/include/drivers/irq/bcm2836-armctrl-ic.h
@@ -29,8 +29,8 @@ enum {
     INTERRUPT_CORE_PMU                       =  9,
     INTERRUPT_CORE_AXI                       = 10,
     INTERRUPT_CORE_LOCAL_TIMER               = 11,
-    //17:12 Peripheral 1..15 interrupt (Currently not used)
-    //31:28 <Reserved>
+    /*17:12 Peripheral 1..15 interrupt (Currently not used) */
+    /*31:28 <Reserved> */
 
     INTERRUPT_BASIC_IRQ_ARM_TIMER            = (BASIC_IRQ_OFFSET + 0),
     INTERRUPT_BASIC_IRQ_ARM_MAILBOX          = (BASIC_IRQ_OFFSET + 1),
@@ -53,7 +53,7 @@ enum {
     INTERRUPT_BASIC_IRQ_GPU_IRQ_56           = (BASIC_IRQ_OFFSET + 18),
     INTERRUPT_BASIC_IRQ_GPU_IRQ_57           = (BASIC_IRQ_OFFSET + 19),
     INTERRUPT_BASIC_IRQ_GPU_IRQ_62           = (BASIC_IRQ_OFFSET + 20),
-    // 31:21 <unused>
+    /* 31:21 <unused> */
 
     INTERRUPT_IRQ_AUX                        = (NORMAL_IRQ_OFFSET + 29),
     INTERRUPT_IRQ_I2C_SPI_SLV                = (NORMAL_IRQ_OFFSET + 43),

--- a/include/drivers/timer/am335x.h
+++ b/include/drivers/timer/am335x.h
@@ -12,25 +12,25 @@
 
 /* Kernel uses DMTIMER4 */
 struct timer {
-    uint32_t tidr; // 00h TIDR Identification Register
+    uint32_t tidr; /* 00h TIDR Identification Register */
     uint32_t padding1[3];
-    uint32_t cfg; // 10h TIOCP_CFG Timer OCP Configuration Register
+    uint32_t cfg; /* 10h TIOCP_CFG Timer OCP Configuration Register */
     uint32_t padding2[3];
-    uint32_t tieoi; // 20h IRQ_EOI Timer IRQ End-Of-Interrupt Register
-    uint32_t tisrr; // 24h IRQSTATUS_RAW Timer IRQSTATUS Raw Register
-    uint32_t tisr; // 28h IRQSTATUS Timer IRQSTATUS Register
-    uint32_t tier; // 2Ch IRQSTATUS_SET Timer IRQENABLE Set Register
-    uint32_t ticr; // 30h IRQSTATUS_CLR Timer IRQENABLE Clear Register
-    uint32_t twer; // 34h IRQWAKEEN Timer IRQ Wakeup Enable Register
-    uint32_t tclr; // 38h TCLR Timer Control Register
-    uint32_t tcrr; // 3Ch TCRR Timer Counter Register
-    uint32_t tldr; // 40h TLDR Timer Load Register
-    uint32_t ttgr; // 44h TTGR Timer Trigger Register
-    uint32_t twps; // 48h TWPS Timer Write Posted Status Register
-    uint32_t tmar; // 4Ch TMAR Timer Match Register
-    uint32_t tcar1; // 50h TCAR1 Timer Capture Register
-    uint32_t tsicr; // 54h TSICR Timer Synchronous Interface Control Register
-    uint32_t tcar2; // 58h TCAR2 Timer Capture Register
+    uint32_t tieoi; /* 20h IRQ_EOI Timer IRQ End-Of-Interrupt Register */
+    uint32_t tisrr; /* 24h IRQSTATUS_RAW Timer IRQSTATUS Raw Register */
+    uint32_t tisr; /* 28h IRQSTATUS Timer IRQSTATUS Register */
+    uint32_t tier; /* 2Ch IRQSTATUS_SET Timer IRQENABLE Set Register */
+    uint32_t ticr; /* 30h IRQSTATUS_CLR Timer IRQENABLE Clear Register */
+    uint32_t twer; /* 34h IRQWAKEEN Timer IRQ Wakeup Enable Register */
+    uint32_t tclr; /* 38h TCLR Timer Control Register */
+    uint32_t tcrr; /* 3Ch TCRR Timer Counter Register */
+    uint32_t tldr; /* 40h TLDR Timer Load Register */
+    uint32_t ttgr; /* 44h TTGR Timer Trigger Register */
+    uint32_t twps; /* 48h TWPS Timer Write Posted Status Register */
+    uint32_t tmar; /* 4Ch TMAR Timer Match Register */
+    uint32_t tcar1; /* 50h TCAR1 Timer Capture Register */
+    uint32_t tsicr; /* 54h TSICR Timer Synchronous Interface Control Register */
+    uint32_t tcar2; /* 58h TCAR2 Timer Capture Register */
 };
 
 typedef volatile struct timer timer_t;

--- a/include/machine/profiler.h
+++ b/include/machine/profiler.h
@@ -23,7 +23,7 @@
  * This value corresponds to the size of a hash table, and needs
  * to be a prime number to ensure correctness.
  */
-//#define MAX_UNIQUE_INSTRUCTIONS ((256 * 1024) + 3)  /* 262147 is prime */
+/*#define MAX_UNIQUE_INSTRUCTIONS ((256 * 1024) + 3)  /* 262147 is prime */ */
 /* Downsized to fit in the default 1M kernel section - davec */
 #define MAX_UNIQUE_INSTRUCTIONS 94349
 

--- a/include/object/structures.h
+++ b/include/object/structures.h
@@ -65,23 +65,23 @@ typedef word_t notification_state_t;
 #define CNODE_PTR(r) (CTE_PTR(r))
 #define CNODE_REF(p) (CTE_REF(p)>>CNODE_MIN_BITS)
 
-// We would like the actual 'tcb' region (the portion that contains the tcb_t) of the tcb
-// to be as large as possible, but it still needs to be aligned. As the TCB object contains
-// two sub objects the largest we can make either sub object whilst preserving size alignment
-// is half the total size. To halve an object size defined in bits we just subtract 1
-//
-// A diagram of a TCB kernel object that is created from untyped:
-//  _______________________________________
-// |     |             |                   |
-// |     |             |                   |
-// |cte_t|   unused    |       tcb_t       |
-// |     |(debug_tcb_t)|                   |
-// |_____|_____________|___________________|
-// 0     a             b                   c
-// a = tcbCNodeEntries * sizeof(cte_t)
-// b = BIT(TCB_SIZE_BITS)
-// c = BIT(seL4_TCBBits)
-//
+/* We would like the actual 'tcb' region (the portion that contains the tcb_t) of the tcb */
+/* to be as large as possible, but it still needs to be aligned. As the TCB object contains */
+/* two sub objects the largest we can make either sub object whilst preserving size alignment */
+/* is half the total size. To halve an object size defined in bits we just subtract 1 */
+/* */
+/* A diagram of a TCB kernel object that is created from untyped: */
+/*  _______________________________________ */
+/* |     |             |                   | */
+/* |     |             |                   | */
+/* |cte_t|   unused    |       tcb_t       | */
+/* |     |(debug_tcb_t)|                   | */
+/* |_____|_____________|___________________| */
+/* 0     a             b                   c */
+/* a = tcbCNodeEntries * sizeof(cte_t) */
+/* b = BIT(TCB_SIZE_BITS) */
+/* c = BIT(seL4_TCBBits) */
+/* */
 #define TCB_SIZE_BITS (seL4_TCBBits - 1)
 
 #define TCB_CNODE_SIZE_BITS (TCB_CNODE_RADIX + seL4_SlotBits)

--- a/include/smp/lock.h
+++ b/include/smp/lock.h
@@ -31,8 +31,8 @@ typedef struct clh_req {
 
 /* Our node (called "Process" in the paper) */
 typedef struct clh_node {
-    clh_req_t *watch; // Used by predecessor to grant the lock to us.
-    clh_req_t *myreq; // Used to grant the lock to our successor.
+    clh_req_t *watch; /* Used by predecessor to grant the lock to us. */
+    clh_req_t *myreq; /* Used to grant the lock to our successor. */
     /* This is the software blocking IPI flag */
     word_t ipi;
 } ALIGN(L1_CACHE_LINE_SIZE) clh_node_t;

--- a/include/util.h
+++ b/include/util.h
@@ -170,19 +170,19 @@ CONST int __clzdi2(uint64_t x);
 CONST int __ctzsi2(uint32_t x);
 CONST int __ctzdi2(uint64_t x);
 
-// Used for compile-time constants, so should always use the builtin.
+/* Used for compile-time constants, so should always use the builtin. */
 #define CTZL(x) __builtin_ctzl(x)
 
-// Count leading zeros.
-// The CONFIG_CLZ_NO_BUILTIN macro may be used to expose the library function
-// to the C parser for verification.
+/* Count leading zeros. */
+/* The CONFIG_CLZ_NO_BUILTIN macro may be used to expose the library function */
+/* to the C parser for verification. */
 #ifndef CONFIG_CLZ_NO_BUILTIN
-// If we use a compiler builtin, we cannot verify it, so we use the following
-// annotations to hide the function body from the proofs, and axiomatise its
-// behaviour.
-// On the other hand, if we use our own implementation instead of the builtin,
-// then we want to expose that implementation to the proofs, and therefore hide
-// these annotations.
+/* If we use a compiler builtin, we cannot verify it, so we use the following */
+/* annotations to hide the function body from the proofs, and axiomatise its */
+/* behaviour. */
+/* On the other hand, if we use our own implementation instead of the builtin, */
+/* then we want to expose that implementation to the proofs, and therefore hide */
+/* these annotations. */
 /** MODIFIES: */
 /** DONT_TRANSLATE */
 /** FNSPEC clzl_spec:
@@ -207,7 +207,7 @@ CONST clzl(unsigned long x)
 }
 
 #ifndef CONFIG_CLZ_NO_BUILTIN
-// See comments on clzl.
+/* See comments on clzl. */
 /** MODIFIES: */
 /** DONT_TRANSLATE */
 /** FNSPEC clzll_spec:
@@ -227,9 +227,9 @@ CONST clzll(unsigned long long x)
 #endif
 }
 
-// Count trailing zeros.
+/* Count trailing zeros. */
 #ifndef CONFIG_CTZ_NO_BUILTIN
-// See comments on clzl.
+/* See comments on clzl. */
 /** MODIFIES: */
 /** DONT_TRANSLATE */
 /** FNSPEC ctzl_spec:
@@ -243,33 +243,33 @@ static inline long
 CONST ctzl(unsigned long x)
 {
 #ifdef CONFIG_CTZ_NO_BUILTIN
-// If there is a builtin CLZ, but no builtin CTZ, then CTZ will be implemented
-// using the builtin CLZ, rather than the long-form implementation.
-// This is typically the fastest way to calculate ctzl on such platforms.
+/* If there is a builtin CLZ, but no builtin CTZ, then CTZ will be implemented */
+/* using the builtin CLZ, rather than the long-form implementation. */
+/* This is typically the fastest way to calculate ctzl on such platforms. */
 #ifdef CONFIG_CLZ_NO_BUILTIN
-    // Here, there are no builtins we can use, so call the library function.
+    /* Here, there are no builtins we can use, so call the library function. */
 #if CONFIG_WORD_SIZE == 32
     return __ctzsi2(x);
 #else
     return __ctzdi2(x);
 #endif
 #else
-    // Here, we have __builtin_clzl, but no __builtin_ctzl.
+    /* Here, we have __builtin_clzl, but no __builtin_ctzl. */
     if (unlikely(x == 0)) {
         return 8 * sizeof(unsigned long);
     }
-    // -x = ~x + 1, so (x & -x) isolates the least significant 1-bit of x,
-    // allowing ctzl to be calculated from clzl and the word size.
+    /* -x = ~x + 1, so (x & -x) isolates the least significant 1-bit of x, */
+    /* allowing ctzl to be calculated from clzl and the word size. */
     return 8 * sizeof(unsigned long) - 1 - __builtin_clzl(x & -x);
 #endif
 #else
-    // Here, we have __builtin_ctzl.
+    /* Here, we have __builtin_ctzl. */
     return __builtin_ctzl(x);
 #endif
 }
 
 #ifndef CONFIG_CTZ_NO_BUILTIN
-// See comments on clzl.
+/* See comments on clzl. */
 /** MODIFIES: */
 /** DONT_TRANSLATE */
 /** FNSPEC ctzll_spec:
@@ -283,14 +283,14 @@ static inline long long
 CONST ctzll(unsigned long long x)
 {
 #ifdef CONFIG_CTZ_NO_BUILTIN
-// See comments on ctzl.
+/* See comments on ctzl. */
 #ifdef CONFIG_CLZ_NO_BUILTIN
     return __ctzdi2(x);
 #else
     if (unlikely(x == 0)) {
         return 8 * sizeof(unsigned long long);
     }
-    // See comments on ctzl.
+    /* See comments on ctzl. */
     return 8 * sizeof(unsigned long long) - 1 - __builtin_clzll(x & -x);
 #endif
 #else
@@ -305,9 +305,9 @@ static inline long
 CONST popcountl(unsigned long mask)
 {
 #ifndef __POPCNT__
-    unsigned int count; // c accumulates the total bits set in v
+    unsigned int count; /* c accumulates the total bits set in v */
     for (count = 0; mask; count++) {
-        mask &= mask - 1; // clear the least significant bit set
+        mask &= mask - 1; /* clear the least significant bit set */
     }
 
     return count;

--- a/libsel4/arch_include/x86/sel4/arch/bootinfo_types.h
+++ b/libsel4/arch_include/x86/sel4/arch/bootinfo_types.h
@@ -116,10 +116,10 @@ typedef struct _seL4_X86_BootInfo_VBE {
  * https://www.gnu.org/software/grub/manual/multiboot/multiboot.html
  */
 typedef struct seL4_X86_mb_mmap {
-    uint32_t size; // size of this struct in bytes
-    uint64_t base_addr; // physical address of start of this region
-    uint64_t length; // length of the region this struct represents in bytes
-    uint32_t type; // memory type of region. Type 1 corresponds to RAM.
+    uint32_t size; /* size of this struct in bytes */
+    uint64_t base_addr; /* physical address of start of this region */
+    uint64_t length; /* length of the region this struct represents in bytes */
+    uint32_t type; /* memory type of region. Type 1 corresponds to RAM. */
 } SEL4_PACKED seL4_X86_mb_mmap_t;
 
 typedef struct seL4_X86_BootInfo_mmap {

--- a/libsel4/include/sel4/debug_assert.h
+++ b/libsel4/include/sel4/debug_assert.h
@@ -17,7 +17,7 @@
 /** NDEBUG is defined do nothing */
 #define seL4_DebugAssert(expr) ((void)(0))
 
-#else // NDEBUG is not defined
+#else /* NDEBUG is not defined */
 
 #include <sel4/assert.h>
 
@@ -26,5 +26,5 @@
  */
 #define seL4_DebugAssert(expr) seL4_Assert(expr)
 
-#endif // NDEBUG
+#endif /* NDEBUG */
 

--- a/libsel4/include/sel4/simple_types.h
+++ b/libsel4/include/sel4/simple_types.h
@@ -72,10 +72,10 @@ seL4_integer_size_assert(seL4_Uint32, 4)
  */
 #if defined(SEL4_INT64_IS_LONG)
 #define _seL4_int64_type    long int
-#define _seL4_int64_fmt     l  // printf() formatting, integer suffix
+#define _seL4_int64_fmt     l  /* printf() formatting, integer suffix */
 #elif defined(SEL4_INT64_IS_LONG_LONG)
 #define _seL4_int64_type    long long int
-#define _seL4_int64_fmt     ll  // printf() formatting, integer suffix
+#define _seL4_int64_fmt     ll  /* printf() formatting, integer suffix */
 #else
 #error missing definition for 64-bit types
 #endif
@@ -106,7 +106,7 @@ typedef seL4_Int8   seL4_Bool;
 #define seL4_Null   0L
 #else
 #define seL4_Null   ((void*)0)
-#endif // __cplusplus
+#endif /* __cplusplus */
 
 /* Define seL4_Word */
 #if defined(SEL4_WORD_IS_UINT32)

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
@@ -101,7 +101,7 @@ typedef enum {
     /* general registers x0 to x30 have been saved by traps.S */
     seL4_VCPUReg_SP_EL1,
     seL4_VCPUReg_ELR_EL1,
-    seL4_VCPUReg_SPSR_EL1, // 32-bit
+    seL4_VCPUReg_SPSR_EL1, /* 32-bit */
     seL4_VCPURegSaveRange_end = seL4_VCPUReg_SPSR_EL1, /* end vcpu save/restore reg range */
 
     /* generic timer registers, to be completed */

--- a/src/arch/arm/32/machine/fpu.c
+++ b/src/arch/arm/32/machine/fpu.c
@@ -109,7 +109,7 @@ BOOT_CODE bool_t fpsimd_HWCapTest(void)
             printf("Error: seL4 doesn't support FPU subarchitectures that support asynchronous exceptions\n");
             return false;
         } else {
-            // if we aren't using the fpu then we have detected an fpu that we cannot use, but that is fine
+            /* if we aren't using the fpu then we have detected an fpu that we cannot use, but that is fine */
             return true;
         }
     }
@@ -127,7 +127,7 @@ BOOT_CODE bool_t fpsimd_HWCapTest(void)
             printf("Error: seL4 doesn't support this VFP subarchitecture\n");
             return false;
         } else {
-            // if we aren't using the fpu then we have detected an fpu that we cannot use, but that is fine
+            /* if we aren't using the fpu then we have detected an fpu that we cannot use, but that is fine */
             return true;
         }
     }

--- a/src/arch/arm/32/object/objecttype.c
+++ b/src/arch/arm/32/object/objecttype.c
@@ -234,7 +234,7 @@ finaliseCap_ret_t Arch_finaliseCap(cap_t cap, bool_t final)
 
 #ifndef CONFIG_ENABLE_SMP_SUPPORT
     case cap_sgi_signal_cap:
-        // do nothing
+        /* do nothing */
         break;
 #endif
 

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -270,9 +270,9 @@ BOOT_CODE void map_kernel_window(void)
         armKSGlobalKernelPDs[GET_KPT_INDEX(vaddr, KLVL_FRM_ARM_PT_LVL(1))][GET_KPT_INDEX(vaddr,
                                                                                          KLVL_FRM_ARM_PT_LVL(2))] = pte_pte_page_new(
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
-                                                                                                                        0, // XN
+                                                                                                                        0, /* XN */
 #else
-                                                                                                                        1, // UXN
+                                                                                                                        1, /* UXN */
 #endif
                                                                                                                         paddr,
                                                                                                                         0,                        /* global */
@@ -1985,9 +1985,9 @@ exception_t benchmark_arch_map_logBuffer(word_t frame_cptr)
 
     *armKSGlobalLogPTE = pte_pte_page_new(
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
-                             0, // XN
+                             0, /* XN */
 #else
-                             1, // UXN
+                             1, /* UXN */
 #endif
                              ksUserLogBuffer,
                              0,                         /* global */

--- a/src/arch/arm/64/machine/capdl.c
+++ b/src/arch/arm/64/machine/capdl.c
@@ -152,7 +152,7 @@ static void arm64_cap_pt_print_slots(pte_t *pdSlot, vptr_t vptr)
         pte_t *ptSlot = pt + i;
 
         if (pte_4k_page_ptr_get_present(ptSlot)) {
-            // print pte entries
+            /* print pte entries */
             printf("0x%lx: frame_%p_%04lu", i, ptSlot, i);
             cap_frame_print_attrs_pt(ptSlot);
         }

--- a/src/arch/arm/64/object/objecttype.c
+++ b/src/arch/arm/64/object/objecttype.c
@@ -186,7 +186,7 @@ finaliseCap_ret_t Arch_finaliseCap(cap_t cap, bool_t final)
 #endif
 #ifndef CONFIG_ENABLE_SMP_SUPPORT
     case cap_sgi_signal_cap:
-        // do nothing
+        /* do nothing */
         break;
 #endif
 

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -136,7 +136,7 @@ BOOT_CODE static void init_irqs(cap_t root_cnode_cap)
 #ifdef KERNEL_PMU_IRQ
     setIRQState(IRQReserved, CORE_IRQ_TO_IRQT(0, KERNEL_PMU_IRQ));
 #if (defined CONFIG_PLAT_TX1 && defined ENABLE_SMP_SUPPORT)
-//SELFOUR-1252
+/*SELFOUR-1252 */
 #error "This platform doesn't support tracking CPU utilisation on multicore"
 #endif /* CONFIG_PLAT_TX1 && ENABLE_SMP_SUPPORT */
 #else

--- a/src/arch/arm/machine/gic_v3.c
+++ b/src/arch/arm/machine/gic_v3.c
@@ -81,11 +81,11 @@ static inline uint64_t sgir_word_from_args(word_t irq, word_t target)
 {
     uint64_t t = target; /* make sure shifts below are on 64 bit */
     return (uint64_t) irq << ICC_SGI1R_INTID_SHIFT
-           | (1llu << (t & 0xf)) // AFF0 base
-           | ((t >> 4)  & 0x0f) << ICC_SGI1R_RS_SHIFT // AFF0 Range select
-           | ((t >> 8)  & 0xff) << ICC_SGI1R_AFF1_SHIFT // AFF1
-           | ((t >> 16) & 0xff) << ICC_SGI1R_AFF2_SHIFT // AFF2
-           | ((t >> 24) & 0xff) << ICC_SGI1R_AFF2_SHIFT; // AFF3
+           | (1llu << (t & 0xf)) /* AFF0 base */
+           | ((t >> 4)  & 0x0f) << ICC_SGI1R_RS_SHIFT /* AFF0 Range select */
+           | ((t >> 8)  & 0xff) << ICC_SGI1R_AFF1_SHIFT /* AFF1 */
+           | ((t >> 16) & 0xff) << ICC_SGI1R_AFF2_SHIFT /* AFF2 */
+           | ((t >> 24) & 0xff) << ICC_SGI1R_AFF2_SHIFT; /* AFF3 */
 }
 
 /* Wait for completion of a distributor change */
@@ -384,8 +384,8 @@ void ipi_send_target(irq_t irq, word_t cpuTargetList)
             word_t mpidr = mpidr_map[i];
             word_t aff1 = MPIDR_AFF1(mpidr);
             word_t aff0 = MPIDR_AFF0(mpidr);
-            // AFF1 is assumed to be contiguous and less than CONFIG_MAX_NUM_NODES.
-            // The targets are grouped by AFF1.
+            /* AFF1 is assumed to be contiguous and less than CONFIG_MAX_NUM_NODES. */
+            /* The targets are grouped by AFF1. */
             assert(aff1 >= 0 && aff1 < CONFIG_MAX_NUM_NODES);
             sgi1r[aff1] |= sgi1r_base | (aff1 << ICC_SGI1R_AFF1_SHIFT) | (1 << aff0);
             if (aff1 > last_aff1) {

--- a/src/arch/riscv/machine/hardware.c
+++ b/src/arch/riscv/machine/hardware.c
@@ -225,8 +225,8 @@ static inline void ackInterrupt(irq_t irq)
 void resetTimer(void)
 {
     uint64_t target;
-    // repeatedly try and set the timer in a loop as otherwise there is a race and we
-    // may set a timeout in the past, resulting in it never getting triggered
+    /* repeatedly try and set the timer in a loop as otherwise there is a race and we */
+    /* may set a timeout in the past, resulting in it never getting triggered */
     do {
         target = riscv_read_time() + RESET_CYCLES;
         sbi_set_timer(target);

--- a/src/arch/x86/32/c_traps.c
+++ b/src/arch/x86/32/c_traps.c
@@ -43,7 +43,7 @@ static void NORETURN restore_vmx(tcb_t *cur_thread, vcpu_t *vcpu)
     if (vcpu->launched) {
     /* attempt to do a vmresume */
     asm volatile(
-        // Set our stack pointer to the top of the tcb so we can efficiently pop
+        /* Set our stack pointer to the top of the tcb so we can efficiently pop */
         "movl %0, %%esp\n"
         "popl %%eax\n"
         "popl %%ebx\n"
@@ -52,9 +52,9 @@ static void NORETURN restore_vmx(tcb_t *cur_thread, vcpu_t *vcpu)
         "popl %%esi\n"
         "popl %%edi\n"
         "popl %%ebp\n"
-        // Now do the vmresume
+        /* Now do the vmresume */
         "vmresume\n"
-        // if we get here we failed
+        /* if we get here we failed */
 #ifdef ENABLE_SMP_SUPPORT
         "movl (%%esp), %%esp\n"
 #else
@@ -64,14 +64,14 @@ static void NORETURN restore_vmx(tcb_t *cur_thread, vcpu_t *vcpu)
         :
         : "r"(&vcpu->gp_registers[VCPU_EAX]),
         "i"(BIT(CONFIG_KERNEL_STACK_BITS) - sizeof(word_t))
-        // Clobber memory so the compiler is forced to complete all stores
-        // before running this assembler
+        /* Clobber memory so the compiler is forced to complete all stores */
+        /* before running this assembler */
         : "memory"
     );
     } else {
         /* attempt to do a vmlaunch */
         asm volatile(
-            // Set our stack pointer to the top of the tcb so we can efficiently pop
+            /* Set our stack pointer to the top of the tcb so we can efficiently pop */
             "movl %0, %%esp\n"
             "popl %%eax\n"
             "popl %%ebx\n"
@@ -80,9 +80,9 @@ static void NORETURN restore_vmx(tcb_t *cur_thread, vcpu_t *vcpu)
             "popl %%esi\n"
             "popl %%edi\n"
             "popl %%ebp\n"
-            // Now do the vmresume
+            /* Now do the vmresume */
             "vmlaunch\n"
-            // if we get here we failed
+            /* if we get here we failed */
 #ifdef ENABLE_SMP_SUPPORT
             "movl (%%esp), %%esp\n"
 #else
@@ -92,8 +92,8 @@ static void NORETURN restore_vmx(tcb_t *cur_thread, vcpu_t *vcpu)
             :
             : "r"(&vcpu->gp_registers[VCPU_EAX]),
             "i"(BIT(CONFIG_KERNEL_STACK_BITS) - sizeof(word_t))
-            // Clobber memory so the compiler is forced to complete all stores
-            // before running this assembler
+            /* Clobber memory so the compiler is forced to complete all stores */
+            /* before running this assembler */
             : "memory"
         );
     }
@@ -151,25 +151,25 @@ void NORETURN VISIBLE restore_user_context(void)
     if (likely(cur_thread->tcbArch.tcbContext.registers[Error] == -1)) {
         cur_thread->tcbArch.tcbContext.registers[FLAGS] &= ~FLAGS_IF;
         asm volatile(
-            // Set our stack pointer to the top of the tcb so we can efficiently pop
+            /* Set our stack pointer to the top of the tcb so we can efficiently pop */
             "movl %0, %%esp\n"
-            // restore syscall number
+            /* restore syscall number */
             "popl %%eax\n"
-            // cap/badge register
+            /* cap/badge register */
             "popl %%ebx\n"
-            // skip ecx and edx, these will contain esp and NextIP due to sysenter/sysexit convention
+            /* skip ecx and edx, these will contain esp and NextIP due to sysenter/sysexit convention */
             "addl $8, %%esp\n"
-            // message info register
+            /* message info register */
             "popl %%esi\n"
-            // message register
+            /* message register */
             "popl %%edi\n"
-            // message register
+            /* message register */
             "popl %%ebp\n"
-            // skip FaultIP and Error (these are fake registers)
+            /* skip FaultIP and Error (these are fake registers) */
             "addl $8, %%esp\n"
-            // restore NextIP
+            /* restore NextIP */
             "popl %%edx\n"
-            // skip cs
+            /* skip cs */
             "addl $4,  %%esp\n"
             "movl 4(%%esp), %%ecx\n"
             "popfl\n"
@@ -179,13 +179,13 @@ void NORETURN VISIBLE restore_user_context(void)
             :
             : "r"(&cur_thread->tcbArch.tcbContext.registers[EAX]),
             [IFMASK]"i"(FLAGS_IF)
-            // Clobber memory so the compiler is forced to complete all stores
-            // before running this assembler
+            /* Clobber memory so the compiler is forced to complete all stores */
+            /* before running this assembler */
             : "memory"
         );
     } else {
         asm volatile(
-            // Set our stack pointer to the top of the tcb so we can efficiently pop
+            /* Set our stack pointer to the top of the tcb so we can efficiently pop */
             "movl %0, %%esp\n"
             "popl %%eax\n"
             "popl %%ebx\n"
@@ -194,13 +194,13 @@ void NORETURN VISIBLE restore_user_context(void)
             "popl %%esi\n"
             "popl %%edi\n"
             "popl %%ebp\n"
-            // skip FaultIP and Error
+            /* skip FaultIP and Error */
             "addl $8, %%esp\n"
             "iret\n"
             :
             : "r"(&cur_thread->tcbArch.tcbContext.registers[EAX])
-            // Clobber memory so the compiler is forced to complete all stores
-            // before running this assembler
+            /* Clobber memory so the compiler is forced to complete all stores */
+            /* before running this assembler */
             : "memory"
         );
     }

--- a/src/arch/x86/32/kernel/vspace.c
+++ b/src/arch/x86/32/kernel/vspace.c
@@ -341,7 +341,7 @@ BOOT_CODE void *map_temp_boot_page(void *entry, uint32_t large_pages)
     unsigned int virt_pg_start = PPTR_BASE - (large_pages << LARGE_PAGE_BITS);
 
     for (i = 0; i < large_pages; i++) {
-        unsigned int pg_offset = i << LARGE_PAGE_BITS; // num pages since start * page size
+        unsigned int pg_offset = i << LARGE_PAGE_BITS; /* num pages since start * page size */
 
         *(get_boot_pd() + virt_pd_start + i) = pde_pde_large_new(
                                                    phys_pg_start + pg_offset, /* physical address */
@@ -359,7 +359,7 @@ BOOT_CODE void *map_temp_boot_page(void *entry, uint32_t large_pages)
         invalidateLocalTranslationSingle(virt_pg_start + pg_offset);
     }
 
-    // assign replacement virtual addresses page
+    /* assign replacement virtual addresses page */
     offset_in_page = (unsigned int)(entry) & MASK(LARGE_PAGE_BITS);
     replacement_vaddr = (void *)(virt_pg_start + offset_in_page);
 

--- a/src/arch/x86/64/c_traps.c
+++ b/src/arch/x86/64/c_traps.c
@@ -43,60 +43,60 @@ static void NORETURN restore_vmx(tcb_t *cur_thread, vcpu_t *vcpu)
 #endif /* CONFIG_X86_64_VTX_64BIT_GUESTS */
     /* attempt to do a vmlaunch/vmresume */
     asm volatile(
-        // Arguments are getting stored in general purpose registers that need to be used.
-        // Copy them to unused general purpose registers
+        /* Arguments are getting stored in general purpose registers that need to be used. */
+        /* Copy them to unused general purpose registers */
         "movq %[launched], %%rbx\n"
 #ifdef CONFIG_X86_64_VTX_64BIT_GUESTS
         "movq %[host_msr], %%r8\n"
         "movq %[guest_msr], %%r9\n"
         "movq %[reg], %%r10\n"
 
-        // Save host's GS, Shadow GS, and FS
+        /* Save host's GS, Shadow GS, and FS */
         "mov $0xC0000101, %%ecx\n"
         "rdmsr\n"
         "shl $0x20,%%rdx\n"
         "or %%rdx, %%rax\n"
-        "mov %%rax, %%r11\n" // R11 has GS
+        "mov %%rax, %%r11\n" /* R11 has GS */
         "swapgs\n"
         "rdmsr\n"
         "shl $0x20,%%rdx\n"
         "or %%rdx,%%rax\n"
-        "mov %%rax, %%r12\n" // R12 has Shadow GS
+        "mov %%rax, %%r12\n" /* R12 has Shadow GS */
         "mov $0xC0000100, %%ecx\n"
         "rdmsr\n"
         "shl $0x20,%%rdx\n"
         "or %%rdx, %%rax\n"
-        "mov %%rax, %%r13\n" // R13 has FS
-        "movq %%r8, %%rsp\n" // host_gs
+        "mov %%rax, %%r13\n" /* R13 has FS */
+        "movq %%r8, %%rsp\n" /* host_gs */
         "pushq %%r13\n"
         "pushq %%r12\n"
         "pushq %%r11\n"
 
-        // Restore guest's GS and Shadow GS
+        /* Restore guest's GS and Shadow GS */
         "mov $0xC0000101, %%ecx\n"
         "swapgs\n"
-        "movq %%r9, %%rsp\n" // guest_gs
-        "popq %%rax\n"       // GS
+        "movq %%r9, %%rsp\n" /* guest_gs */
+        "popq %%rax\n"       /* GS */
         "mov %%rax,%%rdx\n"
         "shr $0x20,%%rdx\n"
         "wrmsr\n"
         "swapgs\n"
-        "popq %%rax\n"       // Shadow GS
+        "popq %%rax\n"       /* Shadow GS */
         "mov %%rax,%%rdx\n"
         "shr $0x20,%%rdx\n"
         "wrmsr\n"
         "swapgs\n"
         "mov $0xC0000100, %%ecx\n"
-        "popq %%rax\n"       // FS
+        "popq %%rax\n"       /* FS */
         "mov %%rax,%%rdx\n"
         "shr $0x20,%%rdx\n"
         "wrmsr\n"
-        "movq %%r10, %%rsp\n" // reg
+        "movq %%r10, %%rsp\n" /* reg */
 #else /* not CONFIG_X86_64_VTX_64BIT_GUESTS */
-        // Set our stack pointer to the top of the tcb so we can efficiently pop
+        /* Set our stack pointer to the top of the tcb so we can efficiently pop */
         "movq %[reg], %%rsp\n"
 #endif /* CONFIG_X86_64_VTX_64BIT_GUESTS */
-        "cmpq $0x1, (%%rbx)\n" // is the VM launched already?
+        "cmpq $0x1, (%%rbx)\n" /* is the VM launched already? */
         "jne launch\n"
         "popq %%rax\n"
         "popq %%rbx\n"
@@ -119,7 +119,7 @@ static void NORETURN restore_vmx(tcb_t *cur_thread, vcpu_t *vcpu)
         "swapgs\n"
 #endif
 #endif /* CONFIG_X86_64_VTX_64BIT_GUESTS */
-        "vmresume\n" // yes, do the vmresume
+        "vmresume\n" /* yes, do the vmresume */
         "jmp done\n"
 
         "launch:\n"
@@ -144,33 +144,33 @@ static void NORETURN restore_vmx(tcb_t *cur_thread, vcpu_t *vcpu)
         "swapgs\n"
 #endif
 #endif /* CONFIG_X86_64_VTX_64BIT_GUESTS */
-        "vmlaunch\n" // no, do the vmlaunch
+        "vmlaunch\n" /* no, do the vmlaunch */
 
         "done:\n"
         "setb %%al\n"
         "sete %%bl\n"
         "movzx %%al, %%rdi\n"
         "movzx %%bl, %%rsi\n"
-        // if we get here we failed
+        /* if we get here we failed */
 
 #ifdef CONFIG_X86_64_VTX_64BIT_GUESTS
-        // Restore host's GS, Shadow GS, and FS
-        "sub $0xA8, %%rsp\n" // 15 * 8 (regs) + 3 * 8 (guest_msr) + 3 * 8 (host_msr)
+        /* Restore host's GS, Shadow GS, and FS */
+        "sub $0xA8, %%rsp\n" /* 15 * 8 (regs) + 3 * 8 (guest_msr) + 3 * 8 (host_msr) */
         "mov $0xC0000101, %%ecx\n"
         "pop %%rax\n"
         "movq %%rax, %%rdx\n"
         "shr $0x20, %%rdx\n"
-        "wrmsr\n" // GS
+        "wrmsr\n" /* GS */
         "swapgs\n"
         "pop %%rax\n"
         "movq %%rax, %%rdx\n"
         "shr $0x20, %%rdx\n"
-        "wrmsr\n" // Shadow GS
+        "wrmsr\n" /* Shadow GS */
         "mov $0xC0000100, %%ecx\n"
         "pop %%rax\n"
         "movq %%rax, %%rdx\n"
         "shr $0x20, %%rdx\n"
-        "wrmsr\n" // FS
+        "wrmsr\n" /* FS */
 
 #else /* not CONFIG_X86_64_VTX_64BIT_GUESTS */
 #ifdef ENABLE_SMP_SUPPORT
@@ -197,8 +197,8 @@ static void NORETURN restore_vmx(tcb_t *cur_thread, vcpu_t *vcpu)
         , [stack_offset]"i"(OFFSETOF(nodeInfo_t, stackTop))
 #endif
 #endif /* CONFIG_X86_64_VTX_64BIT_GUESTS */
-        // Clobber memory so the compiler is forced to complete all stores
-        // before running this assembler
+        /* Clobber memory so the compiler is forced to complete all stores */
+        /* before running this assembler */
         : "memory"
     );
     UNREACHABLE();
@@ -256,9 +256,9 @@ void VISIBLE NORETURN restore_user_context(void)
         x86_disable_ibrs();
     }
 
-    // Check if we are returning from a syscall/sysenter or from an interrupt
-    // There is a special case where if we would be returning from a sysenter,
-    // but are current singlestepping, do a full return like an interrupt
+    /* Check if we are returning from a syscall/sysenter or from an interrupt */
+    /* There is a special case where if we would be returning from a sysenter, */
+    /* but are current singlestepping, do a full return like an interrupt */
     if (likely(cur_thread->tcbArch.tcbContext.registers[Error] == -1) &&
         (!config_set(CONFIG_SYSENTER) || !config_set(CONFIG_HARDWARE_DEBUG_API)
          || ((cur_thread->tcbArch.tcbContext.registers[FLAGS] & FLAGS_TF) == 0))) {
@@ -284,7 +284,7 @@ void VISIBLE NORETURN restore_user_context(void)
             register word_t user_cr3_r11 asm("r11") = user_cr3;
 #endif
             asm volatile(
-                // Set our stack pointer to the top of the tcb so we can efficiently pop
+                /* Set our stack pointer to the top of the tcb so we can efficiently pop */
                 "movq %0, %%rsp\n"
                 "popq %%rdi\n"
                 "popq %%rsi\n"
@@ -294,23 +294,23 @@ void VISIBLE NORETURN restore_user_context(void)
                 "popq %%r12\n"
                 "popq %%r13\n"
                 "popq %%r14\n"
-                // skip RDX
+                /* skip RDX */
                 "addq $8, %%rsp\n"
                 "popq %%r10\n"
                 "popq %%r8\n"
                 "popq %%r9\n"
                 "popq %%r15\n"
-                //restore RFLAGS
+                /*restore RFLAGS */
                 "popfq\n"
-                // reset interrupt bit
+                /* reset interrupt bit */
                 "orq %[IF], -8(%%rsp)\n"
-                // Restore NextIP
+                /* Restore NextIP */
                 "popq %%rdx\n"
-                // Skip ERROR
+                /* Skip ERROR */
                 "addq $8, %%rsp\n"
-                // Restore RSP
+                /* Restore RSP */
                 "popq %%rcx\n"
-                // Skip FaultIP
+                /* Skip FaultIP */
                 "addq $8, %%rsp\n"
 #if defined(ENABLE_SMP_SUPPORT) && defined(CONFIG_KERNEL_SKIM_WINDOW)
                 "popq %%rsp\n"
@@ -323,8 +323,8 @@ void VISIBLE NORETURN restore_user_context(void)
                 "movq %%rsp, %%cr3\n"
 #endif /* CONFIG_KERNEL_SKIM_WINDOW */
 #endif /* defined(ENABLE_SMP_SUPPORT) && defined(CONFIG_KERNEL_SKIM_WINDOW) */
-                // More register but we can ignore and are done restoring
-                // enable interrupt disabled by sysenter
+                /* More register but we can ignore and are done restoring */
+                /* enable interrupt disabled by sysenter */
                 "sti\n"
                 SYSEXITQ "\n"
                 :
@@ -333,13 +333,13 @@ void VISIBLE NORETURN restore_user_context(void)
                 "r"(user_cr3_r11),
 #endif
                 [IF] "i"(FLAGS_IF)
-                // Clobber memory so the compiler is forced to complete all stores
-                // before running this assembler
+                /* Clobber memory so the compiler is forced to complete all stores */
+                /* before running this assembler */
                 : "memory"
             );
         } else {
             asm volatile(
-                // Set our stack pointer to the top of the tcb so we can efficiently pop
+                /* Set our stack pointer to the top of the tcb so we can efficiently pop */
                 "movq %0, %%rsp\n"
                 "popq %%rdi\n"
                 "popq %%rsi\n"
@@ -354,9 +354,9 @@ void VISIBLE NORETURN restore_user_context(void)
                 "popq %%r8\n"
                 "popq %%r9\n"
                 "popq %%r15\n"
-                //restore RFLAGS
+                /*restore RFLAGS */
                 "popq %%r11\n"
-                // Restore NextIP
+                /* Restore NextIP */
 #if defined(ENABLE_SMP_SUPPORT) && defined(CONFIG_KERNEL_SKIM_WINDOW)
                 "popq %%rsp\n"
                 "movq %%rcx, %%cr3\n"
@@ -368,18 +368,18 @@ void VISIBLE NORETURN restore_user_context(void)
                 "movq %%rsp, %%cr3\n"
 #endif /* CONFIG_KERNEL_SKIM_WINDOW */
 #endif /* defined(ENABLE_SMP_SUPPORT) && defined(CONFIG_KERNEL_SKIM_WINDOW) */
-                // clear RSP to not leak information to the user
+                /* clear RSP to not leak information to the user */
                 "xor %%rsp, %%rsp\n"
-                // More register but we can ignore and are done restoring
-                // enable interrupt disabled by sysenter
+                /* More register but we can ignore and are done restoring */
+                /* enable interrupt disabled by sysenter */
                 "sysretq\n"
                 :
                 : "r"(&cur_thread->tcbArch.tcbContext.registers[RDI])
 #if defined(ENABLE_SMP_SUPPORT) && defined(CONFIG_KERNEL_SKIM_WINDOW)
                 , "c"(user_cr3)
 #endif
-                // Clobber memory so the compiler is forced to complete all stores
-                // before running this assembler
+                /* Clobber memory so the compiler is forced to complete all stores */
+                /* before running this assembler */
                 : "memory"
             );
         }
@@ -395,7 +395,7 @@ void VISIBLE NORETURN restore_user_context(void)
         irqstack[4] = getRegister(cur_thread, RSP);
         irqstack[5] = getRegister(cur_thread, SS);
         asm volatile(
-            // Set our stack pointer to the top of the tcb so we can efficiently pop
+            /* Set our stack pointer to the top of the tcb so we can efficiently pop */
             "movq %0, %%rsp\n"
             "popq %%rdi\n"
             "popq %%rsi\n"
@@ -423,8 +423,8 @@ void VISIBLE NORETURN restore_user_context(void)
 #endif /* defined(ENABLE_SMP_SUPPORT) && defined(CONFIG_KERNEL_SKIM_WINDOW) */
 
 #ifdef ENABLE_SMP_SUPPORT
-            // Swapping gs twice here is worth it as it allows us to efficiently
-            // set the user gs base previously
+            /* Swapping gs twice here is worth it as it allows us to efficiently */
+            /* set the user gs base previously */
             "swapgs\n"
 #ifdef CONFIG_KERNEL_SKIM_WINDOW
             /* now we stash rcx in the scratch space that we can access once we've
@@ -439,7 +439,7 @@ void VISIBLE NORETURN restore_user_context(void)
             "movq %%gs:%c[scratch_offset], %%rcx\n"
 #endif /* CONFIG_KERNEL_SKIM_WINDOW */
             "addq $8, %%rsp\n"
-            // Switch to the user GS value
+            /* Switch to the user GS value */
             "swapgs\n"
 #else /* !ENABLE_SMP_SUPPORT */
 #ifdef CONFIG_KERNEL_SKIM_WINDOW
@@ -455,8 +455,8 @@ void VISIBLE NORETURN restore_user_context(void)
             , "c"(user_cr3)
             , [scratch_offset] "i"(nodeSkimScratchOffset)
 #endif
-            // Clobber memory so the compiler is forced to complete all stores
-            // before running this assembler
+            /* Clobber memory so the compiler is forced to complete all stores */
+            /* before running this assembler */
             : "memory"
         );
     }

--- a/src/arch/x86/64/kernel/vspace.c
+++ b/src/arch/x86/64/kernel/vspace.c
@@ -330,9 +330,9 @@ BOOT_CODE void init_tss(tss_t *tss)
 BOOT_CODE void init_syscall_msrs(void)
 {
     x86_wrmsr(IA32_LSTAR_MSR, (uint64_t)&handle_fastsyscall);
-    // mask bit 9 in the kernel (which is the interrupt enable bit)
-    // also mask bit 8, which is the Trap Flag, to prevent the kernel
-    // from single stepping
+    /* mask bit 9 in the kernel (which is the interrupt enable bit) */
+    /* also mask bit 8, which is the Trap Flag, to prevent the kernel */
+    /* from single stepping */
     x86_wrmsr(IA32_FMASK_MSR, FLAGS_TF | FLAGS_IF);
     x86_wrmsr(IA32_STAR_MSR, ((uint64_t)SEL_CS_0 << 32) | ((uint64_t)SEL_CS_3 << 48));
 }

--- a/src/arch/x86/kernel/apic.c
+++ b/src/arch/x86/kernel/apic.c
@@ -62,7 +62,7 @@ BOOT_CODE bool_t apic_init(bool_t mask_legacy_irqs)
         x86KSapicRatio = div64((uint64_t)x86KStscMhz * 1000llu, apic_khz);
         printf("Apic Khz %lu, TSC Mhz %lu, ratio %lu\n", (long) apic_khz, (long) x86KStscMhz, (long) x86KSapicRatio);
     } else {
-        // use tsc deadline mode
+        /* use tsc deadline mode */
         x86KSapicRatio = 0;
     }
 #else

--- a/src/arch/x86/kernel/boot.c
+++ b/src/arch/x86/kernel/boot.c
@@ -72,9 +72,9 @@ BOOT_CODE static bool_t arch_init_freemem(p_region_t ui_p_reg,
                                           mem_p_regs_t *mem_p_regs,
                                           word_t extra_bi_size_bits)
 {
-    // Extend the reserved region down to include the base of the kernel image.
-    // KERNEL_ELF_PADDR_BASE is the lowest physical load address used
-    // in the x86 linker script.
+    /* Extend the reserved region down to include the base of the kernel image. */
+    /* KERNEL_ELF_PADDR_BASE is the lowest physical load address used */
+    /* in the x86 linker script. */
     ui_p_reg.start = KERNEL_ELF_PADDR_BASE;
     reserved[0] = paddr_to_pptr_reg(ui_p_reg);
     return init_freemem(mem_p_regs->count, mem_p_regs->list, MAX_RESERVED,
@@ -136,7 +136,7 @@ BOOT_CODE bool_t init_sys_state(
     word_t mb_mmap_size = sizeof(seL4_X86_BootInfo_mmap_t);
     extra_bi_size += mb_mmap_size;
 
-    // room for tsc frequency
+    /* room for tsc frequency */
     extra_bi_size += sizeof(seL4_BootInfoHeader) + 4;
     word_t extra_bi_size_bits = calculate_extra_bi_size_bits(extra_bi_size);
 

--- a/src/arch/x86/kernel/boot_sys.c
+++ b/src/arch/x86/kernel/boot_sys.c
@@ -190,8 +190,8 @@ static BOOT_CODE bool_t try_boot_sys_node(cpu_id_t cpu_id)
 static BOOT_CODE bool_t add_mem_p_regs(p_region_t reg)
 {
     if (reg.start == reg.end) {
-        // Return true here if asked to add an empty region.
-        // Some of the callers round down the end address to
+        /* Return true here if asked to add an empty region. */
+        /* Some of the callers round down the end address to */
         return true;
     }
     if (reg.end > PADDR_TOP && reg.start > PADDR_TOP) {

--- a/src/arch/x86/kernel/vspace.c
+++ b/src/arch/x86/kernel/vspace.c
@@ -819,9 +819,9 @@ static exception_t performX86PageInvocationUnmap(cap_t cap, cte_t *ctSlot)
 {
     assert(cap_frame_cap_get_capFMappedASID(cap));
     assert(cap_frame_cap_get_capFMapType(cap) == X86_MappingVSpace);
-    // We have this `if` for something we just asserted to be true for simplicity of verification
-    // This has no performance implications as when this function is inlined this `if` will be
-    // inside an identical `if` and will therefore be elided
+    /* We have this `if` for something we just asserted to be true for simplicity of verification */
+    /* This has no performance implications as when this function is inlined this `if` will be */
+    /* inside an identical `if` and will therefore be elided */
     if (cap_frame_cap_get_capFMappedASID(cap)) {
         unmapPage(
             cap_frame_cap_get_capFSize(cap),

--- a/src/arch/x86/object/ioport.c
+++ b/src/arch/x86/object/ioport.c
@@ -23,10 +23,10 @@ static inline void apply_pattern(word_t_may_alias *w, word_t pattern, bool_t set
 
 static inline word_t make_pattern(int start, int end)
 {
-    // number of bits we want to have set
+    /* number of bits we want to have set */
     int num_bits = end - start;
-    // shift down to cut off the bits we don't want, then shift up to put the
-    // bits into position
+    /* shift down to cut off the bits we don't want, then shift up to put the */
+    /* bits into position */
     return (~(word_t)0) >> (CONFIG_WORD_SIZE - num_bits) << start;
 }
 
@@ -61,26 +61,26 @@ static bool_t isIOPortRangeFree(uint16_t first_port, uint16_t last_port)
     int low_index = first_port & MASK(wordRadix);
     int high_index = last_port & MASK(wordRadix);
 
-    // check if we are operating on a partial word
+    /* check if we are operating on a partial word */
     if (low_word == high_word) {
         if ((x86KSAllocatedIOPorts[low_word] & make_pattern(low_index, high_index + 1)) != 0) {
             return false;
         }
         return true;
     }
-    // check the starting word
+    /* check the starting word */
     if ((x86KSAllocatedIOPorts[low_word] & make_pattern(low_index, CONFIG_WORD_SIZE)) != 0) {
         return false;
     }
     low_word++;
-    // check the rest of the whole words
+    /* check the rest of the whole words */
     while (low_word < high_word) {
         if (x86KSAllocatedIOPorts[low_word] != 0) {
             return false;
         }
         low_word++;
     }
-    // check any trailing bits
+    /* check any trailing bits */
     if ((x86KSAllocatedIOPorts[low_word] & make_pattern(0, high_index + 1)) != 0) {
         return false;
     }
@@ -293,7 +293,7 @@ exception_t decodeX86PortInvocation(
 
 void setIOPortMask(void *ioport_bitmap, uint16_t low, uint16_t high, bool_t set)
 {
-    //get an aliasing pointer
+    /*get an aliasing pointer */
     word_t_may_alias *bitmap = ioport_bitmap;
 
     int low_word = low >> wordRadix;
@@ -301,20 +301,20 @@ void setIOPortMask(void *ioport_bitmap, uint16_t low, uint16_t high, bool_t set)
     int low_index = low & MASK(wordRadix);
     int high_index = high & MASK(wordRadix);
 
-    // see if we are just manipulating bits inside a single word. handling this
-    // specially makes reasoning easier
+    /* see if we are just manipulating bits inside a single word. handling this */
+    /* specially makes reasoning easier */
     if (low_word == high_word) {
         apply_pattern(bitmap + low_word, make_pattern(low_index, high_index + 1), set);
     } else {
-        // operate on the potentially partial first word
+        /* operate on the potentially partial first word */
         apply_pattern(bitmap + low_word, make_pattern(low_index, CONFIG_WORD_SIZE), set);
         low_word++;
-        // iterate over the whole words
+        /* iterate over the whole words */
         while (low_word < high_word) {
             apply_pattern(bitmap + low_word, ~(word_t)0, set);
             low_word++;
         }
-        // apply to any remaining bits
+        /* apply to any remaining bits */
         apply_pattern(bitmap + low_word, make_pattern(0, high_index + 1), set);
     }
 }

--- a/src/arch/x86/object/vcpu.c
+++ b/src/arch/x86/object/vcpu.c
@@ -245,27 +245,27 @@ static bool_t vtx_check_fixed_values(word_t cr0, word_t cr4)
 static bool_t BOOT_CODE init_vtx_fixed_values(bool_t useTrueMsrs)
 {
     uint32_t pin_control_mask =
-        BIT(0) |    //Extern interrupt exiting
-        BIT(3) |    //NMI exiting
-        BIT(5);     //virtual NMIs
+        BIT(0) |    /*Extern interrupt exiting */
+        BIT(3) |    /*NMI exiting */
+        BIT(5);     /*virtual NMIs */
     uint32_t primary_control_mask =
-        BIT(25) |   //Use I/O bitmaps
-        BIT(28) |   //Use MSR bitmaps
-        BIT(31);    //Activate secondary controls
+        BIT(25) |   /*Use I/O bitmaps */
+        BIT(28) |   /*Use MSR bitmaps */
+        BIT(31);    /*Activate secondary controls */
     uint32_t secondary_control_mask =
-        BIT(1);     //Enable EPT
+        BIT(1);     /*Enable EPT */
     uint32_t exit_control_mask =
-        BIT(2)  |   //Save debug controls
-        BIT(18) |   //Save guest IA32_PAT on exit
-        BIT(19) |   //Load host IA32_PAT
-        BIT(20) |   //Save guest IA32_EFER on exit
-        BIT(21);    //Load host IA32_EFER
+        BIT(2)  |   /*Save debug controls */
+        BIT(18) |   /*Save guest IA32_PAT on exit */
+        BIT(19) |   /*Load host IA32_PAT */
+        BIT(20) |   /*Save guest IA32_EFER on exit */
+        BIT(21);    /*Load host IA32_EFER */
 #ifdef CONFIG_ARCH_X86_64
 #ifdef CONFIG_X86_64_VTX_64BIT_GUESTS
     uint32_t entry_control_mask = 0;
-    entry_control_mask |= BIT(9); //Guest address-space size
+    entry_control_mask |= BIT(9); /*Guest address-space size */
 #endif
-    exit_control_mask |= BIT(9); //Host address-space size
+    exit_control_mask |= BIT(9); /*Host address-space size */
 #endif /* CONFIG_ARCH_X86_64 */
     /* Read out the fixed high and low bits from the MSRs */
     uint32_t pinbased_ctls;
@@ -454,9 +454,9 @@ void vcpu_init(vcpu_t *vcpu)
 
     vmwrite(VMX_HOST_PAT, x86_rdmsr(IA32_PAT_MSR));
     vmwrite(VMX_HOST_EFER, x86_rdmsr(IA32_EFER_MSR));
-    // By default we will disable performance counters when we come out
-    // of a VM. When performance counters are supported this host state
-    // needs to be updated on VM entry
+    /* By default we will disable performance counters when we come out */
+    /* of a VM. When performance counters are supported this host state */
+    /* needs to be updated on VM entry */
     if (vmx_feature_load_perf_global_ctrl) {
         vmwrite(VMX_HOST_PERF_GLOBAL_CTRL, 0);
     }

--- a/src/drivers/timer/am335x-timer.c
+++ b/src/drivers/timer/am335x-timer.c
@@ -42,7 +42,7 @@ static BOOT_CODE void disableWatchdog(void)
 {
     uint32_t wdt = WDT1_PPTR;
 
-    // am335x ref man, sec 20.4.3.8
+    /* am335x ref man, sec 20.4.3.8 */
     *WDT_REG(wdt, WDT_REG_WSPR) = 0xaaaa;
     while ((*WDT_REG(wdt, WDT_REG_WWPS) & WDT_WWPS_PEND_WSPR)) {
         continue;

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -175,14 +175,14 @@ BOOT_CODE static word_t calculate_rootserver_size(v_region_t it_v_reg, word_t ex
 {
     /* work out how much memory we need for root server objects */
     word_t size = BIT(CONFIG_ROOT_CNODE_SIZE_BITS + seL4_SlotBits);
-    size += BIT(seL4_TCBBits); // root thread tcb
-    size += BIT(seL4_PageBits); // ipc buf
-    size += BIT(seL4_BootInfoFrameBits); // boot info
+    size += BIT(seL4_TCBBits); /* root thread tcb */
+    size += BIT(seL4_PageBits); /* ipc buf */
+    size += BIT(seL4_BootInfoFrameBits); /* boot info */
     size += BIT(seL4_ASIDPoolBits);
     size += extra_bi_size_bits > 0 ? BIT(extra_bi_size_bits) : 0;
-    size += BIT(seL4_VSpaceBits); // root vspace
+    size += BIT(seL4_VSpaceBits); /* root vspace */
 #ifdef CONFIG_KERNEL_MCS
-    size += BIT(seL4_MinSchedContextBits); // root sched context
+    size += BIT(seL4_MinSchedContextBits); /* root sched context */
 #endif
     /* for all archs, seL4_PageTable Bits is the size of all non top-level paging structures */
     return size + arch_get_n_paging(it_v_reg) * BIT(seL4_PageTableBits);

--- a/src/machine/io.c
+++ b/src/machine/io.c
@@ -277,7 +277,7 @@ static char *fmt_u(uintmax_t x, char *s)
         q += (q >> 16); /* q += (13107x/2^14)/2^16 = 858993458x/2^30 */
         q += (q >> 32); /* q += (858993458x/2^30)/2^32 = .../2^62 */
         q >>= 3; /* q is roughly 0.8x, so q/8 is roughly x/10 */
-        unsigned int rem = x - (((q << 2) + q) << 1); // rem = x - 10q */
+        unsigned int rem = x - (((q << 2) + q) << 1); /* rem = x - 10q */ */
         if (rem > 9) { /* handle rounding issues */
             q += 1;
             rem = x - (((q << 2) + q) << 1); /* recalculate reminder */

--- a/src/object/notification.c
+++ b/src/object/notification.c
@@ -230,8 +230,8 @@ void receiveSignal(tcb_t *thread, cap_t cap, bool_t isBlocking)
         notification_ptr_set_state(ntfnPtr, NtfnState_Idle);
 #ifdef CONFIG_KERNEL_MCS
         maybeDonateSchedContext(thread, ntfnPtr);
-        // If the SC has been donated to the current thread (in a reply_recv, send_recv scenario) then
-        // we may need to perform refill_unblock_check if the SC is becoming activated.
+        /* If the SC has been donated to the current thread (in a reply_recv, send_recv scenario) then */
+        /* we may need to perform refill_unblock_check if the SC is becoming activated. */
         if (thread->tcbSchedContext != NODE_STATE(ksCurSC) && sc_sporadic(thread->tcbSchedContext)) {
             refill_unblock_check(thread->tcbSchedContext);
         }

--- a/src/object/schedcontext.c
+++ b/src/object/schedcontext.c
@@ -256,9 +256,9 @@ static exception_t decodeSchedContext_YieldTo(sched_context_t *sc, bool_t call)
         return EXCEPTION_SYSCALL_ERROR;
     }
 
-    // This should not be possible as the currently running thread
-    // should never have a non-null yieldTo, however verifying this
-    // invariant is being left to future work.
+    /* This should not be possible as the currently running thread */
+    /* should never have a non-null yieldTo, however verifying this */
+    /* invariant is being left to future work. */
     assert(NODE_STATE(ksCurThread)->tcbYieldTo == NULL);
     if (NODE_STATE(ksCurThread)->tcbYieldTo != NULL) {
         userError("SchedContext_YieldTo: cannot seL4_SchedContext_YieldTo to more than on SC at a time");
@@ -329,11 +329,11 @@ void schedContext_bindTCB(sched_context_t *sc, tcb_t *tcb)
     if (isSchedulable(tcb)) {
         SCHED_ENQUEUE(tcb);
         rescheduleRequired();
-        // TODO -- at some stage we should take this call out of any TCB invocations that
-        // alter capabilities, so that we can do a direct switch. The preference here is to
-        // remove seL4_SetSchedParams from using ThreadControl. It's currently out of scope for
-        // verification work, so the work around is to use rescheduleRequired()
-        //possibleSwitchTo(tcb);
+        /* TODO -- at some stage we should take this call out of any TCB invocations that */
+        /* alter capabilities, so that we can do a direct switch. The preference here is to */
+        /* remove seL4_SetSchedParams from using ThreadControl. It's currently out of scope for */
+        /* verification work, so the work around is to use rescheduleRequired() */
+        /*possibleSwitchTo(tcb); */
     }
 }
 

--- a/src/plat/bcm2837/machine/intc.c
+++ b/src/plat/bcm2837/machine/intc.c
@@ -98,17 +98,17 @@ static inline void maskInterrupt(bool_t disable, irq_t irq)
         }
         return;
     case INTERRUPT_CORE_GPU:
-    // Not maskable
+    /* Not maskable */
     case INTERRUPT_CORE_PMU:
-    // Not currently handled
+    /* Not currently handled */
     case INTERRUPT_CORE_AXI:
-        // Not currently handled
+        /* Not currently handled */
         return;
     default:
         break;
     }
     if (irq < BASIC_IRQ_OFFSET) {
-        // Other invalid irq
+        /* Other invalid irq */
         return;
     }
 

--- a/src/plat/pc99/machine/acpi.c
+++ b/src/plat/pc99/machine/acpi.c
@@ -205,7 +205,7 @@ BOOT_CODE static void *acpi_table_init(void *entry, enum acpi_type table_type)
         pages_for_table = (rsdp_entry->length + offset_in_page) / MASK(LARGE_PAGE_BITS) + 1;
         break;
     }
-    case ACPI_RSDT: { // RSDT, MADT, DMAR etc.
+    case ACPI_RSDT: { /* RSDT, MADT, DMAR etc. */
         acpi_rsdt_t *rsdt_entry = (acpi_rsdt_t *)entry;
         pages_for_table = (rsdt_entry->header.length + offset_in_page) / MASK(LARGE_PAGE_BITS) + 1;
         break;

--- a/src/util.c
+++ b/src/util.c
@@ -137,114 +137,114 @@ long PURE str_to_long(const char *str)
     return val;
 }
 
-// The following implementations of CLZ (count leading zeros) and CTZ (count
-// trailing zeros) perform a binary search for the first 1 bit from the
-// beginning (resp. end) of the input. Initially, the focus is the whole input.
-// Then, each iteration determines whether there are any 1 bits set in the
-// upper (resp. lower) half of the current focus. If there are (resp. are not),
-// then the upper half is shifted into the lower half. Either way, the lower
-// half of the current focus becomes the new focus for the next iteration.
-// After enough iterations (6 for 64-bit inputs, 5 for 32-bit inputs), the
-// focus is reduced to a single bit, and the total number of bits shifted can
-// be used to determine the number of zeros before (resp. after) the first 1
-// bit.
-//
-// Although the details vary, the general approach is used in several library
-// implementations, including in LLVM and GCC. Wikipedia has some references:
-// https://en.wikipedia.org/wiki/Find_first_set
-//
-// The current implementation avoids branching. The test that determines
-// whether the upper (resp. lower) half contains any ones directly produces a
-// number which can be used for an unconditional shift. If the upper (resp.
-// lower) half is all zeros, the test produces a zero, and the shift is a
-// no-op. A branchless implementation has the disadvantage that it requires
-// more instructions to execute than one which branches, but the advantage is
-// that none will be mispredicted branches. Whether this is a good tradeoff
-// depends on the branch predictability and the architecture's pipeline depth.
-// The most critical use of clzl in the kernel is in the scheduler priority
-// queue. In the absence of a concrete application and hardware implementation
-// to evaluate the tradeoff, we somewhat arbitrarily choose a branchless
-// implementation. In any case, the compiler might convert this to a branching
-// binary.
+/* The following implementations of CLZ (count leading zeros) and CTZ (count */
+/* trailing zeros) perform a binary search for the first 1 bit from the */
+/* beginning (resp. end) of the input. Initially, the focus is the whole input. */
+/* Then, each iteration determines whether there are any 1 bits set in the */
+/* upper (resp. lower) half of the current focus. If there are (resp. are not), */
+/* then the upper half is shifted into the lower half. Either way, the lower */
+/* half of the current focus becomes the new focus for the next iteration. */
+/* After enough iterations (6 for 64-bit inputs, 5 for 32-bit inputs), the */
+/* focus is reduced to a single bit, and the total number of bits shifted can */
+/* be used to determine the number of zeros before (resp. after) the first 1 */
+/* bit. */
+/* */
+/* Although the details vary, the general approach is used in several library */
+/* implementations, including in LLVM and GCC. Wikipedia has some references: */
+/* https://en.wikipedia.org/wiki/Find_first_set */
+/* */
+/* The current implementation avoids branching. The test that determines */
+/* whether the upper (resp. lower) half contains any ones directly produces a */
+/* number which can be used for an unconditional shift. If the upper (resp. */
+/* lower) half is all zeros, the test produces a zero, and the shift is a */
+/* no-op. A branchless implementation has the disadvantage that it requires */
+/* more instructions to execute than one which branches, but the advantage is */
+/* that none will be mispredicted branches. Whether this is a good tradeoff */
+/* depends on the branch predictability and the architecture's pipeline depth. */
+/* The most critical use of clzl in the kernel is in the scheduler priority */
+/* queue. In the absence of a concrete application and hardware implementation */
+/* to evaluate the tradeoff, we somewhat arbitrarily choose a branchless */
+/* implementation. In any case, the compiler might convert this to a branching */
+/* binary. */
 
-// Check some assumptions made by the clzl, clzll, ctzl functions:
+/* Check some assumptions made by the clzl, clzll, ctzl functions: */
 compile_assert(clz_ulong_32_or_64, sizeof(unsigned long) == 4 || sizeof(unsigned long) == 8);
 compile_assert(clz_ullong_64, sizeof(unsigned long long) == 8);
 compile_assert(clz_word_size, sizeof(unsigned long) * 8 == CONFIG_WORD_SIZE);
 
-// Count leading zeros.
-// This implementation contains no branches. If the architecture provides an
-// instruction to set a register to a boolean value on a comparison, then the
-// binary might also avoid branching. A branchless implementation might be
-// preferable on architectures with deep pipelines, or when the maximum
-// priority of runnable threads frequently varies. However, note that the
-// compiler may choose to convert this to a branching implementation.
-//
-// These functions are potentially `UNUSED` because we want to always expose
-// them to verification without necessarily linking them into the kernel
-// binary.
+/* Count leading zeros. */
+/* This implementation contains no branches. If the architecture provides an */
+/* instruction to set a register to a boolean value on a comparison, then the */
+/* binary might also avoid branching. A branchless implementation might be */
+/* preferable on architectures with deep pipelines, or when the maximum */
+/* priority of runnable threads frequently varies. However, note that the */
+/* compiler may choose to convert this to a branching implementation. */
+/* */
+/* These functions are potentially `UNUSED` because we want to always expose */
+/* them to verification without necessarily linking them into the kernel */
+/* binary. */
 static UNUSED CONST inline unsigned clz32(uint32_t x)
 {
-    // Compiler builtins typically return int, but we use unsigned internally
-    // to reduce the number of guards we see in the proofs.
+    /* Compiler builtins typically return int, but we use unsigned internally */
+    /* to reduce the number of guards we see in the proofs. */
     unsigned count = 32;
     uint32_t mask = UINT32_MAX;
 
-    // Each iteration i (counting backwards) considers the least significant
-    // 2^(i+1) bits of x as the current focus. At the first iteration, the
-    // focus is the whole input. Each iteration assumes x contains no 1 bits
-    // outside its focus. The iteration contains a test which determines
-    // whether there are any 1 bits in the upper half (2^i bits) of the focus,
-    // setting `bits` to 2^i if there are, or zero if not. Shifting by `bits`
-    // then narrows the focus to the lower 2^i bits and satisfies the
-    // assumption for the next iteration. After the final iteration, the focus
-    // is just the least significant bit, and the most significsnt 1 bit of the
-    // original input (if any) has been shifted into this position. The leading
-    // zero count can be determined from the total shift.
-    //
-    // The iterations are given a very regular structure to facilitate proofs,
-    // while also generating reasonably efficient binary code.
+    /* Each iteration i (counting backwards) considers the least significant */
+    /* 2^(i+1) bits of x as the current focus. At the first iteration, the */
+    /* focus is the whole input. Each iteration assumes x contains no 1 bits */
+    /* outside its focus. The iteration contains a test which determines */
+    /* whether there are any 1 bits in the upper half (2^i bits) of the focus, */
+    /* setting `bits` to 2^i if there are, or zero if not. Shifting by `bits` */
+    /* then narrows the focus to the lower 2^i bits and satisfies the */
+    /* assumption for the next iteration. After the final iteration, the focus */
+    /* is just the least significant bit, and the most significsnt 1 bit of the */
+    /* original input (if any) has been shifted into this position. The leading */
+    /* zero count can be determined from the total shift. */
+    /* */
+    /* The iterations are given a very regular structure to facilitate proofs, */
+    /* while also generating reasonably efficient binary code. */
 
-    // The `if (1)` blocks make it easier to reason by chunks in the proofs.
+    /* The `if (1)` blocks make it easier to reason by chunks in the proofs. */
     if (1) {
-        // iteration 4
-        mask >>= (1 << 4); // 0x0000ffff
-        unsigned bits = ((unsigned)(mask < x)) << 4; // [0, 16]
-        x >>= bits; // <= 0x0000ffff
-        count -= bits; // [16, 32]
+        /* iteration 4 */
+        mask >>= (1 << 4); /* 0x0000ffff */
+        unsigned bits = ((unsigned)(mask < x)) << 4; /* [0, 16] */
+        x >>= bits; /* <= 0x0000ffff */
+        count -= bits; /* [16, 32] */
     }
     if (1) {
-        // iteration 3
-        mask >>= (1 << 3); // 0x000000ff
-        unsigned bits = ((unsigned)(mask < x)) << 3; // [0, 8]
-        x >>= bits; // <= 0x000000ff
-        count -= bits; // [8, 16, 24, 32]
+        /* iteration 3 */
+        mask >>= (1 << 3); /* 0x000000ff */
+        unsigned bits = ((unsigned)(mask < x)) << 3; /* [0, 8] */
+        x >>= bits; /* <= 0x000000ff */
+        count -= bits; /* [8, 16, 24, 32] */
     }
     if (1) {
-        // iteration 2
-        mask >>= (1 << 2); // 0x0000000f
-        unsigned bits = ((unsigned)(mask < x)) << 2; // [0, 4]
-        x >>= bits; // <= 0x0000000f
-        count -= bits; // [4, 8, 12, ..., 32]
+        /* iteration 2 */
+        mask >>= (1 << 2); /* 0x0000000f */
+        unsigned bits = ((unsigned)(mask < x)) << 2; /* [0, 4] */
+        x >>= bits; /* <= 0x0000000f */
+        count -= bits; /* [4, 8, 12, ..., 32] */
     }
     if (1) {
-        // iteration 1
-        mask >>= (1 << 1); // 0x00000003
-        unsigned bits = ((unsigned)(mask < x)) << 1; // [0, 2]
-        x >>= bits; // <= 0x00000003
-        count -= bits; // [2, 4, 6, ..., 32]
+        /* iteration 1 */
+        mask >>= (1 << 1); /* 0x00000003 */
+        unsigned bits = ((unsigned)(mask < x)) << 1; /* [0, 2] */
+        x >>= bits; /* <= 0x00000003 */
+        count -= bits; /* [2, 4, 6, ..., 32] */
     }
     if (1) {
-        // iteration 0
-        mask >>= (1 << 0); // 0x00000001
-        unsigned bits = ((unsigned)(mask < x)) << 0; // [0, 1]
-        x >>= bits; // <= 0x00000001
-        count -= bits; // [1, 2, 3, ..., 32]
+        /* iteration 0 */
+        mask >>= (1 << 0); /* 0x00000001 */
+        unsigned bits = ((unsigned)(mask < x)) << 0; /* [0, 1] */
+        x >>= bits; /* <= 0x00000001 */
+        count -= bits; /* [1, 2, 3, ..., 32] */
     }
 
-    // If the original input was zero, there will have been no shifts, so this
-    // gives a result of 32. Otherwise, x is now exactly 1, so subtracting from
-    // count gives a result from [0, 1, 2, ..., 31].
+    /* If the original input was zero, there will have been no shifts, so this */
+    /* gives a result of 32. Otherwise, x is now exactly 1, so subtracting from */
+    /* count gives a result from [0, 1, 2, ..., 31]. */
     return count - x;
 }
 
@@ -253,115 +253,115 @@ static UNUSED CONST inline unsigned clz64(uint64_t x)
     unsigned count = 64;
     uint64_t mask = UINT64_MAX;
 
-    // Although we could implement this using clz32, we spell out the
-    // iterations in full for slightly better code generation at low
-    // optimisation levels, and to allow us to reuse the proof machinery we
-    // developed for clz32.
+    /* Although we could implement this using clz32, we spell out the */
+    /* iterations in full for slightly better code generation at low */
+    /* optimisation levels, and to allow us to reuse the proof machinery we */
+    /* developed for clz32. */
     if (1) {
-        // iteration 5
-        mask >>= (1 << 5); // 0x00000000ffffffff
-        unsigned bits = ((unsigned)(mask < x)) << 5; // [0, 32]
-        x >>= bits; // <= 0x00000000ffffffff
-        count -= bits; // [32, 64]
+        /* iteration 5 */
+        mask >>= (1 << 5); /* 0x00000000ffffffff */
+        unsigned bits = ((unsigned)(mask < x)) << 5; /* [0, 32] */
+        x >>= bits; /* <= 0x00000000ffffffff */
+        count -= bits; /* [32, 64] */
     }
     if (1) {
-        // iteration 4
-        mask >>= (1 << 4); // 0x000000000000ffff
-        unsigned bits = ((unsigned)(mask < x)) << 4; // [0, 16]
-        x >>= bits; // <= 0x000000000000ffff
-        count -= bits; // [16, 32, 48, 64]
+        /* iteration 4 */
+        mask >>= (1 << 4); /* 0x000000000000ffff */
+        unsigned bits = ((unsigned)(mask < x)) << 4; /* [0, 16] */
+        x >>= bits; /* <= 0x000000000000ffff */
+        count -= bits; /* [16, 32, 48, 64] */
     }
     if (1) {
-        // iteration 3
-        mask >>= (1 << 3); // 0x00000000000000ff
-        unsigned bits = ((unsigned)(mask < x)) << 3; // [0, 8]
-        x >>= bits; // <= 0x00000000000000ff
-        count -= bits; // [8, 16, 24, ..., 64]
+        /* iteration 3 */
+        mask >>= (1 << 3); /* 0x00000000000000ff */
+        unsigned bits = ((unsigned)(mask < x)) << 3; /* [0, 8] */
+        x >>= bits; /* <= 0x00000000000000ff */
+        count -= bits; /* [8, 16, 24, ..., 64] */
     }
     if (1) {
-        // iteration 2
-        mask >>= (1 << 2); // 0x000000000000000f
-        unsigned bits = ((unsigned)(mask < x)) << 2; // [0, 4]
-        x >>= bits; // <= 0x000000000000000f
-        count -= bits; // [4, 8, 12, ..., 64]
+        /* iteration 2 */
+        mask >>= (1 << 2); /* 0x000000000000000f */
+        unsigned bits = ((unsigned)(mask < x)) << 2; /* [0, 4] */
+        x >>= bits; /* <= 0x000000000000000f */
+        count -= bits; /* [4, 8, 12, ..., 64] */
     }
     if (1) {
-        // iteration 1
-        mask >>= (1 << 1); // 0x0000000000000003
-        unsigned bits = ((unsigned)(mask < x)) << 1; // [0, 2]
-        x >>= bits; // <= 0x0000000000000003
-        count -= bits; // [2, 4, 6, ..., 64]
+        /* iteration 1 */
+        mask >>= (1 << 1); /* 0x0000000000000003 */
+        unsigned bits = ((unsigned)(mask < x)) << 1; /* [0, 2] */
+        x >>= bits; /* <= 0x0000000000000003 */
+        count -= bits; /* [2, 4, 6, ..., 64] */
     }
     if (1) {
-        // iteration 0
-        mask >>= (1 << 0); // 0x0000000000000001
-        unsigned bits = ((unsigned)(mask < x)) << 0; // [0, 1]
-        x >>= bits; // <= 0x0000000000000001
-        count -= bits; // [1, 2, 3, ..., 64]
+        /* iteration 0 */
+        mask >>= (1 << 0); /* 0x0000000000000001 */
+        unsigned bits = ((unsigned)(mask < x)) << 0; /* [0, 1] */
+        x >>= bits; /* <= 0x0000000000000001 */
+        count -= bits; /* [1, 2, 3, ..., 64] */
     }
 
     return count - x;
 }
 
-// Count trailing zeros.
-// See comments on clz32.
+/* Count trailing zeros. */
+/* See comments on clz32. */
 static UNUSED CONST inline unsigned ctz32(uint32_t x)
 {
     unsigned count = (x == 0);
     uint32_t mask = UINT32_MAX;
 
-    // Each iteration i (counting backwards) considers the least significant
-    // 2^(i+1) bits of x as the current focus. At the first iteration, the
-    // focus is the whole input. The iteration contains a test which determines
-    // whether there are any 1 bits in the lower half (2^i bits) of the focus,
-    // setting `bits` to zero if there are, or 2^i if not. Shifting by `bits`
-    // then narrows the focus to the lower 2^i bits for the next iteration.
-    // After the final iteration, the focus is just the least significant bit,
-    // and the least significsnt 1 bit of the original input (if any) has been
-    // shifted into this position. The trailing zero count can be determined
-    // from the total shift.
-    //
-    // If the initial input is zero, every iteration causes a shift, for a
-    // total shift count of 31, so in that case, we add one for a total count
-    // of 32. In the comments, xi is the initial value of x.
-    //
-    // The iterations are given a very regular structure to facilitate proofs,
-    // while also generating reasonably efficient binary code.
+    /* Each iteration i (counting backwards) considers the least significant */
+    /* 2^(i+1) bits of x as the current focus. At the first iteration, the */
+    /* focus is the whole input. The iteration contains a test which determines */
+    /* whether there are any 1 bits in the lower half (2^i bits) of the focus, */
+    /* setting `bits` to zero if there are, or 2^i if not. Shifting by `bits` */
+    /* then narrows the focus to the lower 2^i bits for the next iteration. */
+    /* After the final iteration, the focus is just the least significant bit, */
+    /* and the least significsnt 1 bit of the original input (if any) has been */
+    /* shifted into this position. The trailing zero count can be determined */
+    /* from the total shift. */
+    /* */
+    /* If the initial input is zero, every iteration causes a shift, for a */
+    /* total shift count of 31, so in that case, we add one for a total count */
+    /* of 32. In the comments, xi is the initial value of x. */
+    /* */
+    /* The iterations are given a very regular structure to facilitate proofs, */
+    /* while also generating reasonably efficient binary code. */
 
     if (1) {
-        // iteration 4
-        mask >>= (1 << 4); // 0x0000ffff
-        unsigned bits = ((unsigned)((x & mask) == 0)) << 4; // [0, 16]
-        x >>= bits; // xi != 0 --> x & 0x0000ffff != 0
-        count += bits; // if xi != 0 then [0, 16] else 17
+        /* iteration 4 */
+        mask >>= (1 << 4); /* 0x0000ffff */
+        unsigned bits = ((unsigned)((x & mask) == 0)) << 4; /* [0, 16] */
+        x >>= bits; /* xi != 0 --> x & 0x0000ffff != 0 */
+        count += bits; /* if xi != 0 then [0, 16] else 17 */
     }
     if (1) {
-        // iteration 3
-        mask >>= (1 << 3); // 0x000000ff
-        unsigned bits = ((unsigned)((x & mask) == 0)) << 3; // [0, 8]
-        x >>= bits; // xi != 0 --> x & 0x000000ff != 0
-        count += bits; // if xi != 0 then [0, 8, 16, 24] else 25
+        /* iteration 3 */
+        mask >>= (1 << 3); /* 0x000000ff */
+        unsigned bits = ((unsigned)((x & mask) == 0)) << 3; /* [0, 8] */
+        x >>= bits; /* xi != 0 --> x & 0x000000ff != 0 */
+        count += bits; /* if xi != 0 then [0, 8, 16, 24] else 25 */
     }
     if (1) {
-        // iteration 2
-        mask >>= (1 << 2); // 0x0000000f
-        unsigned bits = ((unsigned)((x & mask) == 0)) << 2; // [0, 4]
-        x >>= bits; // xi != 0 --> x & 0x0000000f != 0
-        count += bits; // if xi != 0 then [0, 4, 8, ..., 28] else 29
+        /* iteration 2 */
+        mask >>= (1 << 2); /* 0x0000000f */
+        unsigned bits = ((unsigned)((x & mask) == 0)) << 2; /* [0, 4] */
+        x >>= bits; /* xi != 0 --> x & 0x0000000f != 0 */
+        count += bits; /* if xi != 0 then [0, 4, 8, ..., 28] else 29 */
     }
     if (1) {
-        // iteration 1
-        mask >>= (1 << 1); // 0x00000003
-        unsigned bits = ((unsigned)((x & mask) == 0)) << 1; // [0, 2]
-        x >>= bits; // xi != 0 --> x & 0x00000003 != 0
-        count += bits; // if xi != 0 then [0, 2, 4, ..., 30] else 31
+        /* iteration 1 */
+        mask >>= (1 << 1); /* 0x00000003 */
+        unsigned bits = ((unsigned)((x & mask) == 0)) << 1; /* [0, 2] */
+        x >>= bits; /* xi != 0 --> x & 0x00000003 != 0 */
+        count += bits; /* if xi != 0 then [0, 2, 4, ..., 30] else 31 */
     }
     if (1) {
-        // iteration 0
-        mask >>= (1 << 0); // 0x00000001
-        unsigned bits = ((unsigned)((x & mask) == 0)) << 0; // [0, 1]
-        x >>= bits; // xi != 0 --> x & 0x00000001 != 0
-        count += bits; // if xi != 0 then [0, 1, 2, ..., 31] else 32
+        /* iteration 0 */
+        mask >>= (1 << 0); /* 0x00000001 */
+        unsigned bits = ((unsigned)((x & mask) == 0)) << 0; /* [0, 1] */
+        x >>= bits; /* xi != 0 --> x & 0x00000001 != 0 */
+        count += bits; /* if xi != 0 then [0, 1, 2, ..., 31] else 32 */
     }
 
     return count;
@@ -373,56 +373,56 @@ static UNUSED CONST inline unsigned ctz64(uint64_t x)
     uint64_t mask = UINT64_MAX;
 
     if (1) {
-        // iteration 5
-        mask >>= (1 << 5); // 0x00000000ffffffff
-        unsigned bits = ((unsigned)((x & mask) == 0)) << 5; // [0, 32]
-        x >>= bits; // xi != 0 --> x & 0x00000000ffffffff != 0
-        count += bits; // if xi != 0 then [0, 32] else 33
+        /* iteration 5 */
+        mask >>= (1 << 5); /* 0x00000000ffffffff */
+        unsigned bits = ((unsigned)((x & mask) == 0)) << 5; /* [0, 32] */
+        x >>= bits; /* xi != 0 --> x & 0x00000000ffffffff != 0 */
+        count += bits; /* if xi != 0 then [0, 32] else 33 */
     }
     if (1) {
-        // iteration 4
-        mask >>= (1 << 4); // 0x000000000000ffff
-        unsigned bits = ((unsigned)((x & mask) == 0)) << 4; // [0, 16]
-        x >>= bits; // xi != 0 --> x & 0x000000000000ffff != 0
-        count += bits; // if xi != 0 then [0, 16, 32, 48] else 49
+        /* iteration 4 */
+        mask >>= (1 << 4); /* 0x000000000000ffff */
+        unsigned bits = ((unsigned)((x & mask) == 0)) << 4; /* [0, 16] */
+        x >>= bits; /* xi != 0 --> x & 0x000000000000ffff != 0 */
+        count += bits; /* if xi != 0 then [0, 16, 32, 48] else 49 */
     }
     if (1) {
-        // iteration 3
-        mask >>= (1 << 3); // 0x00000000000000ff
-        unsigned bits = ((unsigned)((x & mask) == 0)) << 3; // [0, 8]
-        x >>= bits; // xi != 0 --> x & 0x00000000000000ff != 0
-        count += bits; // if xi != 0 then [0, 8, 16, ..., 56] else 57
+        /* iteration 3 */
+        mask >>= (1 << 3); /* 0x00000000000000ff */
+        unsigned bits = ((unsigned)((x & mask) == 0)) << 3; /* [0, 8] */
+        x >>= bits; /* xi != 0 --> x & 0x00000000000000ff != 0 */
+        count += bits; /* if xi != 0 then [0, 8, 16, ..., 56] else 57 */
     }
     if (1) {
-        // iteration 2
-        mask >>= (1 << 2); // 0x000000000000000f
-        unsigned bits = ((unsigned)((x & mask) == 0)) << 2; // [0, 4]
-        x >>= bits; // xi != 0 --> x & 0x000000000000000f != 0
-        count += bits; // if xi != 0 then [0, 4, 8, ..., 60] else 61
+        /* iteration 2 */
+        mask >>= (1 << 2); /* 0x000000000000000f */
+        unsigned bits = ((unsigned)((x & mask) == 0)) << 2; /* [0, 4] */
+        x >>= bits; /* xi != 0 --> x & 0x000000000000000f != 0 */
+        count += bits; /* if xi != 0 then [0, 4, 8, ..., 60] else 61 */
     }
     if (1) {
-        // iteration 1
-        mask >>= (1 << 1); // 0x0000000000000003
-        unsigned bits = ((unsigned)((x & mask) == 0)) << 1; // [0, 2]
-        x >>= bits; // xi != 0 --> x & 0x0000000000000003 != 0
-        count += bits; // if xi != 0 then [0, 2, 4, ..., 62] else 63
+        /* iteration 1 */
+        mask >>= (1 << 1); /* 0x0000000000000003 */
+        unsigned bits = ((unsigned)((x & mask) == 0)) << 1; /* [0, 2] */
+        x >>= bits; /* xi != 0 --> x & 0x0000000000000003 != 0 */
+        count += bits; /* if xi != 0 then [0, 2, 4, ..., 62] else 63 */
     }
     if (1) {
-        // iteration 0
-        mask >>= (1 << 0); // 0x0000000000000001
-        unsigned bits = ((unsigned)((x & mask) == 0)) << 0; // [0, 1]
-        x >>= bits; // xi != 0 --> x & 0x0000000000000001 != 0
-        count += bits; // if xi != 0 then [0, 1, 2, ..., 63] else 64
+        /* iteration 0 */
+        mask >>= (1 << 0); /* 0x0000000000000001 */
+        unsigned bits = ((unsigned)((x & mask) == 0)) << 0; /* [0, 1] */
+        x >>= bits; /* xi != 0 --> x & 0x0000000000000001 != 0 */
+        count += bits; /* if xi != 0 then [0, 1, 2, ..., 63] else 64 */
     }
 
     return count;
 }
 
-// GCC's builtins will emit calls to these functions when the platform does
-// not provide suitable inline assembly.
-// These are only provided when the relevant config items are set.
-// We define these separately from `ctz32` etc. so that we can verify all of
-// `ctz32` etc. without necessarily linking them into the kernel binary.
+/* GCC's builtins will emit calls to these functions when the platform does */
+/* not provide suitable inline assembly. */
+/* These are only provided when the relevant config items are set. */
+/* We define these separately from `ctz32` etc. so that we can verify all of */
+/* `ctz32` etc. without necessarily linking them into the kernel binary. */
 #ifdef CONFIG_CLZ_32
 CONST int __clzsi2(uint32_t x)
 {


### PR DESCRIPTION
## Summary
- Replace remaining C++ style `//` comments with C89 block comments across kernel, libraries, and drivers

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `cmake -S . -B build` *(fails: Variable 'KernelPlatform' is not set)*

------
https://chatgpt.com/codex/tasks/task_e_6894e6054d38832ba89183c4985a0479