### PR TITLE
Add sel4 config header to preconfigured build

### DIFF
--- a/preconfigured/X64_verified/libsel4/include/sel4/config.h
+++ b/preconfigured/X64_verified/libsel4/include/sel4/config.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2014, General Dynamics C4 Systems
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+/* Compile-time configuration parameters. Might be set by the build system. */
+
+#include <autoconf.h>


### PR DESCRIPTION
## Summary
- include sel4/config.h in preconfigured X64_verified build to remove need for regeneration

## Testing
- `cmake -G Ninja -B build -S . -C configs/X64_verified.cmake`
- `cmake --build build`
- `./replay_preconfigured_build.sh` *(fails: fatal error: sel4/config.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68969911c390832ba6e065f0ce135b6a