### PR TITLE
Add pristine skeleton with baseline configs

### DIFF
--- a/PRISTINE-AND-PRECONFIGURED-PLAN.md
+++ b/PRISTINE-AND-PRECONFIGURED-PLAN.md
@@ -48,21 +48,28 @@ Each bullet above is intended to correspond to a single reasonable commit (or, w
 ### Top-level change summary
 | Path / File | Total paths | Modified | Added | Deleted | Notes |
 | --- | ---: | ---: | ---: | ---: | --- |
-| `sysdeps/` | 1,582 | 0 | 1,582 | 0 | Completely new directory full of generated or third-party sources that must stay under `preconfigured/`.
-| `preconfigured/` | 134 | 0 | 134 | 0 | Newly added helper tree; plan to keep under `preconfigured/` and audit contents in later commits.
-| `src/` | 44 | 44 | 0 | 0 | Upstream sources modified in place; these need pristine copies restored.
-| `include/` | 43 | 43 | 0 | 0 | Upstream headers modified in place; also need pristine copies restored.
-| `pipdeps/` | 8 | 0 | 8 | 0 | New Python dependency lockfiles; candidates for `preconfigured/`.
-| `libsel4/` | 4 | 4 | 0 | 0 | Library sources modified in place; will receive pristine copies later.
-| `tools/` | 3 | 0 | 3 | 0 | Small set of helper scripts newly added for the preconfigured layout.
-| `.gitignore` | 1 | 1 | 0 | 0 | Root metadata changed; revisit once pristine tree is in place.
-| `.python-version` | 1 | 0 | 1 | 0 | New pyenv pin introduced for tooling.
-| `PLAN.md` | 1 | 0 | 1 | 0 | Planning document introduced in this branch.
-| `PRISTINE-AND-PRECONFIGURED-PLAN.md` | 1 | 0 | 1 | 0 | Current planning document (being updated in this step).
-| `README.md` | 1 | 1 | 0 | 0 | Root README modified; needs reconciliation after directories are split.
-| `preconfigured_build.log` | 1 | 0 | 1 | 0 | Generated build log; should live under `preconfigured/`.
-| `replay_preconfigured_build.sh` | 1 | 0 | 1 | 0 | Helper script for replaying the build; belongs in `preconfigured/`.
+| `sysdeps/` | 1,582 | 0 | 1,582 | 0 | Completely new directory full of generated or third-party sources that must stay under `preconfigured/`. |
+| `preconfigured/` | 134 | 0 | 134 | 0 | Newly added helper tree; plan to keep under `preconfigured/` and audit contents in later commits. |
+| `pristine/` | 38 | 0 | 38 | 0 | New directory added in Step 3 containing baseline build configuration files (`CMakeLists.txt`, `config.cmake`, and `configs/`). |
+| `src/` | 44 | 44 | 0 | 0 | Upstream sources modified in place; these need pristine copies restored. |
+| `include/` | 43 | 43 | 0 | 0 | Upstream headers modified in place; also need pristine copies restored. |
+| `pipdeps/` | 8 | 0 | 8 | 0 | New Python dependency lockfiles; candidates for `preconfigured/`. |
+| `libsel4/` | 4 | 4 | 0 | 0 | Library sources modified in place; will receive pristine copies later. |
+| `tools/` | 3 | 0 | 3 | 0 | Small set of helper scripts newly added for the preconfigured layout. |
+| `.gitignore` | 1 | 1 | 0 | 0 | Root metadata changed; revisit once pristine tree is in place. |
+| `.python-version` | 1 | 0 | 1 | 0 | New pyenv pin introduced for tooling. |
+| `PLAN.md` | 1 | 0 | 1 | 0 | Planning document introduced in this branch. |
+| `PRISTINE-AND-PRECONFIGURED-PLAN.md` | 1 | 0 | 1 | 0 | Current planning document (being updated in this step). |
+| `README.md` | 1 | 1 | 0 | 0 | Root README modified; needs reconciliation after directories are split. |
+| `preconfigured_build.log` | 1 | 0 | 1 | 0 | Generated build log; should live under `preconfigured/`. |
+| `replay_preconfigured_build.sh` | 1 | 0 | 1 | 0 | Helper script for replaying the build; belongs in `preconfigured/`. |
+
+## Step 3 Progress: Introduce the `pristine/` skeleton
+- Created the new `pristine/` directory with a README explaining that it mirrors upstream commit `1c50485c9a1b3c0595c143432664ab55e59e7991`.
+- Imported the baseline `CMakeLists.txt`, `config.cmake`, and the entire `configs/` tree into `pristine/` directly from the reference commit, giving us an untouched configuration snapshot for future comparisons.
+- Counted 38 files now living under `pristine/`, and recorded the directory in the change summary table above to keep the progress tracker in sync.
 
 ### Next actions
-- Use this checklist to drive the upcoming commits that introduce `pristine/` and move preconfigured assets out of the root tree.
-- Update the "Total paths" counts and notes as directories are migrated or cleaned in subsequent steps.
+- Continue Step 4 by restoring the upstream `include/`, `libsel4/`, and `src/` trees under `pristine/` in focused commits.
+- Audit remaining root-level assets so that generated or convenience files ultimately reside under `preconfigured/`.
+- Keep updating the table counts and notes as additional directories move into `pristine/` or `preconfigured/`.

--- a/pristine/CMakeLists.txt
+++ b/pristine/CMakeLists.txt
@@ -1,0 +1,787 @@
+#
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+cmake_minimum_required(VERSION 3.16.0)
+include(CheckCCompilerFlag)
+
+include(${CMAKE_CURRENT_LIST_DIR}/configs/seL4Config.cmake)
+project(seL4 C ASM)
+
+# First find our helpers
+find_file(KERNEL_HELPERS_PATH helpers.cmake PATHS tools CMAKE_FIND_ROOT_PATH_BOTH)
+mark_as_advanced(FORCE KERNEL_HELPERS_PATH)
+include(${KERNEL_HELPERS_PATH})
+
+function(RequireTool config file)
+    RequireFile("${config}" "${file}" PATHS tools)
+endfunction(RequireTool)
+
+RequireTool(KERNEL_FLAGS_PATH flags.cmake)
+
+if(CCACHEFOUND)
+    set(ccache "ccache")
+endif()
+
+include(tools/internal.cmake)
+
+# Define tools used by the kernel
+set(PYTHON3 "python3" CACHE INTERNAL "")
+RequireTool(CPP_GEN_PATH cpp_gen.sh)
+RequireTool(CIRCULAR_INCLUDES circular_includes.py)
+RequireTool(CONFIG_GEN_PATH config_gen.py)
+RequireTool(BF_GEN_PATH bitfield_gen.py)
+RequireTool(HARDWARE_GEN_PATH hardware_gen.py)
+RequireTool(INVOCATION_ID_GEN_PATH invocation_header_gen.py)
+RequireTool(INVOCATION_JSON_GEN_PATH invocation_json_gen.py)
+RequireTool(SYSCALL_ID_GEN_PATH syscall_header_gen.py)
+RequireTool(XMLLINT_PATH xmllint.sh)
+
+# Process the configuration scripts
+include(config.cmake)
+
+# Define default global flag information so that users can compile with the same
+# basic architecture flags as the kernel
+
+string(APPEND common_flags " -D__KERNEL_${KernelWordSize}__")
+
+if(KernelArchX86)
+    if(${KernelX86MicroArch} STREQUAL "generic")
+        string(APPEND common_flags " -mtune=generic")
+    else()
+        string(APPEND common_flags " -march=${KernelX86MicroArch}")
+    endif()
+
+    if(KernelSel4ArchX86_64)
+        string(APPEND common_exe_flags " -Wl,-m,elf_x86_64")
+    elseif(KernelSel4ArchIA32)
+        string(APPEND common_exe_flags " -Wl,-m,elf_i386")
+    else()
+        message(FATAL_ERROR "unknown x86 KernelSel4Arch '${KernelSel4Arch}'")
+    endif()
+
+    string(APPEND c_common_flags " -m${KernelWordSize}")
+
+    if(LLVM_TOOLCHAIN)
+        if(KernelSel4ArchIA32)
+            string(APPEND asm_common_flags " -m32")
+        endif()
+    else() # default is GCC toolchain
+        string(APPEND asm_common_flags " -Wa,--${KernelWordSize}")
+    endif()
+
+elseif(KernelArchARM)
+    set(arm_march "${KernelArmArmV}${KernelArmMachFeatureModifiers}")
+    string(APPEND c_common_flags " -march=${arm_march}")
+    string(APPEND asm_common_flags " -march=${arm_march}")
+
+    if(KernelSel4ArchAarch64)
+        # nothing special
+    elseif(KernelSel4ArchAarch32)
+        # Explicitly request ARM instead of THUMB for compilation.
+        string(APPEND c_common_flags " -marm")
+    else()
+        message(FATAL_ERROR "unknown ARM KernelSel4Arch '${KernelSel4Arch}'")
+    endif()
+
+elseif(KernelArchRiscV)
+    # The "RISC-V Instruction Set Manual, Volume I: RISC-V User-Level ISA",
+    # chapter "ISA Extension Naming Conventions" describes the march string. Its
+    # form is roughly "rv(32|64)((im?a?f?d?)|g)q?c?b?...", where 'g' equals
+    # 'mafd_Zicsr_Zifencei'. Underscores are allowed as extension separator and
+    # even required between for all Z-extensions.
+
+    if(KernelSel4ArchRiscV32)
+        set(_riscv_march "rv32i") # Currently we don't support "rv32e"
+        set(_riscv_mabi "ilp32")
+    elseif(KernelSel4ArchRiscV64)
+        set(_riscv_march "rv64i")
+        set(_riscv_mabi "lp64")
+    else()
+        message(FATAL_ERROR "unknown RISC-V KernelSel4Arch '${KernelSel4Arch}'")
+    endif()
+
+    # Currently there are no KernelRiscvExtM or KernelRiscvExtA, thus the
+    # M-extension and A-extension are always enabled.
+    string(APPEND _riscv_march "ma")
+
+    # FPU support. The Q-extension implies the D-extension, which implies the
+    # F-extension, which implies the "Zicsr"-extension. Currently there is no
+    # KernelRiscvExtQ yet.
+    if(KernelRiscvExtD)
+        # Since the D-extension implies F-extension, specifying "d" would be
+        # sufficient. But it's common practice to say "fd"
+        string(APPEND _riscv_march "fd")
+        # Pass floating-point values up to 64 bits in F registers
+        string(APPEND _riscv_mabi "d")
+    elseif(KernelRiscvExtF)
+        string(APPEND _riscv_march "f")
+        # Pass floating-point values up to 32 bits in F registers
+        string(APPEND _riscv_mabi "f")
+    endif()
+
+    # Currently there is no KernelRiscvExtC and thus the C-extension is always
+    # enabled
+    string(APPEND _riscv_march "c")
+
+    # Determine if GNU toolchain is used and if yes, whether GCC version >= 11.3 (implies binutils version >= 2.38)
+    if(
+        CMAKE_ASM_COMPILER_ID STREQUAL "GNU"
+        AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "11.3"
+    )
+        # Manually enable Zicsr and Zifencei extensions
+        # This became necessary due to a change in the default ISA version in GNU binutils 2.38 which is the
+        # default binutils version shipped with GCC 11.3
+        string(APPEND _riscv_march "_zicsr_zifencei")
+    endif()
+
+    string(APPEND common_flags " -march=${_riscv_march} -mabi=${_riscv_mabi}")
+
+else()
+    message(FATAL_ERROR "unknown KernelArch '${KernelArch}'")
+endif()
+
+set(
+    BASE_ASM_FLAGS "${asm_common_flags} ${common_flags}"
+    CACHE INTERNAL "Default ASM flags for compilation \
+    (subset of flags used by the kernel build)"
+)
+
+set(
+    BASE_C_FLAGS "${c_common_flags} ${common_flags}"
+    CACHE INTERNAL "Default C flags for compilation \
+    (subset of flags used by the kernel)"
+)
+
+set(
+    BASE_CXX_FLAGS "${cxx_common_flags} ${c_common_flags} ${common_flags}"
+    CACHE INTERNAL "Default CXX flags for compilation"
+)
+
+set(
+    BASE_EXE_LINKER_FLAGS "${common_flags} ${common_exe_flags} "
+    CACHE INTERNAL "Default flags for linker an elf binary application"
+)
+
+# Setup kernel specific flags. Initialize all flags them from the same base
+# flags that the users will use. The kernel is a stand-alone application with a
+# custom implementation of the standard libraries.
+include(${KERNEL_FLAGS_PATH})
+
+add_compile_options(
+    -std=c99
+    #-----------------------------------
+    # Configure warnings
+    #-----------------------------------
+    -Wall
+    -Werror
+    -Wstrict-prototypes
+    -Wmissing-prototypes
+    -Wnested-externs
+    -Wmissing-declarations
+    -Wundef
+    -Wpointer-arith
+    -Wno-nonnull
+    #-----------------------------------
+    # Configure compiler settings.
+    #-----------------------------------
+    -nostdinc # Do not use any system include paths, only use those given
+              # explicitly by the "-I <path>" parameters.
+    -ffreestanding # implies "-fno-builtin". Execution will not start at main().
+                   # No assumptions about the meaning of function names from the
+                   # standard library are made, except for memcpy(), memmove(),
+                   # memset() and memcmp(). __builtin_trap() will call abort().
+    -fno-stack-protector
+    -fno-asynchronous-unwind-tables
+    # GCC < 10 and clang < 11 put uninitialized global variables into a 'COMMON'
+    # section unless '-fno-common' is specified. The linker will put anything
+    # from 'COMMON' as the end of the '.bss' if nothing else is specified in the
+    # linker script. Besides making the variable placement look odd, this also
+    # tends to waste a page because we puts large aligned block at the end.
+    # Eventually, GCC 10 and clang 11 made '-fno-common' the default, see
+    # - https://gcc.gnu.org/gcc-10/changes.html
+    # - https://releases.llvm.org/11.0.0/tools/clang/docs/ReleaseNotes.html
+    -fno-common
+)
+
+# Linker parameters. There are two kinds actually:
+#   - flags processed by GCC when invoking it as linker wrapper
+#   - flags passed by GCC to the actual linker invocation ("-Wl,<flag>").
+string(
+    APPEND CMAKE_EXE_LINKER_FLAGS
+    # KernelCommonFlags adds "-nostdlib", it's the GCC linker step counterpart
+    # for "-ffreestanding" and makes GCC not use the standard system startup
+    # files or libraries. This also excludes GCC's helper library libgcc. Any
+    # libraries that are to be linked must be specified explicitly. Tests have
+    # shown that this parameter doesn't prevent GCC from adding paths from a
+    # "-L <path>" argument to the linker invocation for the standard libs, and
+    # there seems no option that prevents this apart from providing an entirely
+    # different specs file via -specs=<file>. Note that "-Wl,-nostdlib" is not
+    # used here, because it is not needed. It makes the linker use library
+    # directories specified on the command line only and ignore any SEARCH_DIR
+    # set in a linker script. We provide our own linker scripts, and these
+    # don't set SEARCH_DIR.
+    " -static" # Implies "-no-pie" (and overrides "-pie"). The ld 2.37 docs say
+               # "-no-pie" is a linker option, but passing "-Wl,-no-pie" fails.
+    " -Wl,--build-id=none" # Ensure reproducible builds
+    " -Wl,-n" # Disable page alignment of sections
+)
+
+# Setup kernel specific flags used for both the compilation and linking step
+macro(KernelCommonFlags)
+    foreach(common_flag IN ITEMS ${ARGV})
+        add_compile_options(${common_flag})
+        string(APPEND CMAKE_EXE_LINKER_FLAGS " ${common_flag} ")
+    endforeach()
+endmacro(KernelCommonFlags)
+
+KernelCommonFlags(
+    ${KernelOptimisation}
+    # The following options are gcc options, it is unclear if ld options are
+    # generated automatically when gcc wraps the linking step and invokes ld.
+    -nostdlib -fno-pic -fno-pie
+)
+
+# Disable cloned functions. This is needed for binary verification at -O2.
+if(NOT KernelOptimisationCloneFunctions AND (CMAKE_C_COMPILER_ID STREQUAL "GNU"))
+    KernelCommonFlags(-fno-partial-inlining -fno-ipa-cp -fno-ipa-sra)
+endif()
+
+if(KernelFWholeProgram)
+    # KernelFWholeProgram is still an experimental feature and disabled by
+    # default. Clarify if the linker step via GCC actually cares about this
+    # parameter. There are also the options -flto and -fuse-linker-plugin that
+    # might be a more modern approach.
+    KernelCommonFlags(-fwhole-program)
+endif()
+
+if(KernelDebugBuild)
+    KernelCommonFlags(-DDEBUG -g -ggdb)
+    # Pretend to CMake that we're a release build with debug info. This is because
+    # we do actually allow CMake to do the final link step, so we'd like it not to
+    # strip our binary
+    set(CMAKE_BUILD_TYPE "RelWithDebInfo")
+else()
+    set(CMAKE_BUILD_TYPE "Release")
+endif()
+
+if(KernelArchX86)
+    if(KernelSel4ArchX86_64)
+        KernelCommonFlags(-mcmodel=kernel)
+    elseif(KernelSel4ArchIA32)
+        # nothing special
+    else()
+        message(FATAL_ERROR "unknown x86 KernelSel4Arch '${KernelSel4Arch}'")
+    endif()
+    add_compile_options(-mno-mmx -mno-sse -mno-sse2 -mno-3dnow)
+
+elseif(KernelArchARM)
+    if(KernelSel4ArchAarch64)
+        KernelCommonFlags(-mgeneral-regs-only)
+        if(
+            ((CMAKE_C_COMPILER_ID STREQUAL "GNU")
+             AND (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "10.0.0")
+             )
+            OR
+                ((CMAKE_C_COMPILER_ID STREQUAL "Clang")
+                 AND (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "12.0.0")
+                 )
+        )
+            add_compile_options(-mno-outline-atomics)
+        endif()
+    elseif(KernelSel4ArchAarch32)
+        KernelCommonFlags(-mfloat-abi=soft)
+    else()
+        message(FATAL_ERROR "unknown ARM KernelSel4Arch '${KernelSel4Arch}'")
+    endif()
+
+elseif(KernelArchRiscV)
+    # Group "small" data objects together in a small-data section so they can
+    # be referenced using gp-relative addressing.  The exact value of
+    # small-data-limit is not crucial but it should be lowered if .small
+    # exceeds 4KiB.
+    #
+    KernelCommonFlags(-mcmodel=medany -msmall-data-limit=1024)
+
+else()
+    message(FATAL_ERROR "unknown KernelArch '${KernelArch}'")
+endif()
+
+if(
+    (CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    AND (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "20.0.0")
+)
+    # To avoid clang: error: argument unused during compilation: '-c'
+    add_compile_options(-Wno-unused-command-line-argument)
+endif()
+
+# Sort the C sources to ensure a stable layout of the final C file
+list(SORT c_sources)
+# Add the domain schedule now that its sorted
+list(APPEND c_sources "${KernelDomainSchedule}")
+
+# Add static header includes
+include_directories(
+    "include"
+    "include/${KernelWordSize}"
+    "include/arch/${KernelArch}"
+    "include/arch/${KernelArch}/arch/${KernelWordSize}"
+    "include/plat/${KernelPlatform}"
+    "include/plat/${KernelPlatform}/plat/${KernelWordSize}"
+)
+
+if(KernelArchARM)
+    include_directories(
+        "include/arch/arm/armv/${KernelArmArmV}"
+        "include/arch/arm/armv/${KernelArmArmV}/${KernelWordSize}"
+    )
+endif()
+
+if(KernelArmMach STREQUAL "exynos")
+    include_directories("include/plat/exynos_common/")
+endif()
+
+# Add libsel4 include directories. These are explicitly added instead of calling
+# target_link_libraries(${target} sel4) because we don't want to inherit any
+# other build options from libsel4.
+include_directories(
+    "libsel4/include"
+    "libsel4/arch_include/${KernelArch}"
+    "libsel4/sel4_arch_include/${KernelSel4Arch}"
+    "libsel4/sel4_plat_include/${KernelPlatform}"
+    "libsel4/mode_include/${KernelWordSize}"
+)
+
+#
+# Config generation
+#
+
+include_directories($<TARGET_PROPERTY:kernel_Config,INTERFACE_INCLUDE_DIRECTORIES>)
+# The kernel expects to be able to include an 'autoconf.h' file at the moment.
+# So lets generate one for it to use
+# TODO: use the kernel_Config directly
+generate_autoconf(kernel_autoconf "kernel")
+include_directories($<TARGET_PROPERTY:kernel_autoconf,INTERFACE_INCLUDE_DIRECTORIES>)
+
+# Target for the config / autoconf headers. This is what all the other generated headers
+# can depend upon
+add_custom_target(
+    kernel_config_headers
+    DEPENDS
+        kernel_autoconf_Gen
+        kernel_autoconf
+        kernel_Config
+        kernel_Gen
+)
+
+# Target for all generated headers. We start with just all the config / autoconf headers
+add_custom_target(kernel_headers DEPENDS kernel_config_headers)
+
+# Build up a list of generated files. needed for dependencies in custom commands
+get_generated_files(gen_files_list kernel_autoconf_Gen)
+get_generated_files(gen_files2 kernel_Gen)
+list(APPEND gen_files_list "${gen_files2}")
+
+#
+# C source generation
+#
+
+# Kernel compiles all C sources as a single C file, this provides
+# rules for doing the concatenation
+
+add_custom_command(
+    OUTPUT kernel_all.c
+    COMMAND
+        "${CPP_GEN_PATH}" ${c_sources} > kernel_all.c
+    DEPENDS "${CPP_GEN_PATH}" ${c_sources}
+    COMMENT "Concatenating C files"
+    VERBATIM
+)
+
+add_custom_target(kernel_all_c_wrapper DEPENDS kernel_all.c)
+
+#
+# Header Generation
+#
+
+# Rules for generating invocation and syscall headers
+# Aside from generating file rules for dependencies this section will also produce a target
+# that can be depended upon (along with the desired files themselves) to control parallelism
+
+set(xml_headers "")
+set(header_dest "gen_headers/arch/api/invocation.h")
+gen_invocation_header(
+    OUTPUT ${header_dest}
+    XML
+        ${CMAKE_CURRENT_SOURCE_DIR}/libsel4/arch_include/${KernelArch}/interfaces/object-api-arch.xml
+    ARCH
+)
+list(APPEND xml_headers "${header_dest}")
+list(APPEND gen_files_list "${header_dest}")
+
+set(header_dest "gen_headers/arch/api/sel4_invocation.h")
+gen_invocation_header(
+    OUTPUT "${header_dest}"
+    XML
+        "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/sel4_arch_include/${KernelSel4Arch}/interfaces/object-api-sel4-arch.xml"
+    SEL4ARCH
+)
+list(APPEND xml_headers "${header_dest}")
+list(APPEND gen_files_list "${header_dest}")
+
+set(header_dest "gen_headers/api/invocation.h")
+gen_invocation_header(
+    OUTPUT "${header_dest}"
+    XML "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/include/interfaces/object-api.xml"
+)
+list(APPEND xml_headers "${header_dest}")
+list(APPEND gen_files_list "${header_dest}")
+
+get_absolute_source_or_binary(
+    invocations_absolute "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/include/interfaces/object-api.xml"
+)
+get_absolute_source_or_binary(
+    arch_invocations_absolute
+    "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/arch_include/${KernelArch}/interfaces/object-api-arch.xml"
+)
+get_absolute_source_or_binary(
+    sel4_arch_invocations_absolute
+    "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/sel4_arch_include/${KernelSel4Arch}/interfaces/object-api-sel4-arch.xml"
+)
+
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/generated/invocations_all.json
+    COMMAND rm -f ${CMAKE_CURRENT_BINARY_DIR}/generated/invocations_all.json
+    COMMAND
+        "${PYTHON3}" "${INVOCATION_JSON_GEN_PATH}"
+        --gen_config ${CMAKE_CURRENT_BINARY_DIR}/gen_config/kernel/gen_config.json
+        --invocations "${invocations_absolute}"
+        --arch_invocations "${arch_invocations_absolute}"
+        --sel4_arch_invocations "${sel4_arch_invocations_absolute}"
+        --dest ${CMAKE_CURRENT_BINARY_DIR}/generated/invocations_all.json
+    DEPENDS
+        "${CMAKE_CURRENT_BINARY_DIR}/gen_config/kernel/gen_config.json"
+        "${INVOCATION_JSON_GEN_PATH}"
+        "${invocations_absolute}"
+        "${arch_invocations_absolute}"
+        "${sel4_arch_invocations_absolute}"
+)
+list(APPEND gen_files_list "generated/invocations_all.json")
+
+set(syscall_xml_base "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/include/api")
+set(syscall_dest "gen_headers/arch/api/syscall.h")
+if(KernelIsMCS)
+    set(mcs --mcs)
+endif()
+add_custom_command(
+    OUTPUT ${syscall_dest}
+    COMMAND
+        "${XMLLINT_PATH}"
+        --noout
+        --schema "${syscall_xml_base}/syscall.xsd" "${syscall_xml_base}/syscall.xml"
+    COMMAND
+        ${CMAKE_COMMAND} -E remove -f "${syscall_dest}"
+    COMMAND
+        ${PYTHON3} "${SYSCALL_ID_GEN_PATH}"
+        --xml "${syscall_xml_base}/syscall.xml"
+        --kernel_header "${syscall_dest}" ${mcs}
+    DEPENDS
+        "${XMLLINT_PATH}"
+        "${SYSCALL_ID_GEN_PATH}"
+        "${syscall_xml_base}/syscall.xsd"
+        "${syscall_xml_base}/syscall.xml"
+    COMMENT "Generate syscall invocations"
+    VERBATIM
+)
+list(APPEND xml_headers "${syscall_dest}")
+list(APPEND gen_files_list "${syscall_dest}")
+# Construct target for just the xml headers
+add_custom_target(xml_headers_target DEPENDS ${xml_headers})
+# Add the xml headers to all the kernel headers
+add_dependencies(kernel_headers xml_headers_target)
+include_directories("${CMAKE_CURRENT_BINARY_DIR}/gen_headers")
+
+#
+# Prune list generation
+#
+
+# When generating bitfield files we can pass multiple '--prune' parameters that are source
+# files that get searched for determing which bitfield functions are used. This allows the
+# bitfield generator to only generate functions that are used. Whilst irrelevant for
+# normal compilation, not generating unused functions has significant time savings for the
+# automated verification tools
+
+# To generate a prune file we 'build' the kernel (similar to the kernel_all_pp.c rule
+# below) but strictly WITHOUT the generated header directory where the bitfield generated
+# headers are. This means our preprocessed file will contain all the code used by the
+# normal compilation, just without the bitfield headers (which we generate dummy versions of).
+# If we allowed the bitfield headers to be included then we would have a circular
+# dependency. As a result this rule comes *before* the Bitfield header generation section
+
+set(dummy_headers "")
+foreach(bf_dec ${bf_declarations})
+    string(
+        REPLACE
+            ":"
+            ";"
+            bf_dec
+            ${bf_dec}
+    )
+    list(GET bf_dec 0 bf_file)
+    list(GET bf_dec 1 bf_gen_dir)
+    get_filename_component(bf_name "${bf_file}" NAME)
+    string(
+        REPLACE
+            ".bf"
+            "_gen.h"
+            bf_target
+            "${bf_name}"
+    )
+    list(
+        APPEND
+            dummy_headers "${CMAKE_CURRENT_BINARY_DIR}/generated_prune/${bf_gen_dir}/${bf_target}"
+    )
+endforeach()
+
+add_custom_command(
+    OUTPUT ${dummy_headers}
+    COMMAND
+        ${CMAKE_COMMAND} -E touch ${dummy_headers}
+    COMMENT "Generate dummy headers for prune compilation"
+)
+
+add_custom_target(dummy_header_wrapper DEPENDS ${dummy_headers})
+
+cppfile(
+    kernel_all_pp_prune.c kernel_all_pp_prune_wrapper kernel_all.c
+    EXTRA_FLAGS -CC "-I${CMAKE_CURRENT_BINARY_DIR}/generated_prune"
+    EXTRA_DEPS
+        kernel_all_c_wrapper
+        dummy_header_wrapper
+        xml_headers_target
+        kernel_config_headers
+        ${gen_files_list}
+)
+
+#
+# Bitfield header generation
+#
+
+# Need to generate a bunch of unique targets, we'll do this with piano numbers
+set(bf_gen_target "kernel_bf_gen_target_1")
+
+foreach(bf_dec ${bf_declarations})
+    string(
+        REPLACE
+            ":"
+            ";"
+            bf_dec
+            ${bf_dec}
+    )
+    list(GET bf_dec 0 bf_file)
+    list(GET bf_dec 1 bf_gen_dir)
+    get_filename_component(bf_name "${bf_file}" NAME)
+    string(
+        REPLACE
+            ".bf"
+            "_gen.h"
+            bf_target
+            "${bf_name}"
+    )
+    string(
+        REPLACE
+            ".bf"
+            "_defs.thy"
+            defs_target
+            "${bf_name}"
+    )
+    string(
+        REPLACE
+            ".bf"
+            "_proofs.thy"
+            proofs_target
+            "${bf_name}"
+    )
+    set(pbf_name "generated/${bf_gen_dir}/${bf_name}.pbf")
+    set(pbf_target "${bf_gen_target}_pbf")
+    cppfile(
+        "${pbf_name}" "${pbf_target}" "${bf_file}"
+        EXTRA_FLAGS -P
+        EXTRA_DEPS kernel_config_headers ${gen_files_list}
+    )
+    GenHBFTarget(
+        ""
+        ${bf_gen_target}
+        "generated/${bf_gen_dir}/${bf_target}"
+        "${pbf_name}"
+        "${pbf_target}"
+        "kernel_all_pp_prune.c"
+        "kernel_all_pp_prune_wrapper"
+        "${bf_file}"
+    )
+    GenDefsBFTarget(
+        "${bf_gen_target}_def"
+        "generated/${bf_gen_dir}/${defs_target}"
+        "${pbf_name}"
+        "${pbf_target}"
+        "kernel_all_pp_prune.c"
+        "kernel_all_pp_prune_wrapper"
+    )
+    GenProofsBFTarget(
+        "${bf_gen_target}_proof"
+        "generated/${bf_gen_dir}/${proofs_target}"
+        "${pbf_name}"
+        "${pbf_target}"
+        "kernel_all_pp_prune.c"
+        "kernel_all_pp_prune_wrapper"
+    )
+    list(
+        APPEND
+            theories_deps
+            "${bf_gen_target}_def"
+            "${CMAKE_CURRENT_BINARY_DIR}/generated/${bf_gen_dir}/${defs_target}"
+            "${bf_gen_target}_proof"
+            "${CMAKE_CURRENT_BINARY_DIR}/generated/${bf_gen_dir}/${proofs_target}"
+    )
+    add_dependencies(kernel_headers "${bf_gen_target}")
+    list(APPEND gen_files_list "${CMAKE_CURRENT_BINARY_DIR}/generated/${bf_gen_dir}/${bf_target}")
+    set(bf_gen_target "${bf_gen_target}1")
+endforeach()
+# At this point we have generated a bunch of headers into ${CMAKE_CURRENT_BINARY_DIR}/generated
+# but we do not pass this to include_directories, as that will cause it to be an include directory
+# for *all* targets in this file (including ones we defined earlier) and the prune generation
+# *must not* see this files and generate dependencies on them as this will result in nonsense.
+# As such we must manually add this as an include directory to future targets
+set(CPPExtraFlags "-I${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+#
+# Kernel compilation
+#
+
+cppfile(
+    kernel_all.i kernel_i_wrapper kernel_all.c
+    EXTRA_DEPS kernel_all_c_wrapper kernel_headers ${gen_files_list}
+    EXTRA_FLAGS
+        -CC "${CPPExtraFlags}"
+        # The circular_includes script relies upon parsing out exactly 'kernel_all_copy.c' as
+        # a special case so we must ask cppfile to use this input name
+    EXACT_NAME kernel_all_copy.c
+)
+
+# Explain to cmake that our object file is actually a C input file
+set_property(SOURCE kernel_all.i PROPERTY LANGUAGE C)
+
+if(KernelArchARM)
+    set(linker_source "src/arch/arm/common_arm.lds")
+elseif(KernelArchRiscV)
+    set(linker_source "src/arch/riscv/common_riscv.lds")
+else()
+    set(linker_source "src/plat/${KernelPlatform}/linker.lds")
+endif()
+set(linker_lds_path "${CMAKE_CURRENT_BINARY_DIR}/linker.lds_pp")
+
+# Preprocess the linker script
+cppfile(
+    "${linker_lds_path}" linker_ld_wrapper "${linker_source}"
+    EXTRA_DEPS kernel_headers ${gen_files_list}
+    EXTRA_FLAGS -CC -P "${CPPExtraFlags}"
+)
+
+add_custom_command(
+    OUTPUT circular_includes_valid
+    COMMAND ${PYTHON3} ${CIRCULAR_INCLUDES} --ignore kernel_all_copy.c < kernel_all.i
+    COMMAND touch circular_includes_valid
+    DEPENDS kernel_i_wrapper kernel_all.i
+)
+
+add_custom_target(circular_includes DEPENDS circular_includes_valid)
+
+add_custom_command(
+    OUTPUT kernel_all_pp.c
+    COMMAND
+        ${CMAKE_COMMAND} -E copy kernel_all.i kernel_all_pp.c
+    DEPENDS kernel_i_wrapper kernel_all.i
+)
+add_custom_target(kernel_all_pp_wrapper DEPENDS kernel_all_pp.c)
+
+add_custom_target(kernel_theories DEPENDS ${theories_deps})
+
+# Declare final kernel output
+add_executable(kernel.elf EXCLUDE_FROM_ALL ${asm_sources} kernel_all.c)
+target_include_directories(kernel.elf PRIVATE ${config_dir})
+target_include_directories(kernel.elf PRIVATE include)
+target_include_directories(kernel.elf PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/generated")
+target_link_libraries(kernel.elf PRIVATE kernel_Config kernel_autoconf)
+set_property(TARGET kernel.elf APPEND_STRING PROPERTY LINK_FLAGS " -Wl,-T ${linker_lds_path} ")
+set_target_properties(kernel.elf PROPERTIES LINK_DEPENDS "${linker_lds_path}")
+add_dependencies(kernel.elf circular_includes)
+
+# The following commands setup the install target for copying generated files and
+# compilation outputs to an install location: CMAKE_INSTALL_PREFIX.
+# CMAKE_INSTALL_PREFIX can be set on the cmake command line.
+#
+# The current installation outputs are:
+# - ${CMAKE_INSTALL_PREFIX}/bin/kernel.elf: Location of kernel.elf binary
+# - ${CMAKE_INSTALL_PREFIX}/libsel4/include: The include root for libsel4
+# - ${CMAKE_INSTALL_PREFIX}/libsel4/src: The c source files for the libsel4 library
+#
+# The install target is only created if this is the top level project.
+# We don't currently support creating install targets if the kernel is
+# imported in another project.
+if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
+
+    # Import libsel4 to get access to generation targets
+    add_subdirectory(libsel4)
+    # Add a default target that builds kernel.elf and generates all libsel4 headers
+    add_custom_target(single-project ALL DEPENDS sel4_generated kernel.elf)
+    # Disable the libsel4.a target as we don't intend to build the libsel4 sources
+    set_target_properties(sel4 PROPERTIES EXCLUDE_FROM_ALL ON)
+    # Install kernel.elf to bin/kernel.elf
+    install(TARGETS kernel.elf RUNTIME DESTINATION bin)
+    # Install all libsel4 headers to libsel4/include
+    # If building for aarch32,hyp explicitly use aarch32 for sel4arch path
+    # otherwise the install command tries to install the arm_hyp symlink file
+    # instead of its realpath.
+    set(realpath_sel4arch "${KernelSel4Arch}")
+    if(KernelSel4ArchArmHyp)
+        set(realpath_sel4arch "aarch32")
+    endif()
+    install(
+        DIRECTORY
+            "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/include/"
+            "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/arch_include/${KernelArch}/"
+            "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/sel4_arch_include/${realpath_sel4arch}/"
+            "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/sel4_plat_include/${KernelPlatform}/"
+            "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/mode_include/${KernelWordSize}/"
+            "${CMAKE_CURRENT_BINARY_DIR}/libsel4/include/"
+            "${CMAKE_CURRENT_BINARY_DIR}/libsel4/arch_include/${KernelArch}/"
+            "${CMAKE_CURRENT_BINARY_DIR}/libsel4/sel4_arch_include/${realpath_sel4arch}/"
+            # The following directories install the autoconf headers
+            "${CMAKE_CURRENT_BINARY_DIR}/gen_config/"
+            "${CMAKE_CURRENT_BINARY_DIR}/libsel4/gen_config/"
+            "${CMAKE_CURRENT_BINARY_DIR}/libsel4/autoconf/"
+        DESTINATION libsel4/include
+        FILES_MATCHING
+        PATTERN "*.h"
+        PATTERN "*.pbf"
+        PATTERN "api/syscall.xml"
+        PATTERN "api/syscall.xsd"
+        PATTERN "object-api*.xml"
+        PATTERN "gen_config.json"
+    )
+    # Install libsel4 sources to libsel4/src
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/src/" DESTINATION libsel4/src)
+    # Install additional support files
+    if(DEFINED KernelDTBPath)
+        install(FILES ${KernelDTBPath} DESTINATION support)
+    endif()
+    if(DEFINED platform_yaml)
+        install(FILES ${platform_yaml} DESTINATION support)
+    endif()
+    if(DEFINED platform_json)
+        install(FILES ${platform_json} DESTINATION support)
+    endif()
+
+endif()

--- a/pristine/README.md
+++ b/pristine/README.md
@@ -1,0 +1,6 @@
+# Pristine tree
+
+This directory contains an untouched copy of the upstream seL4 sources taken
+from commit 1c50485c9a1b3c0595c143432664ab55e59e7991.  Files added here should
+mirror the original layout without local modifications.  The intent is to make
+it easy to compare our preconfigured build assets against the upstream state.

--- a/pristine/config.cmake
+++ b/pristine/config.cmake
@@ -1,0 +1,604 @@
+#
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+cmake_minimum_required(VERSION 3.16.0)
+
+config_option(
+    KernelIsMCS KERNEL_MCS "Use the MCS kernel configuration, which is not verified." DEFAULT OFF
+)
+
+# Error for unsupported MCS platforms
+if(KernelIsMCS AND (NOT KernelPlatformSupportsMCS))
+    message(
+        FATAL_ERROR "KernelIsMCS selected, but platform: ${KernelPlatform} does not support it."
+    )
+endif()
+
+# Proof based configuration variables
+set(CSPEC_DIR
+    "."
+    CACHE PATH ""
+)
+set(SKIP_MODIFIES
+    ON
+    CACHE BOOL ""
+)
+set(SORRY_BITFIELD_PROOFS
+    OFF
+    CACHE BOOL ""
+)
+find_file(UMM_TYPES umm_types.txt CMAKE_FIND_ROOT_PATH_BOTH)
+set(force FORCE)
+if(KernelVerificationBuild)
+    set(force CLEAR)
+endif()
+mark_as_advanced(${force} CSPEC_DIR SKIP_MODIFIES SORRY_BITFIELD_PROOFS UMM_TYPES)
+# Use a custom target for collecting information during generation that we need during build
+add_custom_target(kernel_config_target)
+# Put our common top level types in
+set_property(
+    TARGET kernel_config_target
+    APPEND
+    PROPERTY TOPLEVELTYPES
+             cte_C
+             tcb_C
+             endpoint_C
+             notification_C
+             asid_pool_C
+             pte_C
+             user_data_C
+             user_data_device_C
+)
+
+# These options are now set in seL4Config.cmake
+if(DEFINED CALLED_declare_default_headers)
+    # calculate the irq cnode size based on MAX_NUM_IRQ
+    if("${KernelArch}" STREQUAL "riscv")
+        math(EXPR MAX_NUM_IRQ "${CONFIGURE_MAX_IRQ} + 2")
+    else()
+        if(DEFINED KernelMaxNumNodes
+           AND CONFIGURE_NUM_PPI GREATER "0"
+           AND "${KernelArch}" STREQUAL "arm"
+        )
+            math(EXPR MAX_NUM_IRQ
+                 "(${KernelMaxNumNodes}-1)*${CONFIGURE_NUM_PPI} + ${CONFIGURE_MAX_IRQ}"
+            )
+        else()
+            set(MAX_NUM_IRQ "${CONFIGURE_MAX_IRQ}")
+        endif()
+    endif()
+    set(BITS "0")
+    while(MAX_NUM_IRQ GREATER "0")
+        math(EXPR BITS "${BITS} + 1")
+        math(EXPR MAX_NUM_IRQ "${MAX_NUM_IRQ} >> 1")
+    endwhile()
+    set(CONFIGURE_IRQ_SLOT_BITS
+        "${BITS}"
+        CACHE INTERNAL ""
+    )
+    if(NOT DEFINED CONFIGURE_TIMER_PRECISION)
+        set(CONFIGURE_TIMER_PRECISION "0")
+    endif()
+    if(NOT DEFINED CONFIGURE_TIMER_OVERHEAD_TICKS)
+        set(CONFIGURE_TIMER_OVERHEAD_TICKS "0")
+    endif()
+    configure_file(
+        src/arch/${KernelArch}/platform_gen.h.in
+        ${CMAKE_CURRENT_BINARY_DIR}/gen_headers/plat/platform_gen.h @ONLY
+    )
+    include_directories(include/plat/default)
+endif()
+
+# Set defaults for common variables
+set(KernelHaveFPU OFF)
+set(KernelSetTLSBaseSelf OFF)
+
+include(src/arch/${KernelArch}/config.cmake)
+include(include/${KernelWordSize}/mode/config.cmake)
+include(src/config.cmake)
+
+set(KernelCustomDTS
+    ""
+    CACHE FILEPATH "Provide a device tree file to use instead of the \
+KernelPlatform's defaults"
+)
+
+if(NOT "${KernelCustomDTS}" STREQUAL "")
+    if(NOT EXISTS ${KernelCustomDTS})
+        message(FATAL_ERROR "Can't open external dts file '${KernelCustomDTS}'!")
+    endif()
+    # Override list to hold only custom dts
+    set(KernelDTSList "${KernelCustomDTS}")
+    message(STATUS "Using custom ${KernelCustomDTS} device tree, ignoring default dts and overlays")
+endif()
+
+# Enshrine common variables in the config
+config_set(KernelHaveFPU HAVE_FPU "${KernelHaveFPU}")
+config_set(KernelPaddrUserTop PADDR_USER_DEVICE_TOP "${KernelPaddrUserTop}")
+
+# System parameters
+config_string(
+    KernelRootCNodeSizeBits
+    ROOT_CNODE_SIZE_BITS
+    "Root CNode Size (2^n slots) \
+    The acceptable range is 8-27 and 7-26, for 32-bit and 64-bit respectively. \
+    The root CNode needs at least enough space to contain seL4_NumInitialCaps \
+    plus enough room for all the Untyped Caps."
+    DEFAULT 12
+    UNQUOTE
+)
+
+config_string(
+    KernelTimerTickMS TIMER_TICK_MS "Timer tick period in milliseconds"
+    DEFAULT 2
+    UNQUOTE
+    DEPENDS "NOT KernelIsMCS"
+    UNDEF_DISABLED
+)
+config_string(
+    KernelTimeSlice TIME_SLICE "Number of timer ticks until a thread is preempted."
+    DEFAULT 5
+    UNQUOTE
+    DEPENDS "NOT KernelIsMCS"
+    UNDEF_DISABLED
+)
+config_string(
+    KernelBootThreadTimeSlice BOOT_THREAD_TIME_SLICE
+    "Number of milliseconds until the boot thread is preempted."
+    DEFAULT 5
+    UNQUOTE
+    DEPENDS "KernelIsMCS"
+    UNDEF_DISABLED
+)
+config_string(
+    KernelRetypeFanOutLimit RETYPE_FAN_OUT_LIMIT
+    "Maximum number of objects that can be created in a single Retype() invocation."
+    DEFAULT 256
+    UNQUOTE
+)
+config_string(
+    KernelMaxNumWorkUnitsPerPreemption MAX_NUM_WORK_UNITS_PER_PREEMPTION
+    "Maximum number of work units (delete/revoke iterations) until the kernel checks for\
+    pending interrupts (and preempts the currently running syscall if interrupts are pending)."
+    DEFAULT 100
+    UNQUOTE
+)
+config_string(
+    KernelResetChunkBits RESET_CHUNK_BITS
+    "Maximum size in bits of chunks of memory to zero before checking a preemption point."
+    DEFAULT 8
+    UNQUOTE
+)
+config_string(
+    KernelMaxNumBootinfoUntypedCaps MAX_NUM_BOOTINFO_UNTYPED_CAPS
+    "Max number of bootinfo untyped caps"
+    DEFAULT 230
+    UNQUOTE
+)
+config_option(KernelFastpath FASTPATH "Enable IPC fastpath" DEFAULT ON)
+
+config_option(
+    KernelExceptionFastpath EXCEPTION_FASTPATH "Enable exception fastpath"
+    DEFAULT OFF
+    DEPENDS "NOT KernelVerificationBuild; KernelSel4ArchAarch64"
+)
+
+config_string(
+    KernelNumDomains NUM_DOMAINS "The number of scheduler domains in the system"
+    DEFAULT 1
+    UNQUOTE
+)
+
+config_option(
+    KernelSignalFastpath SIGNAL_FASTPATH "Enable notification signal fastpath"
+    DEFAULT OFF
+    DEPENDS "KernelIsMCS; KernelFastpath; KernelSel4ArchAarch64; NOT KernelVerificationBuild"
+    DEFAULT_DISABLED OFF
+)
+
+find_file(
+    KernelDomainSchedule default_domain.c
+    PATHS src/config
+    CMAKE_FIND_ROOT_PATH_BOTH
+    DOC "A C file providing the symbols ksDomSchedule and ksDomScheduleLength \
+        to be linked with the kernel as a scheduling configuration."
+)
+if(SEL4_CONFIG_DEFAULT_ADVANCED)
+    mark_as_advanced(KernelDomainSchedule)
+endif()
+
+config_string(
+    KernelNumPriorities NUM_PRIORITIES "The number of priority levels per domain. Valid range 1-256"
+    DEFAULT 256
+    UNQUOTE
+)
+
+config_string(
+    KernelMaxNumNodes MAX_NUM_NODES "Max number of CPU cores to boot"
+    DEFAULT 1
+    DEPENDS "${KernelNumDomains} EQUAL 1"
+    UNQUOTE
+)
+
+# Set CONFIG_ENABLE_SMP_SUPPORT as an alias of CONFIG_MAX_NUM_NODES > 1
+if(KernelMaxNumNodes GREATER 1)
+    config_set(KernelEnableSMPSupport ENABLE_SMP_SUPPORT ON)
+else()
+    config_set(KernelEnableSMPSupport ENABLE_SMP_SUPPORT OFF)
+endif()
+
+config_string(
+    KernelStackBits
+    KERNEL_STACK_BITS
+    "This describes the log2 size of the kernel stack. Great care should be taken as\
+    there is no guard below the stack so setting this too small will cause random\
+    memory corruption"
+    DEFAULT 12
+    UNQUOTE
+)
+
+config_option(
+    KernelVerificationBuild
+    VERIFICATION_BUILD
+    "When enabled this configuration option prevents the usage of any other options that\
+    would compromise the verification story of the kernel. Enabling this option does NOT\
+    imply you are using a verified kernel."
+    DEFAULT ON
+)
+
+config_option(
+    KernelBinaryVerificationBuild
+    BINARY_VERIFICATION_BUILD
+    "When enabled, this configuration option restricts the use of other options that would \
+     interfere with binary verification. For example, it will disable some inter-procedural \
+     optimisations. Enabling this options does NOT imply that you are using a verified kernel."
+    DEFAULT OFF
+    DEPENDS "KernelVerificationBuild"
+)
+
+config_option(
+    KernelDebugBuild DEBUG_BUILD "Enable debug facilities (symbols and assertions) in the kernel"
+    DEFAULT ON
+    DEPENDS "NOT KernelVerificationBuild"
+    DEFAULT_DISABLED OFF
+)
+
+config_option(
+    HardwareDebugAPI
+    HARDWARE_DEBUG_API
+    "Builds the kernel with support for a userspace debug API, which can \
+    allows userspace processes to set breakpoints, watchpoints and to \
+    single-step through thread execution."
+    DEFAULT OFF
+    DEPENDS "NOT KernelVerificationBuild;NOT KernelHardwareDebugAPIUnsupported"
+)
+config_option(
+    KernelPrinting PRINTING
+    "Allow the kernel to print out messages to the serial console during bootup and execution."
+    DEFAULT "${KernelDebugBuild}"
+    DEPENDS "NOT KernelVerificationBuild"
+    DEFAULT_DISABLED OFF
+)
+
+config_option(
+    KernelInvocationReportErrorIPC KERNEL_INVOCATION_REPORT_ERROR_IPC
+    "Allows the kernel to write the userError to the IPC buffer"
+    DEFAULT OFF
+    DEPENDS "KernelPrinting"
+    DEFAULT_DISABLED OFF
+)
+
+config_choice(
+    KernelBenchmarks
+    KERNEL_BENCHMARK
+    "Enable benchmarks including logging and tracing info. \
+    Setting this value > 1 enables a 1MB log buffer and functions for extracting data from it \
+    at user level. NOTE this is only tested on the sabre and will not work on platforms with < 512mb memory. \
+    This is not fully implemented for x86. \
+    none -> No Benchmarking features enabled. \
+    generic -> Enable global benchmarks config variable with no specific features. \
+    track_kernel_entries -> Log kernel entries information including timing, number of invocations and arguments for \
+    system calls, interrupts, user faults and VM faults. \
+    tracepoints -> Enable manually inserted tracepoints that the kernel will track time consumed between. \
+    track_utilisation -> Enable the kernel to track each thread's utilisation time."
+    "none;KernelBenchmarksNone;NO_BENCHMARKS"
+    "generic;KernelBenchmarksGeneric;BENCHMARK_GENERIC;NOT KernelVerificationBuild"
+    "track_kernel_entries;KernelBenchmarksTrackKernelEntries;BENCHMARK_TRACK_KERNEL_ENTRIES;NOT KernelVerificationBuild"
+    "tracepoints;KernelBenchmarksTracepoints;BENCHMARK_TRACEPOINTS;NOT KernelVerificationBuild"
+    "track_utilisation;KernelBenchmarksTrackUtilisation;BENCHMARK_TRACK_UTILISATION;NOT KernelVerificationBuild"
+)
+if(NOT (KernelBenchmarks STREQUAL "none"))
+    config_set(KernelEnableBenchmarks ENABLE_BENCHMARKS ON)
+else()
+    config_set(KernelEnableBenchmarks ENABLE_BENCHMARKS OFF)
+endif()
+
+# Reflect the existence of kernel Log buffer
+if(KernelBenchmarksTrackKernelEntries OR KernelBenchmarksTracepoints)
+    config_set(KernelLogBuffer KERNEL_LOG_BUFFER ON)
+else()
+    config_set(KernelLogBuffer KERNEL_LOG_BUFFER OFF)
+endif()
+
+config_string(
+    KernelMaxNumTracePoints
+    MAX_NUM_TRACE_POINTS
+    "Use TRACE_POINT_START(k) and TRACE_POINT_STOP(k) macros for recording data, \
+    where k is an integer between 0 and this value - 1. The maximum number of \
+    different trace point identifiers which can be used."
+    DEFAULT 1
+    DEPENDS "NOT KernelVerificationBuild;KernelBenchmarksTracepoints" DEFAULT_DISABLED 0
+    UNQUOTE
+)
+
+config_option(
+    KernelIRQReporting
+    IRQ_REPORTING
+    "seL4 does not properly check for and handle spurious interrupts. This can result \
+    in unnecessary output from the kernel during debug builds. If you are CERTAIN these \
+    messages are benign then use this config to turn them off."
+    DEFAULT ON
+    DEPENDS "KernelPrinting"
+    DEFAULT_DISABLED OFF
+)
+config_option(
+    KernelColourPrinting
+    COLOUR_PRINTING
+    "In debug mode, seL4 prints diagnostic messages to its serial output describing, \
+    e.g., the cause of system call errors. This setting determines whether ANSI escape \
+    codes are applied to colour code these error messages. You may wish to disable this \
+    setting if your serial output is redirected to a file or pipe."
+    DEFAULT ON
+    DEPENDS "KernelPrinting"
+    DEFAULT_DISABLED OFF
+)
+config_string(
+    KernelUserStackTraceLength USER_STACK_TRACE_LENGTH
+    "On a double fault the kernel can try and print out the users stack to aid \
+    debugging. This option determines how many words of stack should be printed."
+    DEFAULT 16
+    DEPENDS "KernelPrinting" DEFAULT_DISABLED 0
+    UNQUOTE
+)
+
+config_choice(
+    KernelOptimisation
+    KERNEL_OPT_LEVEL
+    "Select the kernel optimisation level"
+    "-O2;KernelOptimisationO2;KERNEL_OPT_LEVEL_O2"
+    "-Os;KernelOptimisationOS;KERNEL_OPT_LEVEL_OS"
+    "-O0;KernelOptimisationO0;KERNEL_OPT_LEVEL_O0"
+    "-O1;KernelOptimisationO1;KERNEL_OPT_LEVEL_O1"
+    "-O3;KernelOptimisationO3;KERNEL_OPT_LEVEL_O3"
+)
+
+config_option(
+    KernelOptimisationCloneFunctions
+    KERNEL_OPTIMISATION_CLONE_FUNCTIONS
+    "If enabled, allow inter-procedural optimisations that can generate cloned or partial \
+     functions, according to the coarse optimisation setting (KernelOptimisation). \
+     By default, these optimisations are present at -O2 and higher. \
+     If disabled, prevent those optimisations, regardless of the coarse optimisation setting. \
+     The main use of this option is to disable cloned and partial functions when performing \
+     binary verification at -O2. \
+     This currently only affects GCC builds."
+    DEFAULT ON
+    DEPENDS "NOT KernelBinaryVerificationBuild"
+    DEFAULT_DISABLED OFF
+)
+
+config_option(
+    KernelFWholeProgram KERNEL_FWHOLE_PROGRAM
+    "Enable -fwhole-program when linking kernel. This should work modulo gcc bugs, which \
+    are not uncommon with -fwhole-program. Consider this feature experimental!"
+    DEFAULT OFF
+    DEPENDS "NOT KernelBinaryVerificationBuild"
+)
+
+config_option(
+    KernelDangerousCodeInjection DANGEROUS_CODE_INJECTION
+    "Adds a system call that allows users to specify code to be run in kernel mode. \
+    Useful for profiling."
+    DEFAULT OFF
+    DEPENDS
+        "NOT KernelArmHypervisorSupport;NOT KernelVerificationBuild;NOT KernelPlatformHikey;NOT KernelSkimWindow"
+)
+
+config_option(
+    KernelDebugDisablePrefetchers
+    DEBUG_DISABLE_PREFETCHERS
+    "On ia32 platforms, this option disables the L2 hardware prefetcher, the L2 adjacent \
+    cache line prefetcher, the DCU prefetcher and the DCU IP prefetcher. On the cortex \
+    a53 this disables the L1 Data prefetcher."
+    DEFAULT OFF
+    DEPENDS "KernelArchX86 OR KernelPlatformHikey"
+)
+
+# Builds the kernel with support for an invocation to set the TLS_BASE
+# of the currently running thread without a capability.
+config_set(KernelSetTLSBaseSelf SET_TLS_BASE_SELF ${KernelSetTLSBaseSelf})
+
+config_string(
+    KernelWcetScale
+    KERNEL_WCET_SCALE
+    "Multiplier to scale kernel WCET estimate by: the kernel WCET estimate  \
+     is used to ensure a thread has enough budget to get in and out of the  \
+     kernel. When running in a simulator the WCET estimate, which is tuned  \
+     for hardware, may not be sufficient. This option provides a hacky knob \
+     that can be fiddled with when running inside a simulator."
+    DEFAULT 1
+    UNQUOTE
+    DEPENDS "KernelIsMCS"
+    UNDEF_DISABLED
+)
+
+config_string(
+    KernelStaticMaxPeriodUs KERNEL_STATIC_MAX_PERIOD_US
+    "Specifies a static maximum to which scheduling context can have \
+    either its period or budget configured."
+    DEFAULT 0
+    UNQUOTE
+    DEPENDS "KernelIsMCS"
+    UNDEF_DISABLED
+)
+
+config_option(
+    KernelClz32 CLZ_32 "Define a __clzsi2 function to count leading zeros for uint32_t arguments. \
+                        Only needed on platforms which lack a builtin instruction." DEFAULT OFF
+)
+
+config_option(
+    KernelClz64 CLZ_64 "Define a __clzdi2 function to count leading zeros for uint64_t arguments. \
+                        Only needed on platforms which lack a builtin instruction." DEFAULT OFF
+)
+
+config_option(
+    KernelCtz32 CTZ_32 "Define a __ctzsi2 function to count trailing zeros for uint32_t arguments. \
+                        Only needed on platforms which lack a builtin instruction." DEFAULT OFF
+)
+
+config_option(
+    KernelCtz64 CTZ_64 "Define a __ctzdi2 function to count trailing zeros for uint64_t arguments. \
+                        Only needed on platforms which lack a builtin instruction." DEFAULT OFF
+)
+
+config_option(
+    KernelClzNoBuiltin CLZ_NO_BUILTIN
+    "Expose implementations of clzl and clzll to verification by avoiding the use \
+     of __builtin_clzl and __builtin_clzll." DEFAULT OFF
+)
+
+config_option(
+    KernelCtzNoBuiltin CTZ_NO_BUILTIN
+    "Expose implementations of ctzl and ctzll to verification by avoiding the use \
+     of __builtin_ctzl and __builtin_ctzll." DEFAULT OFF
+)
+
+if(DEFINED KernelDTSList AND (NOT "${KernelDTSList}" STREQUAL ""))
+    set(KernelDTSIntermediate "${CMAKE_CURRENT_BINARY_DIR}/kernel.dts")
+    set(KernelDTBPath
+        "${CMAKE_CURRENT_BINARY_DIR}/kernel.dtb"
+        CACHE INTERNAL "Location of kernel DTB file"
+    )
+    set(compatibility_outfile "${CMAKE_CURRENT_BINARY_DIR}/kernel_compat.txt")
+    set(device_dest "${CMAKE_CURRENT_BINARY_DIR}/gen_headers/plat/machine/devices_gen.h")
+    set(platform_yaml
+        "${CMAKE_CURRENT_BINARY_DIR}/gen_headers/plat/machine/platform_gen.yaml"
+        CACHE INTERNAL "Location of platform YAML description"
+    )
+    set(platform_json
+        "${CMAKE_CURRENT_BINARY_DIR}/gen_headers/plat/machine/platform_gen.json"
+        CACHE INTERNAL "Location of platform JSON description"
+    )
+    set(config_file "${CMAKE_CURRENT_SOURCE_DIR}/tools/hardware.yml")
+    set(config_schema "${CMAKE_CURRENT_SOURCE_DIR}/tools/hardware_schema.yml")
+    set(KernelCustomDTSOverlay
+        ""
+        CACHE STRING
+              "Provide an additional list of overlays to append to the selected KernelPlatform's \
+        device tree during build time"
+    )
+    if(NOT "${KernelCustomDTSOverlay}" STREQUAL "")
+        foreach(dts_entry IN ITEMS ${KernelCustomDTSOverlay})
+            if(NOT EXISTS ${dts_entry})
+                message(FATAL_ERROR "Can't open external overlay file '${dts_entry}'!")
+            endif()
+            list(APPEND KernelDTSList "${dts_entry}")
+            message(STATUS "Appending ${dts_entry} overlay")
+        endforeach()
+    endif()
+
+    find_program(DTC_TOOL dtc)
+    if("${DTC_TOOL}" STREQUAL "DTC_TOOL-NOTFOUND")
+        message(FATAL_ERROR "Cannot find 'dtc' program.")
+    endif()
+    find_program(STAT_TOOL stat)
+    if("${STAT_TOOL}" STREQUAL "STAT_TOOL-NOTFOUND")
+        message(FATAL_ERROR "Cannot find 'stat' program.")
+    endif()
+    mark_as_advanced(DTC_TOOL STAT_TOOL)
+    # Generate final DTS based on Linux DTS + seL4 overlay[s]
+    foreach(entry ${KernelDTSList})
+        get_absolute_source_or_binary(dts_tmp ${entry})
+        list(APPEND dts_list "${dts_tmp}")
+    endforeach()
+
+    check_outfile_stale(regen ${KernelDTBPath} dts_list ${CMAKE_CURRENT_BINARY_DIR}/dts.cmd)
+    if(regen)
+        file(REMOVE "${KernelDTSIntermediate}")
+        foreach(entry ${dts_list})
+            file(READ ${entry} CONTENTS)
+            file(APPEND "${KernelDTSIntermediate}" "${CONTENTS}")
+        endforeach()
+        # Compile DTS to DTB
+        execute_process(
+            COMMAND ${DTC_TOOL} -q -I dts -O dtb -o ${KernelDTBPath} ${KernelDTSIntermediate}
+            RESULT_VARIABLE error
+        )
+        if(error)
+            message(FATAL_ERROR "Failed to compile DTS to DTB: ${KernelDTSIntermediate}")
+        endif()
+        # The macOS and GNU coreutils `stat` utilities have different interfaces.
+        # Check if we're using the macOS version, otherwise assume GNU coreutils.
+        # CMAKE_HOST_APPLE is a built-in CMake variable.
+        if(CMAKE_HOST_APPLE AND "${STAT_TOOL}" STREQUAL "/usr/bin/stat")
+            set(STAT_ARGS "-f%z")
+        else()
+            set(STAT_ARGS "-c '%s'")
+        endif()
+        # Track the size of the DTB for downstream tools
+        execute_process(
+            COMMAND ${STAT_TOOL} ${STAT_ARGS} ${KernelDTBPath}
+            OUTPUT_VARIABLE KernelDTBSize
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            RESULT_VARIABLE error
+        )
+        if(error)
+            message(FATAL_ERROR "Failed to determine KernelDTBSize: ${KernelDTBPath}")
+        endif()
+        string(REPLACE "\'" "" KernelDTBSize ${KernelDTBSize})
+        set(KernelDTBSize
+            "${KernelDTBSize}"
+            CACHE INTERNAL "Size of DTB blob, in bytes"
+        )
+    endif()
+
+    set(deps ${KernelDTBPath} ${config_file} ${config_schema} ${HARDWARE_GEN_PATH})
+    check_outfile_stale(regen ${device_dest} deps ${CMAKE_CURRENT_BINARY_DIR}/gen_header.cmd)
+    if(regen)
+        # Generate devices_gen header based on DTB
+        message(STATUS "${device_dest} is out of date. Regenerating from DTB...")
+        file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/gen_headers/plat/machine/")
+        execute_process(
+            COMMAND
+                ${PYTHON3} "${HARDWARE_GEN_PATH}" --dtb "${KernelDTBPath}" --compat-strings
+                --compat-strings-out "${compatibility_outfile}" --c-header --header-out
+                "${device_dest}" --hardware-config "${config_file}" --hardware-schema
+                "${config_schema}" --yaml --yaml-out "${platform_yaml}" --sel4arch
+                "${KernelSel4Arch}" --addrspace-max "${KernelPaddrUserTop}" --json --json-out
+                "${platform_json}" --kernel-config-flags "CONFIG_PRINTING=${KernelPrinting}"
+                "CONFIG_ARM_HYPERVISOR_SUPPORT=${KernelArmHypervisorSupport}"
+                "CONFIG_ARM_SMMU=${KernelArmSMMU}" "CONFIG_TK1_SMMU=${KernelTk1SMMU}"
+            RESULT_VARIABLE error
+        )
+        if(error)
+            message(FATAL_ERROR "Failed to generate from DTB: ${device_dest}")
+        endif()
+    endif()
+    file(READ "${compatibility_outfile}" compatibility_strings)
+
+    # Mark all file dependencies as CMake rerun dependencies.
+    set(cmake_deps ${deps} ${KernelDTSIntermediate} ${KernelDTSList} ${compatibility_outfile})
+    set_property(
+        DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        APPEND
+        PROPERTY CMAKE_CONFIGURE_DEPENDS ${cmake_deps}
+    )
+
+    include(src/drivers/config.cmake)
+endif()
+
+add_config_library(kernel "${configure_string}")

--- a/pristine/configs/AARCH64_bcm2711_verified.cmake
+++ b/pristine/configs/AARCH64_bcm2711_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/AARCH64_verified_include.cmake)
+
+set(KernelPlatform "bcm2711" CACHE STRING "")

--- a/pristine/configs/AARCH64_hikey_verified.cmake
+++ b/pristine/configs/AARCH64_hikey_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/AARCH64_verified_include.cmake)
+
+set(KernelPlatform "hikey" CACHE STRING "")

--- a/pristine/configs/AARCH64_imx8mm_verified.cmake
+++ b/pristine/configs/AARCH64_imx8mm_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2025, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/AARCH64_verified_include.cmake)
+
+set(KernelPlatform "imx8mm-evk" CACHE STRING "")

