### PR TITLE
Switch preconfigured build to wrapper objects

### DIFF
--- a/replay_preconfigured_build.sh
+++ b/replay_preconfigured_build.sh
@@ -21,6 +21,85 @@ COMMON_GCC_ARGS=(
   "-I\"$ROOT_DIR\"/preconfigured/X64_verified/gen_headers"
 )
 export COMMON_GCC_ARGS
+KERNEL_SOURCES=(
+  "src/api/faults.c"
+  "src/api/syscall.c"
+  "src/arch/x86/64/c_traps.c"
+  "src/arch/x86/64/kernel/elf.c"
+  "src/arch/x86/64/kernel/thread.c"
+  "src/arch/x86/64/kernel/vspace.c"
+  "src/arch/x86/64/machine/capdl.c"
+  "src/arch/x86/64/machine/registerset.c"
+  "src/arch/x86/64/model/smp.c"
+  "src/arch/x86/64/model/statedata.c"
+  "src/arch/x86/64/object/objecttype.c"
+  "src/arch/x86/64/smp/ipi.c"
+  "src/arch/x86/api/faults.c"
+  "src/arch/x86/benchmark/benchmark.c"
+  "src/arch/x86/c_traps.c"
+  "src/arch/x86/idle.c"
+  "src/arch/x86/kernel/apic.c"
+  "src/arch/x86/kernel/boot.c"
+  "src/arch/x86/kernel/boot_sys.c"
+  "src/arch/x86/kernel/cmdline.c"
+  "src/arch/x86/kernel/ept.c"
+  "src/arch/x86/kernel/smp_sys.c"
+  "src/arch/x86/kernel/thread.c"
+  "src/arch/x86/kernel/vspace.c"
+  "src/arch/x86/kernel/x2apic.c"
+  "src/arch/x86/kernel/xapic.c"
+  "src/arch/x86/machine/breakpoint.c"
+  "src/arch/x86/machine/capdl.c"
+  "src/arch/x86/machine/cpu_identification.c"
+  "src/arch/x86/machine/fpu.c"
+  "src/arch/x86/machine/hardware.c"
+  "src/arch/x86/machine/registerset.c"
+  "src/arch/x86/model/statedata.c"
+  "src/arch/x86/object/interrupt.c"
+  "src/arch/x86/object/ioport.c"
+  "src/arch/x86/object/iospace.c"
+  "src/arch/x86/object/objecttype.c"
+  "src/arch/x86/object/tcb.c"
+  "src/arch/x86/object/vcpu.c"
+  "src/arch/x86/smp/ipi.c"
+  "src/assert.c"
+  "src/benchmark/benchmark.c"
+  "src/benchmark/benchmark_track.c"
+  "src/benchmark/benchmark_utilisation.c"
+  "src/fastpath/fastpath.c"
+  "src/inlines.c"
+  "src/kernel/boot.c"
+  "src/kernel/cspace.c"
+  "src/kernel/faulthandler.c"
+  "src/kernel/stack.c"
+  "src/kernel/thread.c"
+  "src/machine/capdl.c"
+  "src/machine/fpu.c"
+  "src/machine/io.c"
+  "src/machine/registerset.c"
+  "src/model/preemption.c"
+  "src/model/smp.c"
+  "src/model/statedata.c"
+  "src/object/cnode.c"
+  "src/object/endpoint.c"
+  "src/object/interrupt.c"
+  "src/object/notification.c"
+  "src/object/objecttype.c"
+  "src/object/tcb.c"
+  "src/object/untyped.c"
+  "src/plat/pc99/machine/acpi.c"
+  "src/plat/pc99/machine/hardware.c"
+  "src/plat/pc99/machine/intel-vtd.c"
+  "src/plat/pc99/machine/io.c"
+  "src/plat/pc99/machine/ioapic.c"
+  "src/plat/pc99/machine/pic.c"
+  "src/plat/pc99/machine/pit.c"
+  "src/smp/ipi.c"
+  "src/smp/lock.c"
+  "src/string.c"
+  "src/util.c"
+  "src/config/default_domain.c"
+)
 # Add common compiler flags
 CFLAGS="-D__KERNEL_64__ -march=nehalem -O3 -DNDEBUG -std=c99 -Wall -Werror -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Wmissing-declarations -Wundef -Wpointer-arith -Wno-nonnull -nostdinc -ffreestanding -fno-stack-protector -fno-asynchronous-unwind-tables -fno-common -O2 -nostdlib -fno-pic -fno-pie -mcmodel=kernel -mno-mmx -mno-sse -mno-sse2 -mno-3dnow"
 export CFLAGS
