### PR TITLE
Move preconfigured tooling under preconfigured/tools

### DIFF
--- a/PRISTINE-AND-PRECONFIGURED-PLAN.md
+++ b/PRISTINE-AND-PRECONFIGURED-PLAN.md
@@ -48,14 +48,14 @@ Each bullet above is intended to correspond to a single reasonable commit (or, w
 ### Top-level change summary
 | Path / File | Total paths | Modified | Added | Deleted | Notes |
 | --- | ---: | ---: | ---: | ---: | --- |
-| `preconfigured/` | 1,726 | 0 | 1,726 | 0 | Preconfigured build tree now also houses `pipdeps/`, `sysdeps/`, and helper logs/scripts. |
+| `preconfigured/` | 1,728 | 0 | 1,728 | 0 | Preconfigured build tree now also houses `pipdeps/`, `sysdeps/`, helper logs/scripts, and relocated tooling. |
 | `pristine/` | 900 | 0 | 900 | 0 | Mirrors the upstream configs, sources, non-DTS tools, and baseline root metadata including `.github` and `.reuse`. |
 | `sysdeps/` | 0 | 0 | 0 | 0 | Relocated under `preconfigured/sysdeps/`; root copy removed. |
 | `src/` | 44 | 44 | 0 | 0 | Root sources remain modified; compare against `pristine/src/` in later cleanup steps. |
 | `include/` | 43 | 43 | 0 | 0 | Root headers remain modified; pristine copies now live under `pristine/include/`. |
 | `pipdeps/` | 0 | 0 | 0 | 0 | Relocated under `preconfigured/pipdeps/`; counted under the `preconfigured/` row. |
 | `libsel4/` | 4 | 4 | 0 | 0 | Root library files remain modified; compare with `pristine/libsel4/` during reconciliation. |
-| `tools/` | 3 | 0 | 3 | 0 | Small set of helper scripts newly added for the preconfigured layout; upstream copy now mirrored in `pristine/tools/`. |
+| `tools/` | 1 | 0 | 1 | 0 | Only the virtual environment helper remains at the root; preconfigured-specific scripts have moved under `preconfigured/tools/`. |
 | `.gitignore` | 1 | 1 | 0 | 0 | Root metadata changed; baseline version archived under `pristine/.gitignore`. |
 | `.python-version` | 1 | 0 | 1 | 0 | New pyenv pin introduced for tooling. |
 | `PLAN.md` | 1 | 0 | 1 | 0 | Planning document introduced in this branch. |
@@ -97,7 +97,9 @@ Each bullet above is intended to correspond to a single reasonable commit (or, w
 - Moved the generated `pipdeps/` and `sysdeps/` hierarchies underneath `preconfigured/` so dependency snapshots stay out of the repository root.
 - Relocated `preconfigured_build.log` and the replay helper script into `preconfigured/`, updating tooling and documentation to reference their new homes.
 - Refreshed the progress table so the consolidated counts in `preconfigured/` reflect the relocated assets.
+- Introduced a `preconfigured/tools/` directory that now hosts the wrapper generator and build logging helpers, clearing the preconfigured-specific scripts out of the root `tools/` tree.
+- Hardened the logging helper so it resolves the repository root automatically, allowing it to run from any working directory without manual path juggling.
 
 ### Next actions
 - Continue auditing the repository root for generated artifacts or helper scripts that should join the `preconfigured/` tree.
-- Decide whether to group logs and helper scripts into subdirectories within `preconfigured/` before moving additional tooling there.
+- Decide whether to relocate the remaining virtual-environment helper or keep it at the root alongside other shared tooling.

--- a/preconfigured/replay_preconfigured_build.sh
+++ b/preconfigured/replay_preconfigured_build.sh
@@ -144,7 +144,7 @@ done
 cd "$BUILD_DIR"
 cd "$ROOT_DIR"/preconfigured/X64_verified && /usr/bin/cmake -E touch "$ROOT_DIR"/preconfigured/X64_verified/generated_prune/plat_mode/machine/hardware_gen.h "$ROOT_DIR"/preconfigured/X64_verified/generated_prune/arch/object/structures_gen.h "$ROOT_DIR"/preconfigured/X64_verified/generated_prune/sel4/shared_types_gen.h
 $CC --sysroot="$ROOT_DIR"/preconfigured/X64_verified  "${COMMON_GCC_ARGS[@]}" -I"$ROOT_DIR"/preconfigured/X64_verified/libsel4/autoconf -I"$ROOT_DIR"/preconfigured/X64_verified/libsel4/gen_config -m64 $CFLAGS -E -P -MD -MT libsel4/CMakeFiles/libsel4_shared_types_gen_pbf_temp_lib.dir/libsel4_shared_types_gen_pbf_temp.c.obj -MF libsel4/CMakeFiles/libsel4_shared_types_gen_pbf_temp_lib.dir/libsel4_shared_types_gen_pbf_temp.c.obj.d -o libsel4/CMakeFiles/libsel4_shared_types_gen_pbf_temp_lib.dir/libsel4_shared_types_gen_pbf_temp.c.obj -c "$ROOT_DIR"/preconfigured/X64_verified/libsel4/libsel4_shared_types_gen_pbf_temp.c
-python3 "$ROOT_DIR"/tools/generate_kernel_wrappers.py
+python3 "$ROOT_DIR"/preconfigured/tools/generate_kernel_wrappers.py
 
 WRAPPER_OBJECTS=()
 for source in "${KERNEL_SOURCES[@]}"; do

--- a/preconfigured/tools/generate_kernel_wrappers.py
+++ b/preconfigured/tools/generate_kernel_wrappers.py
@@ -9,7 +9,8 @@ import re
 import sys
 from typing import Iterable, List
 
-ROOT = pathlib.Path(__file__).resolve().parent.parent
+# Repository root (three levels above this file: ../../..).
+ROOT = pathlib.Path(__file__).resolve().parents[2]
 REPLAY_SCRIPT = ROOT / "preconfigured" / "replay_preconfigured_build.sh"
 WRAPPER_ROOT = ROOT / "preconfigured" / "X64_verified" / "src"
 KERNEL_COPY_PATH = ROOT / "preconfigured" / "X64_verified" / "kernel_all_copy.c"

--- a/preconfigured/tools/log_preconfigured_build.sh
+++ b/preconfigured/tools/log_preconfigured_build.sh
@@ -10,18 +10,31 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
 # Name of the preconfigured build directory (relative to the
 # repository's preconfigured/ folder).
 BUILD_SUBDIR="${1:-X64_verified}"
-# Output log file (relative to repository root).
-LOG_FILE="${2:-preconfigured/preconfigured_build.log}"
 
-BUILD_DIR="preconfigured/${BUILD_SUBDIR}"
+if [ "$#" -ge 2 ]; then
+    LOG_FILE="$2"
+    case "$LOG_FILE" in
+        /*) ;;
+        *) LOG_FILE="$REPO_ROOT/$LOG_FILE" ;;
+    esac
+else
+    LOG_FILE="$REPO_ROOT/preconfigured/preconfigured_build.log"
+fi
+
+BUILD_DIR="$REPO_ROOT/preconfigured/${BUILD_SUBDIR}"
 
 if [ ! -d "$BUILD_DIR" ]; then
     echo "Build directory '$BUILD_DIR' not found" >&2
     exit 1
 fi
+
+mkdir -p "$(dirname "$LOG_FILE")"
 
 # Clean any existing build artifacts so that all commands are emitted.
 ninja -C "$BUILD_DIR" -t clean >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- relocate the wrapper generator and build log helper into a dedicated `preconfigured/tools` directory
- teach the logging helper to resolve the repository root and normalise log paths after the move
- update the replay script and planning documents to reference the relocated tooling and refreshed file counts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2804794a4832b8af2830b70249005