### PR TITLE
Add Python virtual environment setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,23 @@ Repository Overview
 - `libsel4`: C bindings for the seL4 ABI
 - `manual`: LaTeX sources of the seL4 reference manual
 
+Python Environment
+------------------
+
+The seL4 build uses several Python modules. A helper script is provided to
+create a virtual environment and install these dependencies:
+
+```
+./tools/venv.sh
+```
+
+Invoking the script with a command runs that command inside the environment,
+for example:
+
+```
+./tools/venv.sh python --version
+```
+
 Build Instructions
 ------------------
 

--- a/tools/venv.sh
+++ b/tools/venv.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Helper script for setting up and using a Python virtual environment for seL4.
+#
+# When run, this script creates a virtual environment in the repository root at
+# `.venv` if one does not already exist, installs the Python modules required to
+# build seL4, and then executes the given command inside the environment. If no
+# command is supplied, an interactive shell is started.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+VENV_DIR="$REPO_ROOT/.venv"
+
+if [ ! -f "$VENV_DIR/bin/activate" ]; then
+    python3 -m venv "$VENV_DIR"
+    "$VENV_DIR/bin/pip" install --upgrade pip
+    "$VENV_DIR/bin/pip" install -e "$SCRIPT_DIR/python-deps"
+fi
+
+# shellcheck disable=SC1091
+source "$VENV_DIR/bin/activate"
+
+if [ "$#" -gt 0 ]; then
+    exec "$@"
+else
+    exec "$SHELL"
+fi


### PR DESCRIPTION
## Summary
- add `tools/venv.sh` to create and activate a Python virtual environment with required build dependencies
- document how to use the virtual environment helper script in `README.md`

## Testing
- `./tools/venv.sh python --version` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*
- `shellcheck tools/venv.sh` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894e9583944832b82bf737e0a700067