@@ -65,7 +144,17 @@ done
 cd "$BUILD_DIR"
 cd "$ROOT_DIR"/preconfigured/X64_verified && /usr/bin/cmake -E touch "$ROOT_DIR"/preconfigured/X64_verified/generated_prune/plat_mode/machine/hardware_gen.h "$ROOT_DIR"/preconfigured/X64_verified/generated_prune/arch/object/structures_gen.h "$ROOT_DIR"/preconfigured/X64_verified/generated_prune/sel4/shared_types_gen.h
 $CC --sysroot="$ROOT_DIR"/preconfigured/X64_verified  "${COMMON_GCC_ARGS[@]}" -I"$ROOT_DIR"/preconfigured/X64_verified/libsel4/autoconf -I"$ROOT_DIR"/preconfigured/X64_verified/libsel4/gen_config -m64 $CFLAGS -E -P -MD -MT libsel4/CMakeFiles/libsel4_shared_types_gen_pbf_temp_lib.dir/libsel4_shared_types_gen_pbf_temp.c.obj -MF libsel4/CMakeFiles/libsel4_shared_types_gen_pbf_temp_lib.dir/libsel4_shared_types_gen_pbf_temp.c.obj.d -o libsel4/CMakeFiles/libsel4_shared_types_gen_pbf_temp_lib.dir/libsel4_shared_types_gen_pbf_temp.c.obj -c "$ROOT_DIR"/preconfigured/X64_verified/libsel4/libsel4_shared_types_gen_pbf_temp.c