--- a/pristine/configs/AARCH64_imx8mq_verified.cmake
+++ b/pristine/configs/AARCH64_imx8mq_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2025, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/AARCH64_verified_include.cmake)
+
+set(KernelPlatform "imx8mq-evk" CACHE STRING "")

--- a/pristine/configs/AARCH64_imx93_verified.cmake
+++ b/pristine/configs/AARCH64_imx93_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2025, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/AARCH64_verified_include.cmake)
+
+set(KernelPlatform "imx93" CACHE STRING "")

--- a/pristine/configs/AARCH64_maaxboard_verified.cmake
+++ b/pristine/configs/AARCH64_maaxboard_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2025, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/AARCH64_verified_include.cmake)
+
+set(KernelPlatform "maaxboard" CACHE STRING "")

--- a/pristine/configs/AARCH64_odroidc2_verified.cmake
+++ b/pristine/configs/AARCH64_odroidc2_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/AARCH64_verified_include.cmake)
+
+set(KernelPlatform "odroidc2" CACHE STRING "")

--- a/pristine/configs/AARCH64_odroidc4_verified.cmake
+++ b/pristine/configs/AARCH64_odroidc4_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/AARCH64_verified_include.cmake)
+
+set(KernelPlatform "odroidc4" CACHE STRING "")

