### PR TITLE
Create wrapper translation units for kernel sources

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -140,6 +140,12 @@
 - Place wrappers in directories that mirror the original tree so include paths remain intuitive. Reuse the original file names with a suffix (e.g., `_wrapper.c`) to avoid colliding with genuine sources.
 - If a module already lives under `preconfigured/X64_verified/` (e.g., generated sources), skip duplication and just reference the generated file directly.
 
+#### Step 3 progress (2025-09-23)
+- Added `tools/generate_kernel_wrappers.py`, which scrapes the `tools/cpp_gen.sh` invocation from `replay_preconfigured_build.sh` and emits `_wrapper.c` files that mirror the `src/` tree under `preconfigured/X64_verified/src/`.
+- Generated 77 wrappers via the helper; each file just `#include`s its canonical source with a relative path, so static helpers stay scoped to their home translation units.
+- Spot-checked deeply nested modules (`arch/x86/64/kernel/vspace`, `config/default_domain`) to confirm the relative include paths resolve correctly and no existing generated sources were duplicated.
+- The generator is idempotent, so we can rerun it after upstream list changes; with the wrappers in place we're ready to swap the build over in Step 4.
+
 ### 4. Update Build Script and Ancillary Targets
 - Replace the `tools/cpp_gen.sh ... > kernel_all.c` pipeline with commands that synchronize (or regenerate) the wrapper files. Because wrappers simply `#include` the upstream sources, we likely only need to ensure the directory hierarchy exists; no per-build regeneration is required.
 - Modify the subsequent compile step to emit individual object files for each wrapper instead of `kernel_all.c`. Keep the ordering consistent with the original list to minimize risk of hidden dependencies.

--- a/preconfigured/X64_verified/src/api/faults_wrapper.c
+++ b/preconfigured/X64_verified/src/api/faults_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/api/faults.c
+
+#include "../../../../src/api/faults.c"

--- a/preconfigured/X64_verified/src/api/syscall_wrapper.c
+++ b/preconfigured/X64_verified/src/api/syscall_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/api/syscall.c
+
+#include "../../../../src/api/syscall.c"

--- a/preconfigured/X64_verified/src/arch/x86/64/c_traps_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/64/c_traps_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/64/c_traps.c
+
+#include "../../../../../../src/arch/x86/64/c_traps.c"

--- a/preconfigured/X64_verified/src/arch/x86/64/kernel/elf_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/64/kernel/elf_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/64/kernel/elf.c
+
+#include "../../../../../../../src/arch/x86/64/kernel/elf.c"

--- a/preconfigured/X64_verified/src/arch/x86/64/kernel/thread_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/64/kernel/thread_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/64/kernel/thread.c
+
+#include "../../../../../../../src/arch/x86/64/kernel/thread.c"

--- a/preconfigured/X64_verified/src/arch/x86/64/kernel/vspace_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/64/kernel/vspace_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/64/kernel/vspace.c
+
+#include "../../../../../../../src/arch/x86/64/kernel/vspace.c"

--- a/preconfigured/X64_verified/src/arch/x86/64/machine/capdl_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/64/machine/capdl_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/64/machine/capdl.c
+
+#include "../../../../../../../src/arch/x86/64/machine/capdl.c"

--- a/preconfigured/X64_verified/src/arch/x86/64/machine/registerset_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/64/machine/registerset_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/64/machine/registerset.c
+
+#include "../../../../../../../src/arch/x86/64/machine/registerset.c"

--- a/preconfigured/X64_verified/src/arch/x86/64/model/smp_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/64/model/smp_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/64/model/smp.c
+
+#include "../../../../../../../src/arch/x86/64/model/smp.c"

--- a/preconfigured/X64_verified/src/arch/x86/64/model/statedata_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/64/model/statedata_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/64/model/statedata.c
+
+#include "../../../../../../../src/arch/x86/64/model/statedata.c"

--- a/preconfigured/X64_verified/src/arch/x86/64/object/objecttype_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/64/object/objecttype_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/64/object/objecttype.c
+
+#include "../../../../../../../src/arch/x86/64/object/objecttype.c"

--- a/preconfigured/X64_verified/src/arch/x86/64/smp/ipi_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/64/smp/ipi_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/64/smp/ipi.c
+
+#include "../../../../../../../src/arch/x86/64/smp/ipi.c"

--- a/preconfigured/X64_verified/src/arch/x86/api/faults_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/api/faults_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/api/faults.c
+
+#include "../../../../../../src/arch/x86/api/faults.c"