-cd "$ROOT_DIR"/preconfigured/X64_verified && "$ROOT_DIR"/tools/cpp_gen.sh "$ROOT_DIR"/src/api/faults.c "$ROOT_DIR"/src/api/syscall.c "$ROOT_DIR"/src/arch/x86/64/c_traps.c "$ROOT_DIR"/src/arch/x86/64/kernel/elf.c "$ROOT_DIR"/src/arch/x86/64/kernel/thread.c "$ROOT_DIR"/src/arch/x86/64/kernel/vspace.c "$ROOT_DIR"/src/arch/x86/64/machine/capdl.c "$ROOT_DIR"/src/arch/x86/64/machine/registerset.c "$ROOT_DIR"/src/arch/x86/64/model/smp.c "$ROOT_DIR"/src/arch/x86/64/model/statedata.c "$ROOT_DIR"/src/arch/x86/64/object/objecttype.c "$ROOT_DIR"/src/arch/x86/64/smp/ipi.c "$ROOT_DIR"/src/arch/x86/api/faults.c "$ROOT_DIR"/src/arch/x86/benchmark/benchmark.c "$ROOT_DIR"/src/arch/x86/c_traps.c "$ROOT_DIR"/src/arch/x86/idle.c "$ROOT_DIR"/src/arch/x86/kernel/apic.c "$ROOT_DIR"/src/arch/x86/kernel/boot.c "$ROOT_DIR"/src/arch/x86/kernel/boot_sys.c "$ROOT_DIR"/src/arch/x86/kernel/cmdline.c "$ROOT_DIR"/src/arch/x86/kernel/ept.c "$ROOT_DIR"/src/arch/x86/kernel/smp_sys.c "$ROOT_DIR"/src/arch/x86/kernel/thread.c "$ROOT_DIR"/src/arch/x86/kernel/vspace.c "$ROOT_DIR"/src/arch/x86/kernel/x2apic.c "$ROOT_DIR"/src/arch/x86/kernel/xapic.c "$ROOT_DIR"/src/arch/x86/machine/breakpoint.c "$ROOT_DIR"/src/arch/x86/machine/capdl.c "$ROOT_DIR"/src/arch/x86/machine/cpu_identification.c "$ROOT_DIR"/src/arch/x86/machine/fpu.c "$ROOT_DIR"/src/arch/x86/machine/hardware.c "$ROOT_DIR"/src/arch/x86/machine/registerset.c "$ROOT_DIR"/src/arch/x86/model/statedata.c "$ROOT_DIR"/src/arch/x86/object/interrupt.c "$ROOT_DIR"/src/arch/x86/object/ioport.c "$ROOT_DIR"/src/arch/x86/object/iospace.c "$ROOT_DIR"/src/arch/x86/object/objecttype.c "$ROOT_DIR"/src/arch/x86/object/tcb.c "$ROOT_DIR"/src/arch/x86/object/vcpu.c "$ROOT_DIR"/src/arch/x86/smp/ipi.c "$ROOT_DIR"/src/assert.c "$ROOT_DIR"/src/benchmark/benchmark.c "$ROOT_DIR"/src/benchmark/benchmark_track.c "$ROOT_DIR"/src/benchmark/benchmark_utilisation.c "$ROOT_DIR"/src/fastpath/fastpath.c "$ROOT_DIR"/src/inlines.c "$ROOT_DIR"/src/kernel/boot.c "$ROOT_DIR"/src/kernel/cspace.c "$ROOT_DIR"/src/kernel/faulthandler.c "$ROOT_DIR"/src/kernel/stack.c "$ROOT_DIR"/src/kernel/thread.c "$ROOT_DIR"/src/machine/capdl.c "$ROOT_DIR"/src/machine/fpu.c "$ROOT_DIR"/src/machine/io.c "$ROOT_DIR"/src/machine/registerset.c "$ROOT_DIR"/src/model/preemption.c "$ROOT_DIR"/src/model/smp.c "$ROOT_DIR"/src/model/statedata.c "$ROOT_DIR"/src/object/cnode.c "$ROOT_DIR"/src/object/endpoint.c "$ROOT_DIR"/src/object/interrupt.c "$ROOT_DIR"/src/object/notification.c "$ROOT_DIR"/src/object/objecttype.c "$ROOT_DIR"/src/object/tcb.c "$ROOT_DIR"/src/object/untyped.c "$ROOT_DIR"/src/plat/pc99/machine/acpi.c "$ROOT_DIR"/src/plat/pc99/machine/hardware.c "$ROOT_DIR"/src/plat/pc99/machine/intel-vtd.c "$ROOT_DIR"/src/plat/pc99/machine/io.c "$ROOT_DIR"/src/plat/pc99/machine/ioapic.c "$ROOT_DIR"/src/plat/pc99/machine/pic.c "$ROOT_DIR"/src/plat/pc99/machine/pit.c "$ROOT_DIR"/src/smp/ipi.c "$ROOT_DIR"/src/smp/lock.c "$ROOT_DIR"/src/string.c "$ROOT_DIR"/src/util.c "$ROOT_DIR"/src/config/default_domain.c > kernel_all.c
+python3 "$ROOT_DIR"/tools/generate_kernel_wrappers.py
+
+WRAPPER_OBJECTS=()
+for source in "${KERNEL_SOURCES[@]}"; do
+    wrapper="${source%.c}_wrapper.c"
+    obj="CMakeFiles/kernel.elf.dir/${wrapper}.obj"
+    dep="${obj}.d"
+    mkdir -p "$(dirname "$obj")"
+    $CC --sysroot="$ROOT_DIR"/preconfigured/X64_verified  "${COMMON_GCC_ARGS[@]}" -I"$ROOT_DIR"/preconfigured/X64_verified/generated -m64 $CFLAGS -MD -MT "$obj" -MF "$dep" -o "$obj" -c "$ROOT_DIR"/preconfigured/X64_verified/"$wrapper"
+    WRAPPER_OBJECTS+=("$obj")
+done
 $CC --sysroot="$ROOT_DIR"/preconfigured/X64_verified  "${COMMON_GCC_ARGS[@]}" -I"$ROOT_DIR"/preconfigured/X64_verified/libsel4/autoconf -I"$ROOT_DIR"/preconfigured/X64_verified/libsel4/gen_config -m64 $CFLAGS -E -P -MD -MT libsel4/CMakeFiles/libsel4_sel4_arch_types_gen_pbf_temp_lib.dir/libsel4_sel4_arch_types_gen_pbf_temp.c.obj -MF libsel4/CMakeFiles/libsel4_sel4_arch_types_gen_pbf_temp_lib.dir/libsel4_sel4_arch_types_gen_pbf_temp.c.obj.d -o libsel4/CMakeFiles/libsel4_sel4_arch_types_gen_pbf_temp_lib.dir/libsel4_sel4_arch_types_gen_pbf_temp.c.obj -c "$ROOT_DIR"/preconfigured/X64_verified/libsel4/libsel4_sel4_arch_types_gen_pbf_temp.c
 # Kernel syscall header is checked in; header generation skipped
 $CC --sysroot="$ROOT_DIR"/preconfigured/X64_verified  "${COMMON_GCC_ARGS[@]}" -m64 $CFLAGS -E -CC -I"$ROOT_DIR"/preconfigured/X64_verified/generated_prune -MD -MT CMakeFiles/kernel_all_pp_prune_wrapper_temp_lib.dir/kernel_all_pp_prune_wrapper_temp.c.obj -MF CMakeFiles/kernel_all_pp_prune_wrapper_temp_lib.dir/kernel_all_pp_prune_wrapper_temp.c.obj.d -o CMakeFiles/kernel_all_pp_prune_wrapper_temp_lib.dir/kernel_all_pp_prune_wrapper_temp.c.obj -c "$ROOT_DIR"/preconfigured/X64_verified/kernel_all_pp_prune_wrapper_temp.c