--- a/pristine/configs/AARCH64_rockpro64_verified.cmake
+++ b/pristine/configs/AARCH64_rockpro64_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2025, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/AARCH64_verified_include.cmake)
+
+set(KernelPlatform "rockpro64" CACHE STRING "")

--- a/pristine/configs/AARCH64_tqma_verified.cmake
+++ b/pristine/configs/AARCH64_tqma_verified.cmake
@@ -1,0 +1,9 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2025, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/AARCH64_verified_include.cmake)
+set(KernelPlatform "tqma8xqp1gb" CACHE STRING "")

--- a/pristine/configs/AARCH64_tx1_verified.cmake
+++ b/pristine/configs/AARCH64_tx1_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2025, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/AARCH64_verified_include.cmake)
+
+set(KernelPlatform "tx1" CACHE STRING "")

--- a/pristine/configs/AARCH64_ultra96v2_verified.cmake
+++ b/pristine/configs/AARCH64_ultra96v2_verified.cmake
@@ -1,0 +1,11 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2025, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/AARCH64_verified_include.cmake)
+
+set(KernelPlatform "zynqmp" CACHE STRING "")
+set(KernelARMPlatform "ultra96v2" CACHE STRING "")

--- a/pristine/configs/AARCH64_verified.cmake
+++ b/pristine/configs/AARCH64_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/AARCH64_verified_include.cmake)
+
+set(KernelPlatform "tx2" CACHE STRING "")