--- a/preconfigured/X64_verified/src/arch/x86/benchmark/benchmark_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/benchmark/benchmark_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/benchmark/benchmark.c
+
+#include "../../../../../../src/arch/x86/benchmark/benchmark.c"

--- a/preconfigured/X64_verified/src/arch/x86/c_traps_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/c_traps_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/c_traps.c
+
+#include "../../../../../src/arch/x86/c_traps.c"

--- a/preconfigured/X64_verified/src/arch/x86/idle_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/idle_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/idle.c
+
+#include "../../../../../src/arch/x86/idle.c"

--- a/preconfigured/X64_verified/src/arch/x86/kernel/apic_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/kernel/apic_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/kernel/apic.c
+
+#include "../../../../../../src/arch/x86/kernel/apic.c"

--- a/preconfigured/X64_verified/src/arch/x86/kernel/boot_sys_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/kernel/boot_sys_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/kernel/boot_sys.c
+
+#include "../../../../../../src/arch/x86/kernel/boot_sys.c"

--- a/preconfigured/X64_verified/src/arch/x86/kernel/boot_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/kernel/boot_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/kernel/boot.c
+
+#include "../../../../../../src/arch/x86/kernel/boot.c"

--- a/preconfigured/X64_verified/src/arch/x86/kernel/cmdline_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/kernel/cmdline_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/kernel/cmdline.c
+
+#include "../../../../../../src/arch/x86/kernel/cmdline.c"

--- a/preconfigured/X64_verified/src/arch/x86/kernel/ept_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/kernel/ept_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/kernel/ept.c
+
+#include "../../../../../../src/arch/x86/kernel/ept.c"

--- a/preconfigured/X64_verified/src/arch/x86/kernel/smp_sys_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/kernel/smp_sys_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/kernel/smp_sys.c
+
+#include "../../../../../../src/arch/x86/kernel/smp_sys.c"

--- a/preconfigured/X64_verified/src/arch/x86/kernel/thread_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/kernel/thread_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/kernel/thread.c
+
+#include "../../../../../../src/arch/x86/kernel/thread.c"

--- a/preconfigured/X64_verified/src/arch/x86/kernel/vspace_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/kernel/vspace_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/kernel/vspace.c
+
+#include "../../../../../../src/arch/x86/kernel/vspace.c"

--- a/preconfigured/X64_verified/src/arch/x86/kernel/x2apic_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/kernel/x2apic_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/kernel/x2apic.c
+
+#include "../../../../../../src/arch/x86/kernel/x2apic.c"

--- a/preconfigured/X64_verified/src/arch/x86/kernel/xapic_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/kernel/xapic_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/kernel/xapic.c
+
+#include "../../../../../../src/arch/x86/kernel/xapic.c"

--- a/preconfigured/X64_verified/src/arch/x86/machine/breakpoint_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/machine/breakpoint_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/machine/breakpoint.c
+
+#include "../../../../../../src/arch/x86/machine/breakpoint.c"

--- a/preconfigured/X64_verified/src/arch/x86/machine/capdl_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/machine/capdl_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/machine/capdl.c
+
+#include "../../../../../../src/arch/x86/machine/capdl.c"

--- a/preconfigured/X64_verified/src/arch/x86/machine/cpu_identification_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/machine/cpu_identification_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/machine/cpu_identification.c
+
+#include "../../../../../../src/arch/x86/machine/cpu_identification.c"

--- a/preconfigured/X64_verified/src/arch/x86/machine/fpu_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/machine/fpu_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/machine/fpu.c
+
+#include "../../../../../../src/arch/x86/machine/fpu.c"

--- a/preconfigured/X64_verified/src/arch/x86/machine/hardware_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/machine/hardware_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/machine/hardware.c
+
+#include "../../../../../../src/arch/x86/machine/hardware.c"

--- a/preconfigured/X64_verified/src/arch/x86/machine/registerset_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/machine/registerset_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/machine/registerset.c
+
+#include "../../../../../../src/arch/x86/machine/registerset.c"

--- a/preconfigured/X64_verified/src/arch/x86/model/statedata_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/model/statedata_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/model/statedata.c
+
+#include "../../../../../../src/arch/x86/model/statedata.c"

--- a/preconfigured/X64_verified/src/arch/x86/object/interrupt_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/object/interrupt_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/object/interrupt.c
+
+#include "../../../../../../src/arch/x86/object/interrupt.c"

--- a/preconfigured/X64_verified/src/arch/x86/object/ioport_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/object/ioport_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/object/ioport.c
+
+#include "../../../../../../src/arch/x86/object/ioport.c"

--- a/preconfigured/X64_verified/src/arch/x86/object/iospace_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/object/iospace_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/object/iospace.c
+
+#include "../../../../../../src/arch/x86/object/iospace.c"