@@ -80,5 +169,4 @@ $CC --sysroot="$ROOT_DIR"/preconfigured/X64_verified  "${COMMON_GCC_ARGS[@]}" -I
 $CC --sysroot="$ROOT_DIR"/preconfigured/X64_verified  "${COMMON_GCC_ARGS[@]}" -I"$ROOT_DIR"/preconfigured/X64_verified/generated -Wa,--64 $CFLAGS -MD -MT CMakeFiles/kernel.elf.dir/src/arch/x86/64/traps.S.obj -MF CMakeFiles/kernel.elf.dir/src/arch/x86/64/traps.S.obj.d -o CMakeFiles/kernel.elf.dir/src/arch/x86/64/traps.S.obj -c "$ROOT_DIR"/src/arch/x86/64/traps.S
 $CC --sysroot="$ROOT_DIR"/preconfigured/X64_verified  "${COMMON_GCC_ARGS[@]}" -I"$ROOT_DIR"/preconfigured/X64_verified/generated -Wa,--64 $CFLAGS -MD -MT CMakeFiles/kernel.elf.dir/src/arch/x86/64/machine_asm.S.obj -MF CMakeFiles/kernel.elf.dir/src/arch/x86/64/machine_asm.S.obj.d -o CMakeFiles/kernel.elf.dir/src/arch/x86/64/machine_asm.S.obj -c "$ROOT_DIR"/src/arch/x86/64/machine_asm.S
 $CC --sysroot="$ROOT_DIR"/preconfigured/X64_verified  "${COMMON_GCC_ARGS[@]}" -I"$ROOT_DIR"/preconfigured/X64_verified/generated -Wa,--64 $CFLAGS -MD -MT CMakeFiles/kernel.elf.dir/src/arch/x86/64/head.S.obj -MF CMakeFiles/kernel.elf.dir/src/arch/x86/64/head.S.obj.d -o CMakeFiles/kernel.elf.dir/src/arch/x86/64/head.S.obj -c "$ROOT_DIR"/src/arch/x86/64/head.S