--- a/pristine/configs/AARCH64_zynqmp_verified.cmake
+++ b/pristine/configs/AARCH64_zynqmp_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/AARCH64_verified_include.cmake)
+
+set(KernelPlatform "zynqmp" CACHE STRING "")

--- a/pristine/configs/ARM_HYP_exynos5410_verified.cmake
+++ b/pristine/configs/ARM_HYP_exynos5410_verified.cmake
@@ -1,0 +1,11 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/ARM_HYP_verified_include.cmake)
+
+set(KernelPlatform "exynos5" CACHE STRING "")
+set(KernelARMPlatform "exynos5410" CACHE STRING "")

--- a/pristine/configs/ARM_HYP_exynos5_verified.cmake
+++ b/pristine/configs/ARM_HYP_exynos5_verified.cmake
@@ -1,0 +1,11 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/ARM_HYP_verified_include.cmake)
+
+set(KernelPlatform "exynos5" CACHE STRING "")
+set(KernelARMPlatform "exynos5422" CACHE STRING "")

--- a/pristine/configs/ARM_HYP_verified.cmake
+++ b/pristine/configs/ARM_HYP_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/ARM_HYP_verified_include.cmake)
+
+set(KernelPlatform "tk1" CACHE STRING "")

--- a/pristine/configs/ARM_MCS_verified.cmake
+++ b/pristine/configs/ARM_MCS_verified.cmake
@@ -1,0 +1,12 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/ARM_verified_include.cmake)
+
+set(KernelPlatform "imx6" CACHE STRING "")
+set(KernelIsMCS ON CACHE BOOL "")
+set(KernelStaticMaxPeriodUs "(60 * 60 * MS_IN_S * US_IN_MS)" CACHE STRING "")