--- a/preconfigured/X64_verified/src/arch/x86/object/objecttype_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/object/objecttype_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/object/objecttype.c
+
+#include "../../../../../../src/arch/x86/object/objecttype.c"

--- a/preconfigured/X64_verified/src/arch/x86/object/tcb_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/object/tcb_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/object/tcb.c
+
+#include "../../../../../../src/arch/x86/object/tcb.c"

--- a/preconfigured/X64_verified/src/arch/x86/object/vcpu_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/object/vcpu_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/object/vcpu.c
+
+#include "../../../../../../src/arch/x86/object/vcpu.c"

--- a/preconfigured/X64_verified/src/arch/x86/smp/ipi_wrapper.c
+++ b/preconfigured/X64_verified/src/arch/x86/smp/ipi_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/arch/x86/smp/ipi.c
+
+#include "../../../../../../src/arch/x86/smp/ipi.c"

--- a/preconfigured/X64_verified/src/assert_wrapper.c
+++ b/preconfigured/X64_verified/src/assert_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/assert.c
+
+#include "../../../src/assert.c"

--- a/preconfigured/X64_verified/src/benchmark/benchmark_track_wrapper.c
+++ b/preconfigured/X64_verified/src/benchmark/benchmark_track_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/benchmark/benchmark_track.c
+
+#include "../../../../src/benchmark/benchmark_track.c"

--- a/preconfigured/X64_verified/src/benchmark/benchmark_utilisation_wrapper.c
+++ b/preconfigured/X64_verified/src/benchmark/benchmark_utilisation_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/benchmark/benchmark_utilisation.c
+
+#include "../../../../src/benchmark/benchmark_utilisation.c"

--- a/preconfigured/X64_verified/src/benchmark/benchmark_wrapper.c
+++ b/preconfigured/X64_verified/src/benchmark/benchmark_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/benchmark/benchmark.c
+
+#include "../../../../src/benchmark/benchmark.c"

--- a/preconfigured/X64_verified/src/config/default_domain_wrapper.c
+++ b/preconfigured/X64_verified/src/config/default_domain_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/config/default_domain.c
+
+#include "../../../../src/config/default_domain.c"

--- a/preconfigured/X64_verified/src/fastpath/fastpath_wrapper.c
+++ b/preconfigured/X64_verified/src/fastpath/fastpath_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/fastpath/fastpath.c
+
+#include "../../../../src/fastpath/fastpath.c"

--- a/preconfigured/X64_verified/src/inlines_wrapper.c
+++ b/preconfigured/X64_verified/src/inlines_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/inlines.c
+
+#include "../../../src/inlines.c"

--- a/preconfigured/X64_verified/src/kernel/boot_wrapper.c
+++ b/preconfigured/X64_verified/src/kernel/boot_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/kernel/boot.c
+
+#include "../../../../src/kernel/boot.c"

--- a/preconfigured/X64_verified/src/kernel/cspace_wrapper.c
+++ b/preconfigured/X64_verified/src/kernel/cspace_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/kernel/cspace.c
+
+#include "../../../../src/kernel/cspace.c"

--- a/preconfigured/X64_verified/src/kernel/faulthandler_wrapper.c
+++ b/preconfigured/X64_verified/src/kernel/faulthandler_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/kernel/faulthandler.c
+
+#include "../../../../src/kernel/faulthandler.c"

--- a/preconfigured/X64_verified/src/kernel/stack_wrapper.c
+++ b/preconfigured/X64_verified/src/kernel/stack_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/kernel/stack.c
+
+#include "../../../../src/kernel/stack.c"

--- a/preconfigured/X64_verified/src/kernel/thread_wrapper.c
+++ b/preconfigured/X64_verified/src/kernel/thread_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/kernel/thread.c
+
+#include "../../../../src/kernel/thread.c"

--- a/preconfigured/X64_verified/src/machine/capdl_wrapper.c
+++ b/preconfigured/X64_verified/src/machine/capdl_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/machine/capdl.c
+
+#include "../../../../src/machine/capdl.c"

--- a/preconfigured/X64_verified/src/machine/fpu_wrapper.c
+++ b/preconfigured/X64_verified/src/machine/fpu_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/machine/fpu.c
+
+#include "../../../../src/machine/fpu.c"

--- a/preconfigured/X64_verified/src/machine/io_wrapper.c
+++ b/preconfigured/X64_verified/src/machine/io_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/machine/io.c
+
+#include "../../../../src/machine/io.c"