-$CC --sysroot="$ROOT_DIR"/preconfigured/X64_verified  "${COMMON_GCC_ARGS[@]}" -I"$ROOT_DIR"/preconfigured/X64_verified/generated -m64 $CFLAGS -MD -MT CMakeFiles/kernel.elf.dir/kernel_all.c.obj -MF CMakeFiles/kernel.elf.dir/kernel_all.c.obj.d -o CMakeFiles/kernel.elf.dir/kernel_all.c.obj -c "$ROOT_DIR"/preconfigured/X64_verified/kernel_all.c
-: && $CC --sysroot="$ROOT_DIR"/preconfigured/X64_verified -m64 $CFLAGS -D__KERNEL_64__ -march=nehalem -O3 -DNDEBUG -D__KERNEL_64__ -march=nehalem  -Wl,-m,elf_x86_64  -static -Wl,--build-id=none -Wl,-n -O2  -nostdlib  -fno-pic  -fno-pie  -mcmodel=kernel     -Wl,-T "$ROOT_DIR"/preconfigured/X64_verified/linker.lds_pp CMakeFiles/kernel.elf.dir/src/arch/x86/multiboot.S.obj CMakeFiles/kernel.elf.dir/src/arch/x86/64/machine_asm.S.obj CMakeFiles/kernel.elf.dir/src/arch/x86/64/traps.S.obj CMakeFiles/kernel.elf.dir/src/arch/x86/64/head.S.obj CMakeFiles/kernel.elf.dir/kernel_all.c.obj -o kernel.elf   && :
+: && $CC --sysroot="$ROOT_DIR"/preconfigured/X64_verified -m64 $CFLAGS -D__KERNEL_64__ -march=nehalem -O3 -DNDEBUG -D__KERNEL_64__ -march=nehalem  -Wl,-m,elf_x86_64  -static -Wl,--build-id=none -Wl,-n -O2  -nostdlib  -fno-pic  -fno-pie  -mcmodel=kernel     -Wl,-T "$ROOT_DIR"/preconfigured/X64_verified/linker.lds_pp CMakeFiles/kernel.elf.dir/src/arch/x86/multiboot.S.obj CMakeFiles/kernel.elf.dir/src/arch/x86/64/machine_asm.S.obj CMakeFiles/kernel.elf.dir/src/arch/x86/64/traps.S.obj CMakeFiles/kernel.elf.dir/src/arch/x86/64/head.S.obj "${WRAPPER_OBJECTS[@]}" -o kernel.elf   && :

--- a/tools/generate_kernel_wrappers.py
+++ b/tools/generate_kernel_wrappers.py
@@ -15,17 +15,17 @@ WRAPPER_ROOT = ROOT / "preconfigured" / "X64_verified" / "src"
 
 
 def extract_source_paths(script_text: str) -> List[pathlib.Path]:
-    """Return the list of source files fed into tools/cpp_gen.sh."""
+    """Return the list of kernel source files in build order."""
     match = re.search(
-        r"tools/cpp_gen\.sh(?P<body>.*?)>\s*kernel_all\.c",
+        r"KERNEL_SOURCES=\(\s*(?P<body>.*?)\)\s*# Add common compiler flags",
         script_text,
         re.S,
     )
     if not match:
-        raise RuntimeError("Unable to locate tools/cpp_gen.sh invocation")
+        raise RuntimeError("Unable to locate KERNEL_SOURCES definition")
 
-    invocation = match.group("body")
-    paths = re.findall(r'"\$ROOT_DIR"/([^"\s]+\.c)', invocation)
+    body = match.group("body")
+    paths = re.findall(r'"([^"\s]+\.c)"', body)
     if not paths:
         raise RuntimeError("No source paths found in cpp_gen.sh invocation")
     return [pathlib.Path(p) for p in paths]


### PR DESCRIPTION
## Summary
- add a shared `KERNEL_SOURCES` array so the preconfigured build and wrapper generator use the same ordered kernel source list
- invoke the wrapper generator from `replay_preconfigured_build.sh` and compile each wrapper translation unit instead of the monolithic `kernel_all.c`
- update the wrapper generator to understand the new array format and log the work in PLAN.md

## Testing
- python3 tools/generate_kernel_wrappers.py

------
https://chatgpt.com/codex/tasks/task_e_68d245023cf8832b8ab2d5f273fe8d5a