--- a/pristine/configs/ARM_exynos4_verified.cmake
+++ b/pristine/configs/ARM_exynos4_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/ARM_verified_include.cmake)
+
+set(KernelPlatform "exynos4" CACHE STRING "")

--- a/pristine/configs/ARM_exynos5410_verified.cmake
+++ b/pristine/configs/ARM_exynos5410_verified.cmake
@@ -1,0 +1,11 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/ARM_verified_include.cmake)
+
+set(KernelPlatform "exynos5" CACHE STRING "")
+set(KernelARMPlatform "exynos5410" CACHE STRING "")

--- a/pristine/configs/ARM_exynos5422_verified.cmake
+++ b/pristine/configs/ARM_exynos5422_verified.cmake
@@ -1,0 +1,11 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/ARM_verified_include.cmake)
+
+set(KernelPlatform "exynos5" CACHE STRING "")
+set(KernelARMPlatform "exynos5422" CACHE STRING "")

--- a/pristine/configs/ARM_hikey_verified.cmake
+++ b/pristine/configs/ARM_hikey_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/ARM_verified_include.cmake)
+
+set(KernelPlatform "hikey" CACHE STRING "")

--- a/pristine/configs/ARM_imx8mm_verified.cmake
+++ b/pristine/configs/ARM_imx8mm_verified.cmake
@@ -1,0 +1,11 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/ARM_verified_include.cmake)
+
+set(KernelPlatform "imx8mm-evk" CACHE STRING "")
+set(KernelAArch32FPUEnableContextSwitch ON CACHE BOOL "" FORCE)