--- a/preconfigured/X64_verified/src/machine/registerset_wrapper.c
+++ b/preconfigured/X64_verified/src/machine/registerset_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/machine/registerset.c
+
+#include "../../../../src/machine/registerset.c"

--- a/preconfigured/X64_verified/src/model/preemption_wrapper.c
+++ b/preconfigured/X64_verified/src/model/preemption_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/model/preemption.c
+
+#include "../../../../src/model/preemption.c"

--- a/preconfigured/X64_verified/src/model/smp_wrapper.c
+++ b/preconfigured/X64_verified/src/model/smp_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/model/smp.c
+
+#include "../../../../src/model/smp.c"

--- a/preconfigured/X64_verified/src/model/statedata_wrapper.c
+++ b/preconfigured/X64_verified/src/model/statedata_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/model/statedata.c
+
+#include "../../../../src/model/statedata.c"

--- a/preconfigured/X64_verified/src/object/cnode_wrapper.c
+++ b/preconfigured/X64_verified/src/object/cnode_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/object/cnode.c
+
+#include "../../../../src/object/cnode.c"

--- a/preconfigured/X64_verified/src/object/endpoint_wrapper.c
+++ b/preconfigured/X64_verified/src/object/endpoint_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/object/endpoint.c
+
+#include "../../../../src/object/endpoint.c"

--- a/preconfigured/X64_verified/src/object/interrupt_wrapper.c
+++ b/preconfigured/X64_verified/src/object/interrupt_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/object/interrupt.c
+
+#include "../../../../src/object/interrupt.c"

--- a/preconfigured/X64_verified/src/object/notification_wrapper.c
+++ b/preconfigured/X64_verified/src/object/notification_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/object/notification.c
+
+#include "../../../../src/object/notification.c"

--- a/preconfigured/X64_verified/src/object/objecttype_wrapper.c
+++ b/preconfigured/X64_verified/src/object/objecttype_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/object/objecttype.c
+
+#include "../../../../src/object/objecttype.c"

--- a/preconfigured/X64_verified/src/object/tcb_wrapper.c
+++ b/preconfigured/X64_verified/src/object/tcb_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/object/tcb.c
+
+#include "../../../../src/object/tcb.c"

--- a/preconfigured/X64_verified/src/object/untyped_wrapper.c
+++ b/preconfigured/X64_verified/src/object/untyped_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/object/untyped.c
+
+#include "../../../../src/object/untyped.c"

--- a/preconfigured/X64_verified/src/plat/pc99/machine/acpi_wrapper.c
+++ b/preconfigured/X64_verified/src/plat/pc99/machine/acpi_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/plat/pc99/machine/acpi.c
+
+#include "../../../../../../src/plat/pc99/machine/acpi.c"

--- a/preconfigured/X64_verified/src/plat/pc99/machine/hardware_wrapper.c
+++ b/preconfigured/X64_verified/src/plat/pc99/machine/hardware_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/plat/pc99/machine/hardware.c
+
+#include "../../../../../../src/plat/pc99/machine/hardware.c"

--- a/preconfigured/X64_verified/src/plat/pc99/machine/intel-vtd_wrapper.c
+++ b/preconfigured/X64_verified/src/plat/pc99/machine/intel-vtd_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/plat/pc99/machine/intel-vtd.c
+
+#include "../../../../../../src/plat/pc99/machine/intel-vtd.c"

--- a/preconfigured/X64_verified/src/plat/pc99/machine/io_wrapper.c
+++ b/preconfigured/X64_verified/src/plat/pc99/machine/io_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/plat/pc99/machine/io.c
+
+#include "../../../../../../src/plat/pc99/machine/io.c"

--- a/preconfigured/X64_verified/src/plat/pc99/machine/ioapic_wrapper.c
+++ b/preconfigured/X64_verified/src/plat/pc99/machine/ioapic_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/plat/pc99/machine/ioapic.c
+
+#include "../../../../../../src/plat/pc99/machine/ioapic.c"

--- a/preconfigured/X64_verified/src/plat/pc99/machine/pic_wrapper.c
+++ b/preconfigured/X64_verified/src/plat/pc99/machine/pic_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/plat/pc99/machine/pic.c
+
+#include "../../../../../../src/plat/pc99/machine/pic.c"

--- a/preconfigured/X64_verified/src/plat/pc99/machine/pit_wrapper.c
+++ b/preconfigured/X64_verified/src/plat/pc99/machine/pit_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/plat/pc99/machine/pit.c
+
+#include "../../../../../../src/plat/pc99/machine/pit.c"

