### PR TITLE
Document diff inventory for reorg plan

### DIFF
--- a/PRISTINE-AND-PRECONFIGURED-PLAN.md
+++ b/PRISTINE-AND-PRECONFIGURED-PLAN.md
@@ -37,3 +37,32 @@
    - Confirm `git status` is clean and the repository builds in both modes before finishing.
 
 Each bullet above is intended to correspond to a single reasonable commit (or, where explicitly split, multiple small commits) so that none of the steps exceeds the size constraints imposed by the tooling.
+
+## Step 2 Progress: Diff Inventory
+
+### Approach
+- Ran `git diff 1c50485c9a1b3c0595c143432664ab55e59e7991 --name-status` and aggregated the results by the top-level path component.
+- Counted modification types (added vs. modified) to identify which areas are brand new versus edits to upstream files.
+- Captured the summary below to use as the working checklist; this table will be updated as directories are migrated or restored in later steps.
+
+### Top-level change summary
+| Path / File | Total paths | Modified | Added | Deleted | Notes |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `sysdeps/` | 1,582 | 0 | 1,582 | 0 | Completely new directory full of generated or third-party sources that must stay under `preconfigured/`.
+| `preconfigured/` | 134 | 0 | 134 | 0 | Newly added helper tree; plan to keep under `preconfigured/` and audit contents in later commits.
+| `src/` | 44 | 44 | 0 | 0 | Upstream sources modified in place; these need pristine copies restored.
+| `include/` | 43 | 43 | 0 | 0 | Upstream headers modified in place; also need pristine copies restored.
+| `pipdeps/` | 8 | 0 | 8 | 0 | New Python dependency lockfiles; candidates for `preconfigured/`.
+| `libsel4/` | 4 | 4 | 0 | 0 | Library sources modified in place; will receive pristine copies later.
+| `tools/` | 3 | 0 | 3 | 0 | Small set of helper scripts newly added for the preconfigured layout.
+| `.gitignore` | 1 | 1 | 0 | 0 | Root metadata changed; revisit once pristine tree is in place.
+| `.python-version` | 1 | 0 | 1 | 0 | New pyenv pin introduced for tooling.
+| `PLAN.md` | 1 | 0 | 1 | 0 | Planning document introduced in this branch.
+| `PRISTINE-AND-PRECONFIGURED-PLAN.md` | 1 | 0 | 1 | 0 | Current planning document (being updated in this step).
+| `README.md` | 1 | 1 | 0 | 0 | Root README modified; needs reconciliation after directories are split.
+| `preconfigured_build.log` | 1 | 0 | 1 | 0 | Generated build log; should live under `preconfigured/`.
+| `replay_preconfigured_build.sh` | 1 | 0 | 1 | 0 | Helper script for replaying the build; belongs in `preconfigured/`.
+
+### Next actions
+- Use this checklist to drive the upcoming commits that introduce `pristine/` and move preconfigured assets out of the root tree.
+- Update the "Total paths" counts and notes as directories are migrated or cleaned in subsequent steps.


### PR DESCRIPTION
## Summary
- add a Step 2 progress section to PRISTINE-AND-PRECONFIGURED-PLAN.md capturing the top-level diff inventory counts

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d273881564832b82f088fbda247097