--- a/pristine/configs/ARM_tk1_verified.cmake
+++ b/pristine/configs/ARM_tk1_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/ARM_verified_include.cmake)
+
+set(KernelPlatform "tk1" CACHE STRING "")

--- a/pristine/configs/ARM_verified.cmake
+++ b/pristine/configs/ARM_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/ARM_verified_include.cmake)
+
+set(KernelPlatform "imx6" CACHE STRING "")

--- a/pristine/configs/ARM_zynq7000_verified.cmake
+++ b/pristine/configs/ARM_zynq7000_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/ARM_verified_include.cmake)
+
+set(KernelPlatform "zynq7000" CACHE STRING "")

--- a/pristine/configs/ARM_zynqmp_verified.cmake
+++ b/pristine/configs/ARM_zynqmp_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/ARM_verified_include.cmake)
+
+set(KernelPlatform "zynqmp" CACHE STRING "")

--- a/pristine/configs/RISCV64_MCS_verified.cmake
+++ b/pristine/configs/RISCV64_MCS_verified.cmake
@@ -1,0 +1,12 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/RISCV64_verified_include.cmake)
+
+set(KernelPlatform "hifive" CACHE STRING "")
+set(KernelIsMCS ON CACHE BOOL "")
+set(KernelStaticMaxPeriodUs "(60 * 60 * MS_IN_S * US_IN_MS)" CACHE STRING "")