--- a/preconfigured/X64_verified/src/smp/ipi_wrapper.c
+++ b/preconfigured/X64_verified/src/smp/ipi_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/smp/ipi.c
+
+#include "../../../../src/smp/ipi.c"

--- a/preconfigured/X64_verified/src/smp/lock_wrapper.c
+++ b/preconfigured/X64_verified/src/smp/lock_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/smp/lock.c
+
+#include "../../../../src/smp/lock.c"

--- a/preconfigured/X64_verified/src/string_wrapper.c
+++ b/preconfigured/X64_verified/src/string_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/string.c
+
+#include "../../../src/string.c"

--- a/preconfigured/X64_verified/src/util_wrapper.c
+++ b/preconfigured/X64_verified/src/util_wrapper.c
@@ -1,0 +1,4 @@
+// Generated wrapper to provide a standalone translation unit.
+// Source: src/util.c
+
+#include "../../../src/util.c"

--- a/tools/generate_kernel_wrappers.py
+++ b/tools/generate_kernel_wrappers.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Generate wrapper translation units for the kernel sources."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+import sys
+from typing import Iterable, List
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+REPLAY_SCRIPT = ROOT / "replay_preconfigured_build.sh"
+WRAPPER_ROOT = ROOT / "preconfigured" / "X64_verified" / "src"
+
+
+def extract_source_paths(script_text: str) -> List[pathlib.Path]:
+    """Return the list of source files fed into tools/cpp_gen.sh."""
+    match = re.search(
+        r"tools/cpp_gen\.sh(?P<body>.*?)>\s*kernel_all\.c",
+        script_text,
+        re.S,
+    )
+    if not match:
+        raise RuntimeError("Unable to locate tools/cpp_gen.sh invocation")
+
+    invocation = match.group("body")
+    paths = re.findall(r'"\$ROOT_DIR"/([^"\s]+\.c)', invocation)
+    if not paths:
+        raise RuntimeError("No source paths found in cpp_gen.sh invocation")
+    return [pathlib.Path(p) for p in paths]
+
+
+def build_wrapper_path(source_path: pathlib.Path) -> pathlib.Path:
+    """Map a source path like src/foo/bar.c to its wrapper location."""
+    if not source_path.parts or source_path.parts[0] != "src":
+        raise ValueError(f"Expected path rooted at src/, got {source_path}")
+    relative = pathlib.Path(*source_path.parts[1:])
+    return WRAPPER_ROOT / relative.parent / f"{relative.stem}_wrapper.c"
+
+
+def ensure_parent_dir(path: pathlib.Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def compute_include_path(wrapper_path: pathlib.Path, source_path: pathlib.Path) -> str:
+    wrapper_dir = wrapper_path.parent
+    include_rel = os.path.relpath(source_path, wrapper_dir)
+    return include_rel.replace(os.sep, "/")
+
+
+def render_wrapper(source_path: pathlib.Path, include_path: str) -> str:
+    return "\n".join(
+        [
+            "// Generated wrapper to provide a standalone translation unit.",
+            f"// Source: {source_path.as_posix()}",
+            "",
+            f"#include \"{include_path}\"",
+            "",
+        ]
+    )
+
+
+def write_file_if_changed(path: pathlib.Path, content: str) -> bool:
+    if path.exists():
+        existing = path.read_text()
+        if existing == content:
+            return False
+    path.write_text(content)
+    return True
+
+
+def main(argv: Iterable[str]) -> int:
+    try:
+        script_text = REPLAY_SCRIPT.read_text()
+    except FileNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    sources = extract_source_paths(script_text)
+
+    changed_files = []
+    for source in sources:
+        absolute_source = ROOT / source
+        if not absolute_source.exists():
+            raise FileNotFoundError(f"Source file not found: {absolute_source}")
+        wrapper_path = build_wrapper_path(source)
+        ensure_parent_dir(wrapper_path)
+        include_path = compute_include_path(wrapper_path, absolute_source)
+        content = render_wrapper(source, include_path)
+        if write_file_if_changed(wrapper_path, content):
+            changed_files.append(wrapper_path)
+
+    if changed_files:
+        print("Updated wrapper files:")
+        for path in changed_files:
+            print(f"  {path.relative_to(ROOT)}")
+    else:
+        print("Wrappers are up to date.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- add a helper script that parses replay_preconfigured_build.sh and emits wrapper translation units mirroring src/
- generate 77 wrapper .c files under preconfigured/X64_verified/src that include their canonical sources
- record the wrapper creation work in PLAN.md step 3 progress notes

## Testing
- ./tools/generate_kernel_wrappers.py


------
https://chatgpt.com/codex/tasks/task_e_68d2425eaa20832b8743f4dda85fff94