--- a/pristine/configs/RISCV64_verified.cmake
+++ b/pristine/configs/RISCV64_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/RISCV64_verified_include.cmake)
+
+set(KernelPlatform "hifive" CACHE STRING "")

--- a/pristine/configs/X64_verified.cmake
+++ b/pristine/configs/X64_verified.cmake
@@ -1,0 +1,25 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# If this file is executed it will build the kernel.elf and kernel_all_pp.c file
+include(${CMAKE_CURRENT_LIST_DIR}/../tools/helpers.cmake)
+cmake_script_build_kernel(..)
+
+set(KernelPlatform "pc99" CACHE STRING "")
+set(KernelSel4Arch "x86_64" CACHE STRING "")
+set(KernelVerificationBuild ON CACHE BOOL "")
+set(KernelMaxNumNodes "1" CACHE STRING "")
+set(KernelOptimisation "-O2" CACHE STRING "")
+set(KernelRetypeFanOutLimit "256" CACHE STRING "")
+set(KernelBenchmarks "none" CACHE STRING "")
+set(KernelDangerousCodeInjection OFF CACHE BOOL "")
+set(KernelFastpath ON CACHE BOOL "")
+set(KernelPrinting OFF CACHE BOOL "")
+set(KernelNumDomains 16 CACHE STRING "")
+set(KernelRootCNodeSizeBits 19 CACHE STRING "")
+set(KernelMaxNumBootinfoUntypedCaps 50 CACHE STRING "")
+set(KernelFSGSBase "inst" CACHE STRING "")

--- a/pristine/configs/include/AARCH64_verified_include.cmake
+++ b/pristine/configs/include/AARCH64_verified_include.cmake
@@ -1,0 +1,24 @@
+#
+# Copyright 2022, Proofcraft Pty Ltd
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# If this file is executed it will build the kernel.elf and kernel_all_pp.c file
+include(${CMAKE_CURRENT_LIST_DIR}/../../tools/helpers.cmake)
+cmake_script_build_kernel(../..)
+
+set(KernelSel4Arch "aarch64" CACHE STRING "")
+set(KernelArmHypervisorSupport ON CACHE BOOL "")
+set(KernelVerificationBuild ON CACHE BOOL "")
+set(KernelMaxNumNodes "1" CACHE STRING "")
+set(KernelOptimisation "-O2" CACHE STRING "")
+set(KernelRetypeFanOutLimit "256" CACHE STRING "")
+set(KernelBenchmarks "none" CACHE STRING "")
+set(KernelDangerousCodeInjection OFF CACHE BOOL "")
+set(KernelFastpath ON CACHE BOOL "")
+set(KernelPrinting OFF CACHE BOOL "")
+set(KernelNumDomains 16 CACHE STRING "")
+set(KernelMaxNumBootinfoUntypedCaps 50 CACHE STRING "")
+set(KernelArmSMMU OFF CACHE BOOL "")

--- a/pristine/configs/include/ARM_HYP_verified_include.cmake
+++ b/pristine/configs/include/ARM_HYP_verified_include.cmake
@@ -1,0 +1,9 @@
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/ARM_verified_include.cmake)
+
+set(KernelSel4Arch "arm_hyp" CACHE STRING "" FORCE)

--- a/pristine/configs/include/ARM_verified_include.cmake
+++ b/pristine/configs/include/ARM_verified_include.cmake
@@ -1,0 +1,24 @@
+#
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# If this file is executed it will build the kernel.elf and kernel_all_pp.c file
+include(${CMAKE_CURRENT_LIST_DIR}/../../tools/helpers.cmake)
+cmake_script_build_kernel(../..)
+
+set(KernelSel4Arch "aarch32" CACHE STRING "")
+set(KernelAArch32FPUEnableContextSwitch OFF CACHE BOOL "")
+set(KernelVerificationBuild ON CACHE BOOL "")
+set(KernelBinaryVerificationBuild ON CACHE BOOL "")
+set(KernelOptimisationCloneFunctions OFF CACHE BOOL "")
+set(KernelIPCBufferLocation "threadID_register" CACHE STRING "")
+set(KernelMaxNumNodes "1" CACHE STRING "")
+set(KernelOptimisation "-O2" CACHE STRING "")
+set(KernelRetypeFanOutLimit "256" CACHE STRING "")
+set(KernelBenchmarks "none" CACHE STRING "")
+set(KernelDangerousCodeInjection OFF CACHE BOOL "")
+set(KernelFastpath ON CACHE BOOL "")
+set(KernelPrinting OFF CACHE BOOL "")
+set(KernelNumDomains 16 CACHE STRING "")

--- a/pristine/configs/include/RISCV64_verified_include.cmake
+++ b/pristine/configs/include/RISCV64_verified_include.cmake
@@ -1,0 +1,29 @@
+#
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# If this file is executed it will build the kernel.elf and kernel_all_pp.c file
+include(${CMAKE_CURRENT_LIST_DIR}/../../tools/helpers.cmake)
+cmake_script_build_kernel(../..)
+
+set(KernelSel4Arch "riscv64" CACHE STRING "")
+set(KernelPTLevels "3" CACHE STRING "")
+set(KernelVerificationBuild ON CACHE BOOL "")
+set(KernelBinaryVerificationBuild ON CACHE BOOL "")
+set(KernelOptimisationCloneFunctions OFF CACHE BOOL "")
+set(KernelMaxNumNodes "1" CACHE STRING "")
+set(KernelOptimisation "-O2" CACHE STRING "")
+set(KernelRetypeFanOutLimit "256" CACHE STRING "")
+set(KernelBenchmarks "none" CACHE STRING "")
+set(KernelDangerousCodeInjection OFF CACHE BOOL "")
+set(KernelFastpath ON CACHE BOOL "")
+set(KernelPrinting OFF CACHE BOOL "")
+set(KernelNumDomains 16 CACHE STRING "")
+set(KernelRootCNodeSizeBits 19 CACHE STRING "")
+set(KernelMaxNumBootinfoUntypedCaps 50 CACHE STRING "")
+set(KernelClzNoBuiltin ON CACHE BOOL "")
+set(KernelCtzNoBuiltin ON CACHE BOOL "")
+set(KernelRiscvExtF OFF CACHE BOOL "")
+set(KernelRiscvExtD OFF CACHE BOOL "")

--- a/pristine/configs/seL4Config.cmake
+++ b/pristine/configs/seL4Config.cmake
@@ -1,0 +1,335 @@
+#
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+set(KERNEL_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
+
+#
+# Architecture selection
+#
+set(configure_string "")
+set(c_sources "")
+set(asm_sources "")
+set(bf_declarations "")
+set(KernelDTSList "")
+
+include(${KERNEL_ROOT_DIR}/tools/internal.cmake)
+include(${KERNEL_ROOT_DIR}/tools/helpers.cmake)
+
+# helper macro to unify messages printed output
+# Usage example: print_message_multiple_options_helper("architectures" aarch32)
+macro(print_message_multiple_options_helper str_type default_str)
+    message(STATUS "platform ${KernelPlatform} supports multiple ${str_type}, none was given")
+    message(STATUS "  defaulting to: ${default_str}")
+endmacro()
+
+# This macro is used by platforms to declare which seL4 architecture(s) they
+# support. It takes a list and sets up the one selected by KernelSel4Arch. If
+# KernelSel4Arch is not set, the architecture specified by the first list
+# element is used.
+# Usage example: declare_seL4_arch("aarch64" "aarch32")
+macro(declare_seL4_arch)
+    # Since this is a macro and not a function, ARGV is not a real variable. One
+    # must be created to be able iterate over it.
+    set(_arch_list "${ARGV}")
+    if(NOT KernelSel4Arch)
+        # Use first architecture from list as default.
+        list(GET _arch_list 0 _default_KernelSel4Arch)
+        print_message_multiple_options_helper("architectures" "${_default_KernelSel4Arch}")
+        set(KernelSel4Arch
+            "${_default_KernelSel4Arch}"
+            CACHE STRING "" FORCE
+        )
+    elseif(NOT "${KernelSel4Arch}" IN_LIST _arch_list)
+        message(FATAL_ERROR "KernelSel4Arch '${KernelSel4Arch}' not in '${_arch_list}'")
+    endif()
+
+    config_choice(
+        KernelSel4Arch
+        SEL4_ARCH
+        "Architecture mode for building the kernel"
+        "aarch32;KernelSel4ArchAarch32;ARCH_AARCH32"
+        "aarch64;KernelSel4ArchAarch64;ARCH_AARCH64"
+        "arm_hyp;KernelSel4ArchArmHyp;ARCH_ARM_HYP"
+        "riscv32;KernelSel4ArchRiscV32;ARCH_RISCV32"
+        "riscv64;KernelSel4ArchRiscV64;ARCH_RISCV64"
+        "x86_64;KernelSel4ArchX86_64;ARCH_X86_64"
+        "ia32;KernelSel4ArchIA32;ARCH_IA32"
+    )
+
+    if(KernelSel4ArchArmHyp)
+        # arm-hyp is basically aarch32. This should be cleaned up and aligned
+        # with other architectures, where hypervisor support is an additional
+        # flag. The main blocker here is updating the verification flow.
+        config_set(KernelSel4ArchAarch32 ARCH_AARCH32 ON)
+    endif()
+
+    config_choice(
+        KernelArch
+        ARCH
+        "Architecture to use when building the kernel"
+        "arm;KernelArchARM;ARCH_ARM;KernelSel4ArchAarch32 OR KernelSel4ArchAarch64"
+        "riscv;KernelArchRiscV;ARCH_RISCV;KernelSel4ArchRiscV32 OR KernelSel4ArchRiscV64"
+        "x86;KernelArchX86;ARCH_X86;KernelSel4ArchX86_64 OR KernelSel4ArchIA32"
+    )
+
+    # Set kernel mode options
+    if(KernelSel4ArchAarch32
+       OR KernelSel4ArchRiscV32
+       OR KernelSel4ArchIA32
+    )
+        config_set(KernelWordSize WORD_SIZE 32)
+        set(Kernel64
+            OFF
+            CACHE INTERNAL ""
+        )
+        set(Kernel32
+            ON
+            CACHE INTERNAL ""
+        )
+    elseif(
+        KernelSel4ArchAarch64
+        OR KernelSel4ArchRiscV64
+        OR KernelSel4ArchX86_64
+    )
+        config_set(KernelWordSize WORD_SIZE 64)
+        set(Kernel64
+            ON
+            CACHE INTERNAL ""
+        )
+        set(Kernel32
+            OFF
+            CACHE INTERNAL ""
+        )
+    else()
+        message(FATAL_ERROR "unsupported seL4 architecture: '${KernelSel4Arch}'")
+    endif()
+endmacro()
+
+# Register a platform's config options to be set if it is selected.
+# Additionally, the kernel_platforms variable can be used as a record of all
+# platforms that can be built once the platform configuration files have been
+# processed.
+# name: name of the platform, KernelPlatform will be set to this.
+# config1: the CMake configuration name. Such as KernelPlatImx7.
+# config2: the C header file config name without CONFIG_. Such as PLAT_IMX7_SABRE.
+# enable_test: A CMake boolean formula that allows the option to be selected.
+#     e.g. "KernelSel4ArchAarch32", or "KernelSel4ArchX86_64 OR KernelSel4ArchIA32"
+macro(declare_platform name config1 config2 enable_test)
+    list(APPEND kernel_platforms "${name}\;${config1}\;${config2}\;${enable_test}")
+    if("${KernelPlatform}" STREQUAL ${name})
+        set(${config1}
+            ON
+            CACHE INTERNAL "" FORCE
+        )
+        # Write KernelPlatform into the cache in case it is only a local variable
+        set(KernelPlatform
+            ${KernelPlatform}
+            CACHE STRING ""
+        )
+    else()
+        set(${config1}
+            OFF
+            CACHE INTERNAL "" FORCE
+        )
+    endif()
+endmacro()
+
+# helper macro that prints a message that no sub platform is specified and
+# the default sub platform will be used
+# Usage example: check_platform_and_fallback_to_default(KernelARMPlatform "sabre")
+macro(check_platform_and_fallback_to_default var_cmake_kernel_plat default_sub_plat)
+    if("${${var_cmake_kernel_plat}}" STREQUAL "")
+        print_message_multiple_options_helper("sub platforms" ${default_sub_plat})
+        set(${var_cmake_kernel_plat} ${default_sub_plat})
+    endif()
+endmacro()
+
+# CLK_SHIFT and CLK_MAGIC are generated from tools/reciprocal.py
+# based on the TIMER_CLK_HZ to simulate division.
+# This could be moved to a cmake function
+# in future to build the values on the first build. Note the calculation
+# can take a long time though.
+macro(declare_default_headers)
+    cmake_parse_arguments(
+        CONFIGURE
+        ""
+        "TIMER_FREQUENCY;MAX_IRQ;NUM_PPI;INTERRUPT_CONTROLLER;TIMER;SMMU;CLK_SHIFT;CLK_MAGIC;KERNEL_WCET;TIMER_PRECISION;TIMER_OVERHEAD_TICKS;MAX_SID;MAX_CB"
+        ""
+        ${ARGN}
+    )
+    set(CALLED_declare_default_headers 1)
+endmacro()
+
+# For all of the common variables we set a default value here if they haven't
+# been set by a platform.
+foreach(
+    var IN
+    ITEMS KernelArmCortexA7
+          KernelArmCortexA8
+          KernelArmCortexA9
+          KernelArmCortexA15
+          KernelArmCortexA35
+          KernelArmCortexA53
+          KernelArmCortexA55
+          KernelArmCortexA57
+          KernelArmCortexA72
+          KernelArchArmV7a
+          KernelArchArmV7ve
+          KernelArchArmV8a
+          KernelAArch64SErrorIgnore
+)
+    unset(${var} CACHE)
+    set(${var} OFF)
+endforeach()
+unset(KernelArmMach CACHE)
+unset(KernelArmMachFeatureModifiers CACHE)
+unset(KernelArmCPU CACHE)
+unset(KernelArmArmV CACHE)
+
+# Blacklist platforms without MCS support
+set(KernelPlatformSupportsMCS ON)
+
+file(GLOB result ${KERNEL_ROOT_DIR}/src/plat/*/config.cmake)
+list(SORT result)
+
+foreach(file ${result})
+    include("${file}")
+endforeach()
+
+config_choice(KernelPlatform PLAT "Select the platform" ${kernel_platforms})
+
+# Verify that, as a minimum any variables that are used
+# to find other build files are actually defined at this
+# point. This means at least: KernelPlatform KernelArch KernelWordSize
+
+if("${KernelPlatform}" STREQUAL "")
+    message(FATAL_ERROR "Variable 'KernelPlatform' is not set - is PLATFORM '${PLATFORM}' correct? \
+Valid platforms are '${KernelPlatform_all_strings}'"
+    )
+endif()
+
+if("${KernelArch}" STREQUAL "")
+    message(FATAL_ERROR "Variable 'KernelArch' is not set.")
+endif()
+
+if("${KernelWordSize}" STREQUAL "")
+    message(FATAL_ERROR "Variable 'KernelWordSize' is not set.")
+endif()
+
+# Now enshrine all the common variables in the config
+config_set(KernelArmCortexA7 ARM_CORTEX_A7 "${KernelArmCortexA7}")
+config_set(KernelArmCortexA8 ARM_CORTEX_A8 "${KernelArmCortexA8}")
+config_set(KernelArmCortexA9 ARM_CORTEX_A9 "${KernelArmCortexA9}")
+config_set(KernelArmCortexA15 ARM_CORTEX_A15 "${KernelArmCortexA15}")
+config_set(KernelArmCortexA35 ARM_CORTEX_A35 "${KernelArmCortexA35}")
+config_set(KernelArmCortexA53 ARM_CORTEX_A53 "${KernelArmCortexA53}")
+config_set(KernelArmCortexA55 ARM_CORTEX_A55 "${KernelArmCortexA55}")
+config_set(KernelArmCortexA57 ARM_CORTEX_A57 "${KernelArmCortexA57}")
+config_set(KernelArmCortexA72 ARM_CORTEX_A72 "${KernelArmCortexA72}")
+config_set(KernelArchArmV7a ARCH_ARM_V7A "${KernelArchArmV7a}")
+config_set(KernelArchArmV7ve ARCH_ARM_V7VE "${KernelArchArmV7ve}")
+config_set(KernelArchArmV8a ARCH_ARM_V8A "${KernelArchArmV8a}")
+config_set(KernelAArch64SErrorIgnore AARCH64_SERROR_IGNORE "${KernelAArch64SErrorIgnore}")
+
+# Check for v7ve before v7a as v7ve is a superset and we want to set the
+# actual armv to that, but leave armv7a config enabled for anything that
+# checks directly against it
+if(KernelArchArmV7ve)
+    set(KernelArmArmV
+        "armv7ve"
+        CACHE INTERNAL ""
+    )
+elseif(KernelArchArmV7a)
+    set(KernelArmArmV
+        "armv7-a"
+        CACHE INTERNAL ""
+    )
+elseif(KernelArchArmV8a)
+    set(KernelArmArmV
+        "armv8-a"
+        CACHE INTERNAL ""
+    )
+endif()
+if(KernelArmCortexA7)
+    set(KernelArmCPU
+        "cortex-a7"
+        CACHE INTERNAL ""
+    )
+elseif(KernelArmCortexA8)
+    set(KernelArmCPU
+        "cortex-a8"
+        CACHE INTERNAL ""
+    )
+elseif(KernelArmCortexA9)
+    set(KernelArmCPU
+        "cortex-a9"
+        CACHE INTERNAL ""
+    )
+elseif(KernelArmCortexA15)
+    set(KernelArmCPU
+        "cortex-a15"
+        CACHE INTERNAL ""
+    )
+elseif(KernelArmCortexA35)
+    set(KernelArmCPU
+        "cortex-a35"
+        CACHE INTERNAL ""
+    )
+elseif(KernelArmCortexA53)
+    set(KernelArmCPU
+        "cortex-a53"
+        CACHE INTERNAL ""
+    )
+elseif(KernelArmCortexA55)
+    set(KernelArmCPU
+        "cortex-a55"
+        CACHE INTERNAL ""
+    )
+elseif(KernelArmCortexA57)
+    set(KernelArmCPU
+        "cortex-a57"
+        CACHE INTERNAL ""
+    )
+elseif(KernelArmCortexA72)
+    set(KernelArmCPU
+        "cortex-a72"
+        CACHE INTERNAL ""
+    )
+endif()
+if(KernelArchARM)
+    config_set(KernelArmMach ARM_MACH "${KernelArmMach}")
+endif()
+
+if("${TRIPLE}" STREQUAL "")
+    set(toolchain_file gcc.cmake)
+else()
+    set(toolchain_file llvm.cmake)
+endif()
+set(toolchain_outputfile "${CMAKE_BINARY_DIR}/${toolchain_file}")
+if(("${CMAKE_TOOLCHAIN_FILE}" STREQUAL "") OR ("${CMAKE_TOOLCHAIN_FILE}" STREQUAL
+                                               "${toolchain_outputfile}")
+)
+    if(DEFINED CACHE{CROSS_COMPILER_PREFIX})
+        set(cross_prefix $CACHE{CROSS_COMPILER_PREFIX})
+    endif()
+
+    configure_file("${KERNEL_ROOT_DIR}/${toolchain_file}" "${toolchain_outputfile}.temp" @ONLY)
+    if(EXISTS "${toolchain_outputfile}")
+        file(READ "${toolchain_outputfile}.temp" filea)
+        file(READ "${toolchain_outputfile}" fileb)
+        if(NOT "${filea}" STREQUAL "${fileb}")
+            message(
+                FATAL_ERROR
+                    "Config changes have resulted in a different toolchain file. This is not supported"
+            )
+        endif()
+    endif()
+    file(RENAME "${toolchain_outputfile}.temp" "${toolchain_outputfile}")
+    set(CMAKE_TOOLCHAIN_FILE
+        "${toolchain_outputfile}"
+        CACHE PATH ""
+    )
+endif()


### PR DESCRIPTION
## Summary
- create a `pristine/` directory with a README explaining its purpose
- copy the upstream `CMakeLists.txt`, `config.cmake`, and `configs/` tree from commit 1c50485c9a1b3c0595c143432664ab55e59e7991 into `pristine/`
- record the new directory and progress in `PRISTINE-AND-PRECONFIGURED-PLAN.md`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d275326220832b81b9d1270c9d7b21