### PR TITLE
Mirror upstream docs into pristine tree

### DIFF
--- a/PRISTINE-AND-PRECONFIGURED-PLAN.md
+++ b/PRISTINE-AND-PRECONFIGURED-PLAN.md
@@ -49,7 +49,7 @@ Each bullet above is intended to correspond to a single reasonable commit (or, w
 | Path / File | Total paths | Modified | Added | Deleted | Notes |
 | --- | ---: | ---: | ---: | ---: | --- |
 | `preconfigured/` | 2,333 | 0 | 2,333 | 0 | Preconfigured build tree now also houses `pipdeps/`, `sysdeps/`, helper logs/scripts, relocated tooling, the copied header tree, the relocated `libsel4/` sources used by the preconfigured view, and the expanded `src/` mirror with all customized kernel sources (ARM, RISC-V, and x86 variants). Copied the generator helpers and the supporting `tools/hardware/` package into `preconfigured/tools/` so cached builds no longer depend on the root `tools/` directory. |
-| `pristine/` | 932 | 0 | 932 | 0 | Mirrors the upstream configs, sources, non-DTS tools, baseline root metadata including `.github` and `.reuse`, the LaTeX manual, and the relocated toolchain helper files. |
+| `pristine/` | 994 | 0 | 994 | 0 | Mirrors the upstream configs, sources, non-DTS tools, baseline root metadata including `.github`, `.reuse`, the LaTeX manual, the replicated release notes/licensing docs, and the relocated toolchain helper files. |
 | `sysdeps/` | 0 | 0 | 0 | 0 | Relocated under `preconfigured/sysdeps/`; root copy removed. |
 | `src/` | 312 | 0 | 0 | 312 | Removed the entire kernel source tree from the repository root after relocating every architecture, driver, fastpath, object, and platform directory into `pristine/src/` and `preconfigured/src/`, leaving no kernel sources at the top level. |
 | `include/` | 308 | 0 | 0 | 308 | Root headers removed from the repository root after confirming the baseline tree lives under `pristine/include/` and the tailored copies reside in `preconfigured/include/`. |
@@ -90,9 +90,10 @@ Each bullet above is intended to correspond to a single reasonable commit (or, w
 - Renamed the local guidance document to `pristine/README.pristine.md` and expanded it to describe the growing coverage of the pristine snapshot.
 - Updated the change summary counts and notes to record the new pristine totals and cross-links.
 - Captured the upstream `.github` workflows and `.reuse/` licensing metadata inside `pristine/` so future root cleanup can defer to those pristine copies.
+- Mirrored the upstream release notes, contributor guides, and licensing metadata (`CAVEATS.md`, `CHANGES.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `CONTRIBUTORS.md`, `LICENSE.md`, `LICENSES/`, and `SECURITY.md`) into `pristine/` so every baseline top-level document now lives next to the clean source snapshot.
 
 ### Next actions
-- Continue migrating additional root metadata (e.g. release notes and manual updates) into `pristine/`.
+- Spot-check for any remaining top-level metadata that still needs pristine mirrors and track new root documents as they appear.
 - Start moving preconfigured-only helpers into the `preconfigured/` tree once we have pristine references for each script.
 
 ## Step 6 Progress: Corral preconfigured assets

--- a/pristine/CAVEATS.md
+++ b/pristine/CAVEATS.md
@@ -1,0 +1,233 @@
+<!--
+    Copyright 2014, General Dynamics C4 Systems
+
+    SPDX-License-Identifier: GPL-2.0-only
+-->
+
+# Known caveats in the seL4 API and implementation
+
+## Implementation Correctness
+
+The following seL4 architectures have platforms with a C-level functional
+correctness proof. Proof support for further platforms within these
+architectures is on the roadmap and expected in 2025.
+
+- AArch32: Armv7-a with and without hypervisor extensions, no SMMU, with
+  fast path
+  - Platforms (non-hyp): `sabre` (no FPU), `imx8mm-evk` (with FPU)
+  - Platforms (hyp, no FPU): `tk1`, `exynos5`
+- AArch64: Armv8-a with hypervisor extensions only, no SMMU, with fast path
+  - Platforms: `tx2`, `zynqmp`, `bcm2711` (rpi4)
+- RISC-V: 64-bit only, no fast path
+  - Platforms: `hifive`
+- x64: without VT-x and VT-d, no fast path
+  - Platforms: `pc99`
+
+This proof covers the functional behaviour of the C code of the kernel. It does
+not cover machine code, compiler, linker, boot code, cache or TLB management.
+The compiler and linker can be removed from this list by additionally running the
+binary verification tool chain for seL4 for AArch32 or RISC-V.
+
+Overall, the functional correctness proof shows that the seL4 C code implements
+the formal [abstract API specification][ASpec] of seL4 and is free from standard
+C implementation defects such as buffer overruns or NULL pointer dereferences.
+
+For AArch32 without hypervisor extensions and without FPU, and for RISC-V, there
+are additional proofs that this specification satisfies the following high-level
+security properties:
+
+- integrity (no write without authority),
+- confidentiality (no read without authority), and
+- intransitive non-interference (isolation, modulo timing channels, between
+  adequately configured user-level components).
+
+The security property proofs depend on additional assumptions on the correct
+configuration of the system. See the [l4v] repository on GitHub for more
+details.
+
+Similar proofs for AArch64 with hypervisor extensions are in progress.
+
+For AArch32, there additionally exist proofs for correct user-level system
+initialisation. See the [l4v] repository for details.
+
+Note that seL4 currently performs lazy FPU and VCPU switching, which can
+introduce information flow timing channels. An API-change proposal ([RFC]) to
+improve this behaviour is currently in progress.
+
+## Verified Configurations
+
+For the precise configuration of the verified platforms above, see the
+corresponding files in the seL4 `configs/` directory.
+
+The proofs are generally sensitive to changes in configuration parameters, and
+will break if these are changed. For some parameters, the proofs are explicitly
+set up to be robust, such as the number of domains `NUM_DOMAINS`, and the domain
+schedule. More such parameters are on the roadmap to be added and documented
+here.
+
+If in doubt, edit the corresponding `_verified` config files and re-run the
+proofs as specified in the [l4v] repository.
+
+## Real Time
+
+The default version of seL4 must be configured carefully for use in real-time
+requirements. It has a small number of potentially long-running kernel
+operations that are not preemptible (e.g., endpoint deletion, certain
+scheduling states, frame and CNode initialisation). These can (and must) be
+avoided by careful system configuration if low latency is required.
+
+## MCS
+
+The MCS configuration of the kernel addresses many of these real-time problems
+and provides principled access control for execution time, but its formal
+verification is currently still in progress. For RISC-V, design-level proofs
+have completed, and C-level proofs are in progress. Similar proofs for AArch64
+are planned.
+
+The MCS configuration is supported by the seL4 foundation and should generally
+be stable, with small API changes to be expected while verification is ongoing
+and the configuration is deployed in more systems. See open [requests for
+comments][RFC] (RFCs) for MCS for what is currently being discussed.
+
+Note that the kernel worst-case execution time (WCET) configuration values in
+the kernel platform definitions are defaults only and need to be determined
+based on the specific use case -- for instance, static systems can be set up to
+have low latency and WCET, whereas dynamic systems or systems where untrusted
+code has authority to perform longer-running kernel operations may need higher
+values.
+
+## SMP
+
+A symmetric multi-processor (SMP) configuration for seL4 exists and is supported
+by the seL4 Foundation, but currently without formal verification. While
+generally stable, there are a small number of known open issues, in particular
+when the kernel is compiled with `clang`. We recommend `gcc` for working with
+SMP configurations of seL4.
+
+The combination of SMP and hypervisor extensions is supported and should be
+generally stable, but like the plain SMP configuration it is not formally
+verified.
+
+The combination of SMP and MCS is supported and is receiving active development,
+but it is less explored and less tested. It should still be considered
+experimental. There are no supported Armv7-a boards for SMP+MCS, only Armv8-a,
+RISC-V, and Intel. It is tested with `gcc` on `hifive`, `tqma8xqp1gb`,
+`odroidc4`, `zynqmp`, `tx1`, `tx2`, `pc99-32`, and `pc99-64`.
+
+The combination of SMP, MCS, and hypervisor extensions is currently supported on
+AArch64 only. It is less tested with lower code coverage; currently with `gcc`
+only, on `odroidc4`, `tx1`, and `tx2`.
+
+The combination of SMP and domain scheduler is not supported. The SMP
+configuration is not expected to satisfy strong intransitive non-interference
+for information flow.
+
+See the [seL4 issue tracker][issues] and the [sel4test issue tracker][sel4test
+issues] for details using the labels `MCS` and `SMP` for finding issues on these
+configurations.
+
+As these are unverified configurations, standard C implementation defects are
+possible and not excluded as in verified seL4 configurations.
+
+An intermediate step towards higher assurance for seL4-based multicore systems
+is a static multi-kernel configuration of seL4. Formal verification for this
+configuration is on the roadmap for the AArch64 architecture, with initial work
+begun. Even without verification complete, we expect multi-kernel configurations
+to be more robust, because they are simpler and closer to the current sequential
+seL4 proofs.
+
+In a multi-kernel configuration, each CPU core runs a separate instance of seL4,
+with each kernel instance getting access to disjoint subsets of memory of the
+machine. User-level memory can be shared as device-untyped memory, which the
+kernel manages but does not access. These configurations can already be set up
+without kernel changes by providing suitable device tree overlays to each kernel
+instance. Further work is planned to make such configurations easier to use and
+more robust against unsafe use/configurations, e.g. by managing IRQ controller
+access for each instance.
+
+## Re-using Address Spaces
+
+Before a VSpace can be safely reused in a new security context, all frame caps
+previously installed in it should be deleted. The kernel will not do this
+automatically for the user.
+
+If not deleted, old frame capabilities retain some authority in the new security
+context: the authority to perform cache maintenance operations and the unmap
+operation for mappings to the same frame at the same virtual address.
+
+Capabilities to mapped frames store the seL4 ASID and virtual address under
+which the frame is mapped to be able find the corresponding mapping slot. This
+information can become stale when, for instance, the page table object where the
+mapping resides is deleted, and a new page table object is created and used
+there instead. The kernel guards against obvious mistakes such as attempting an
+unmap operation for a mapping slot that now points to another frame, but cannot
+distinguish a cap with correct mapping information for the old VSpace from a cap
+with correct mapping information for the new VSpace.
+
+## Intel VT-d (IOMMU)
+
+### Support
+
+Intel VT-d support in seL4 was tested for the following chipsets:
+
+- Intel Q35 Express
+- Intel 5500
+
+On other chipsets with Intel VT-d support, seL4 might:
+
+- complain and disable IOMMU support
+- hang during bootstrapping
+- have some weird behaviour during runtime
+
+In any of these cases, the workaround is to disable VT-d support, either:
+
+- in the BIOS, or
+- by including `disable_iommu` into the MultiBoot (e.g. GRUB) command line
+  as described in the seL4 documentation
+
+### MSI Remapping
+
+This release does not yet provide support for IOMMU interrupt remapping, which
+means devices cannot be securely passed through to untrusted virtual machines,
+because they could then be used to trigger [arbitrary MSIs with arbitrary
+payload][MSI remap].
+
+Work on a MSI remapping feature is underway.
+
+## Information flow for x86
+
+While no configuration in this release of seL4 provides timing or other
+micro-architectural channel guarantees, timing channel exploits on the x86
+architecture are more widespread and relevant, especially for dynamic systems.
+
+The kernel does provide configuration options for mitigating [Meltdown] and
+[Spectre]-style attacks, but there are no specific mitigations for more recent
+such attacks such as [Zenbleed] and [Inception].
+
+Note that the kernel does not depend on secrets, cryptographic or otherwise, so
+most kernel targets for such attacks are not present, but timing channel
+exploits *can* enable one user-level thread to extract secrets from another.
+
+For many constrained systems, e.g. static embedded systems with known code, the
+existing mitigations may be sufficient. For more dynamic systems they are
+unlikely to be. Further mitigations could be added in the future with dedicated
+funding.
+
+## Rowhammer
+
+seL4 does not offer specific protection against hardware-based memory attacks
+such as Rowhammer, but it does provide primitives for user-level systems to, for
+instance, only map physical memory in such a way that Rowhammer is ineffective
+at crossing protection boundaries.
+
+[l4v]: https://github.com/seL4/l4v
+[RFC]: https://github.com/seL4/rfcs
+[issues]: https://github.com/seL4/seL4/issues/
+[sel4test issues]: https://github.com/seL4/sel4test/issues/
+[ASpec]: https://github.com/seL4/l4v/blob/master/spec/abstract
+
+[Meltdown]: https://meltdownattack.com
+[Spectre]: https://meltdownattack.com
+[Zenbleed]: https://lock.cmpxchg8b.com/zenbleed.html
+[Inception]: https://comsec.ethz.ch/research/microarch/inception/
+[MSI remap]: http://theinvisiblethings.blogspot.com/2011/05/following-white-rabbit-software-attacks.html

--- a/pristine/CHANGES.md
+++ b/pristine/CHANGES.md
@@ -1,0 +1,932 @@
+<!-- SPDX-License-Identifier: CC-BY-SA-4.0 -->
+
+# Revision History for seL4
+
+<!--
+    Document maintainers: Wrap lines in this file at 120 characters.
+
+    Kernel engineers: When making changes to code (rather than documentation or comments) in the kernel repository,
+    include a change item entry here, at the end of the list for the upcoming release, describing the change, and
+    evaluate whether the compatibility breakage level must be promoted as a consequence.  As some rules of thumb:
+    * If the change affects only the sources of the kernel (`src/`, `/include`), it is a BINARY-COMPATIBLE change.
+    * If the change adds visible C preprocessor or language symbols in `libsel4/`, it is a BINARY-COMPATIBLE change.
+    * If the change alters existing symbol definitions, types, or implementations in `libsel4/`, it is a
+      SOURCE-COMPATIBLE change.
+    * Otherwise, it is BREAKING.
+-->
+
+The following is a high-level description of changes to the seL4 kernel project, grouped by release.  It is aimed at
+engineers who desire a summary of changes in more coarse-grained form than the Git commit history.  Each release
+description indicates whether it is SOURCE-COMPATIBLE, BINARY-COMPATIBLE, or BREAKING relative to the previous release.
+
+---
+
+## Upcoming release: BREAKING
+
+### Changes
+
+* Added `zynqmp` and `rpi4` to the set of verified AArch64 configs.
+* riscv: Change default cmake options KernelRiscvExtF and KernelRiscvExtD from OFF to ON.
+  Except for RISCV32 with LLVM clang enabled will default both to OFF.
+* Change fault based FPU context switching to a TCB flag based approach:
+  New system call `seL4_TCB_SetFlags` and new flag `seL4_TCBFlag_fpuDisabled`.
+  See [RFC-18](https://sel4.github.io/rfcs/implemented/0180-fpu-switching.html).
+
+### Platforms
+
+* Removed the default settings `KernelArmVtimerUpdateVOffset` and `KernelArmDisableWFIWFETraps` from the platform
+  `tqma8xqp1gb`, since they are project specific settings, not platform settings. Add
+  `set(KernelArmVtimerUpdateVOffset OFF)` and
+  `set(KernelArmDisableWFIWFETraps ON)`
+  to your project settings to get the same configuration as before if you are using `tqma8xqp1gb`.
+
+#### Arm
+
+* Added config option for selecting which thread ID register is used for Kernel TLS syscalls and invocations.
+  KernelArmTLSReg can be used to select either `tpidru` or `tpidruro` as the TLS register used for `seL4_TCB_SetTLSBase` and `seL4_SetTLSBase` operations.
+  This config option's default value is `tpidru` which is what the register that the kernel currently uses for the TLS register for aarch32 and aarch64 platforms.
+
+* Fixed: under some circumstances, writes by a VMM to VCPU timer registers could have been reverted by the kernel to
+  their previous state. This was triggered when:
+
+  * a VCPU thread was running,
+  * the VCPU was then disabled but remained active by switching to a non-VCPU thread,
+  * that VCPU thread had the VCPU cap and performed the timer register writes,
+  * and execution then switched back to the VCPU thread.
+
+  This was found by Alison Felizzi and independently by Ryan Barry during the integrity proofs for AArch64 hyp mode.
+
+* Fixed: under some circumstances, `seL4_VCPUReg_CPACR` is saved twice to the current VCPU. The value of this
+  register may change between saves, causing the latter save to unintentionally grant EL0/1 access to the FPU.
+
+  1. A thread with an active current VCPU switches to a thread without a VCPU. The current VCPU is disabled.
+    1.1. `seL4_VCPUReg_CPACR` is saved to the current VCPU.
+    1.2. `enableFpuEL01` updates the register, enabling FPU access in EL0 and EL1.
+  2. The thread without a VCPU switches to a thread with a different VCPU to the first
+    2.1. All registers from `seL4_VCPUReg_TTBR0` to `seL4_VCPUReg_SPSR_EL1` are saved. This range includes
+         `seL4_VCPUReg_CPACR`, which overwrites the previously saved value and grants FPU access at EL0 and EL1.
+
+* Fixed: on aarch32 configurations with hypervisor support, `CNTKCTL` was not saved and restored alongside other virtual
+  timer registers. `seL4_VCPUReg_CNTKCTL` has been introduced to mirror `seL4_VCPUReg_CNTKCTL_EL1` from aarch64.
+
+#### X86
+
+* FPU: Fixed XSAVES option. Now it's possible to enable this for newer x86 CPUs.
+* Avoid use-after-free if a VCPU with active FPU state gets deleted.
+
+### Upgrade Notes
+
+Set `seL4_TCBFlag_fpuDisabled` for tasks not using the FPU to retain the old context switch performance.
+The -mgeneral-regs-only option may be needed to stop the compiler from issuing SIMD instructions to speed
+up integer operations.
+
+---
+
+## 13.0.0 2024-07-01: BREAKING
+
+### Security-relevant Changes
+
+* Fixed a kernel-crashing NULL pointer dereference when injecting an IRQ for a non-associated VCPU on SMP
+  configurations. This can be triggered from user-level by any thread that has access to or can create non-associated
+  VCPU objects. While HYP+SMP is not a verified configuration and is not thoroughly tested, it is generally assumed to
+  be working. If you are using this configuration, it is strongly recommended to upgrade.
+
+  * Affected configurations: only unverified HYP+SMP configurations on Arm platforms are affected.
+  * Affected versions: seL4 versions 12.0.0 and 12.1.0.
+  * Exploitability: Any thread that can create or that has access to an unassociated VCPU can cause the crash. In static
+    systems, only the system initialiser thread can create VCPUs and the standard capDL system initialiser will not
+    trigger the issue. VMMs could have the authority to dissociate an existing VCPU from a TCB if they have both
+    capabilities. That is, a malicious VMM could cause a crash, but generally VMMs are trusted, albeit not verified
+    code. Guest VMs generally do not have sufficient authority to exploit this vulnerability.
+  * Severity: Critical. This crashes the entire system.
+
+* Fixed a kernel-crashing cache maintenance operation on AArch64 (Armv8). On AArch64, when seL4 runs in EL1 the kernel
+  would fault with a data abort in `seL4_ARM_Page_Invalidate_Data` and `seL4_ARM_VSpace_Invalidate_Data` when the user
+  requested a `dc ivac` cache maintenance operation on a page that is not mapped writeable. If you are using seL4 in EL1
+  on AArch64, it is strongly recommended to upgrade.
+
+  * Affected configurations: unverified AArch64 configurations of seL4 with hypervisor extensions off (kernel runs in
+    EL1). AArch32 configurations and configurations where seL4 runs in EL2 are not affected.
+  * Affected versions: all previous versions since 5.0.0
+  * Exploitability: Any thread that has a VSpace capability or page capability to a page that is not mapped writable can
+    cause the data abort. Most Microkit and CAmkES systems do not give their component access to these capabilities, but any component with Untyped capabilities could create threads with enough capabilities to trigger the issue.
+  * Severity: Critical. This crashes the system.
+
+* Fixed a cache issue on Arm where cleared memory was not flushed to RAM, but only to the point of unification. This
+  means that uncached access was able to still see old memory content.
+
+  * Affected configurations: Arm platforms that distinguish flushing to PoU from flushing to RAM
+  * Affected versions: all previous versions since 4.0.0
+  * Exploitability: Low. The issue is trivially observable by mapping the same frame as cached and uncached.
+    However, it is unlikely to be exploitable in a real system, because re-using memory over security boundaries
+    is already excluded, so information leakage happens only within the same domain.
+  * Severity: Medium. It breaks functional correctness in the sense that a cleared frame may not yet be cleared when
+    viewed as uncached. It does not break any functional kernel behaviour.
+
+### Platforms
+
+* Added support for the ARM Cortex A55
+* Added support for the imx8mp-evk platform
+* Added support for additional RPI4 variants
+* Added support for the Odroid C4
+* Added support for the Avnet MaaXBoard
+* Added support for arm_hyp on qemu-arm-virt platfrom with cortex-a15 CPU
+* Added support for qemu-riscv-virt
+* Added support for the Pine64 Star64
+* Added support for the TQMa8XQP 1GiB module
+* Remove imx31/kzm platform support. This platform is being removed as it is sufficiently old and unused.
+* Remove ARM1136JF_S and ARMv6 support. This architecture version is being removed as it is sufficiently old and
+  unused. See [RFC-8](https://sel4.github.io/rfcs/implemented/0080-remove-armv6-support.html).
+* Remove ARMv6 specific configs: `KernelGlobalsFrame` and `KernelDangerousCodeInjectionOnUndefInstr`. This removes the
+  constant `seL4_GlobalsFrame` from libsel4 as well as the IPC buffer in GlobalsFrame caveat from CAVEATS.md
+* rpi3+rpi4: Mark first memory page as reserved
+
+#### Arm
+
+* Enabled access to `seL4_VCPUReg_VMPIDR` and `seL4_VCPUReg_VMPIDR_EL2` for all hypervisor configurations. Previously
+  this register was only accessible for SMP kernel configurations. Non-SMP configurations can still require access when
+  wanting to control the value of `MPIDR` that the guest reads. Note that the initial value for new seL4_ARM_VCPUs for
+  this register is 0 which isn't a legal value for `MPIDR_EL1` on AArch64. It may be necessary for the register to be
+  explicitly initialized by user level before launching a thread associated with the new seL4_ARM_VCPU.
+* Allow changing the VCPU of active thread: call `vcpu_switch` in `associateVCPUTCB`. This guarantees that the correct
+  VCPU will be activated when the kernel finishes execution. Previously, changing the VCPU of the current thread would
+  result in no VCPU being active.
+* benchmarking: use write-through kernel log buffer
+* arm_hyp: Access `SPSR` via non-banked instructions
+* `generic_timer`: force timer to de-assert IRQ.
+* No special handling for edge-triggered IRQs.
+  -  Clearing the pending state only has an effect if the IRQ state is active-and-pending, which happens for
+    edge-triggered interrupts if another edge happens on the IRQ line for the currently active interrupt. This window is
+    small enough to ignore, at worst user space will get another notification, which is harmless.
+
+    If unnecessary notifications are unwanted, the pending state should be cleared during `seL4_IRQHandler_Ack()`, as
+    that covers a much bigger window. However, edge-triggered interrupts are not expected to happen often. Making all
+    interrupt handling slightly faster and the code simpler is the better trade-off.
+* Make write-only mapping message consistent. There is a warning when creating a write-only mapping on AArch32/AArch64.
+  This message is now the same in all variants.
+
+##### AArch32
+
+* Implement `KernelArmExportPTMRUser` and `KernelArmExportVTMRUser` options for Arm generic timer use access on AArch32.
+* AArch32 VM fault messages now deliver original (untranslated) faulting IP in a hypervisor context, matching
+  AArch64 behaviour.
+* Fix single stepping on ARMv7
+* TLB: only perform TLB lockdown for Cortex A8.
+  - The code previously used the same instructions for Cortex A8 and A9, but the Cortex A8 instructions are undocumented
+    for A9, and A9 provides a slightly different TLB interface. As far as we can tell, the instructions were simply
+    ignored by the supported A8 platforms, so there was no current correctness issue. Since the instructions had no
+    effect, we removed A9 TLB lockdown support. This potential issue was discovered and reported by the UK's National
+    Cyber Security Centre (NCSC).
+* TLB: guard TLB lockdown count.
+  - `lockTLBEntry` uses the global `tlbLockCount` as input without checking bounds. This is fine, because the function
+    is called at most 2 times per core, but this is only apparent when checking the entire possible calling context.
+    Make this bound obvious locally by doing nothing if the function is called with values of `tlbLockCount` of 2 or
+    greater. This is safe, because TLB lockdown is a performance change only. Also add an assert for debug mode, because
+    we want to know if calling context ever changes. This potential issue was reported by The UK's National Cyber
+    Security Centre (NCSC).
+
+##### AArch64
+
+* Add `AARCH64_verified.cmake` config for functional correctness on AArch64
+* Rename libsel4 config option `AARCH64_VSPACE_S2_START_L1` to `CONFIG_AARCH64_VSPACE_S2_START_L1` to be namespace
+  compliant.
+* Added SMC Capability (`smc_cap`) and SMC forwarding for AArch64 platforms. See
+  [RFC-9](https://sel4.github.io/rfcs/implemented/0090-smc-cap.html).
+* Remove VSpace object types in AArch64: `seL4_ARM_PageDirectory` and `seL4_ARM_PageUpperDirectory`. See also the
+  corresponding [RFC](https://sel4.github.io/rfcs/implemented/0100-refactor-aarch64-vspace.html). The functionality
+  previously provided by these types will be provided by the existing `seL4_ARM_PageTable` object type. This allows for
+  a simpler API and enables a smaller kernel implementation that will be easier to verify. libsel4 provides a source
+  compatibility translation that maps the old libsel4 names and constants the new ones in
+  `<sel4/sel4_arch/deprecated.h>`. There are some exceptional cases where kernel behavior has changed:
+  - A Page directory and page table are now the same kind of object and can be mapped at any page table level.
+    If the lookup for the provided address stops at a slot that can map a page directory, it will map the object as a
+    page directory. If there already is a page directory mapped, the lookup will proceed to the next level and it will
+    map as a page table instead of returning an error.
+* Removed user address space reserved slots restriction on 40bit PA platforms when KernelArmHypervisorSupport is set.
+  This change is reflected in the definition of the seL4_UserTop constant that holds the largest user virtual address.
+* Added support for GICv3 virtualization, tested on iMX8QXP
+* Implemented a signal fastpath on AArch64. Must be enabled explicitly with the `KernelSignalFastpath` config option.
+* Implemented a virtual memory fault fastpath on AArch64. Must be enabled explicitly with the `KernelExceptionFastpath` config option.
+* Add option `KernelAArch64UserCacheEnable` for user cache maintenance.
+  - Enables user level access to `DC CVAU`, `DC CIVAC`, `DC CVAC`, and `IC IVAU` which are cache maintenance operations
+    for the data caches and instruction caches underlying Normal memory and also access to the read-only cache-type
+    register `CTR_EL0` that provides cache type information. The ArmV8-A architecture allows access from EL0 as fast
+    cache maintenance operations improves DMA performance in user-level device drivers.
+
+    These instructions are a subset of the available cache maintenance instructions as they can only address lines by
+    virtual address (VA). They also require that the VA provided refers to a valid mapping with at least read
+    permissions. This corresponds to lines that the EL0 could already affect via regular operation and so it's not
+    expected to break any cache-partitioning scheme.
+
+    The config option allows this policy to be selected for a particular kernel configuration, but it is default enabled
+    as this has been the existing behavior for current aarch64,hyp configurations and have not been explicitly disabled
+    in non-hyp configurations.
+* make error reporting consistent: Report the VSpace cap (1) as invalid, instead of the frame cap (0) in
+  `ARMFrameInvocation` to stay consistent with the other architectures.
+* vcpu: only trap WFx instructions from VCPUs. When `KernelArmDisableWFIWFETraps` is disabled (trapping of WFI/WFE is
+  enabled), the kernel traps WFx instructions from both native and vCPU threads. This change brings the code in line
+  with the config description.
+
+#### RISC-V
+
+* Remove the ability for user-space on RISC-V platforms to access the core-local interrupt controller (CLINT). The
+  CLINT contains memory-mapped registers that the kernel depends on for timer interrupts and hence should not be
+  accessible by user-space.
+* Add configuration option `KernelRiscvUseClintMtime` for faster access of hardware timestamp on RISC-V platforms.
+  The configuration option is not enabled by default as it requires access to the CLINT which depends on the platform
+  and whether the M-mode firmware allows S-mode to access the CLINT. For example, newer versions of OpenSBI (1.0 and above)
+  do not allow direct access of the CLINT.
+* Rename object interface files `include/interfaces/sel4.xml`, `arch_include/*/interfaces/sel4arch.xml`, and
+  `sel4_arch_include/*/interfaces/sel4arch.xml` to `include/interfaces/object-api.xml`,
+  `arch_include/*/interfaces/object-api-arch.xml`, and `sel4_arch_include/*/interfaces/object-api-sel4-arch.xml`,
+  respectively.
+* Improve PLIC driver API and documentation
+* Fix `getMaxUsToTicks` function tor return time instead of ticks.
+* Improve RISC-V PTE compliance: keep D, A, and U bits cleared.
+
+#### Intel
+
+* libsel4: add enum for EPT attributes.
+* VTX: fix EPT cache attribute setting. Previously the only effectively possible value was `EPTWriteBack`.
+* Add kernel support for 64-bit VMs
+* Provide `CONFIG_X86_64_VTX_64BIT_GUESTS` for 64-bit VM support
+* Only access real IOAPIC registers. IOAPICS can have varying numbers of lines attached. The actual number can be
+  accessed in the top 16 bits of the version register. Rather than assuming fixed 24 lines per IRQ, read the actual
+  number and use that.
+
+#### MCS
+
+* Rename `seL4_TimeoutMsg` to `seL4_Timeout_Msg` to make it consistent with the naming of other messages.
+* Correct the minimum size of a scheduling context. This changes the value of `seL4_MinSchedContextBits`.
+* Correct check for message length in `SchedControl_ConfigureFlags`
+* Allow lazy SchedContext rebind. Before, binding a scheduling context to a TCB was not allowed if the SC was bound to a
+  notification object. Also, binding an SC to a notification was not allowed if that scheduling context was already
+  bound to a TCB. Without these restriction it is much easier to move scheduling contexts around: In effect having a SC
+  bound on both the TCB and a notification acts as if the thread is running on a donated SC which will be returned when
+  the tasks calls `Recv`/`Wait`, which is done by `maybeReturnSchedContext()`.
+* Only charge budgets for non-idle thread SCs
+* ARM+MCS: Introduce `TIMER_OVERHEAD_TICKS`. For ARM currently `TIMER_PRECISION` exists, but that is in microseconds and
+  not fine-grained enough. `TIMER_OVERHEAD_TICKS` is needed to make periodic tasks synchronous with the system clock. If
+  this value is non-zero every period will be extended with the overhead of taking an interrupt and reading the system
+  clock. To avoid this drift, the configured value should be set to at least the average overhead.
+* SMP: Do not use cross-node `ksCurTime` assuming they are in sync (which they are not), instead use
+  `NODE_STATE(ksCurTime)`.
+* SMP: Add clock synchronisation test on boot
+* SMP: Fix scheduling context use-after-free
+
+#### Other Changes
+
+* boot: Introduce `seL4_BootInfoFrameSize` and `seL4_BootInfoFrameBits` for user land so there is no longer a need to
+  hard-code a 4 KiByte assumption. Remove `BI_FRAME_SIZE_BITS`.
+* Fix: Don't clobber msgInfo register in `PageGetAddress`, `ASIDControlInvocation`, `ARMCBInvocation`,
+  `A32PageDirectoryGetStatusBits`, `X86PortIn`, `WriteVMCS`, `ReadVMCS`, `ConfigureSingleStepping`, and `GetBreakpoint`.
+* `libsel4`: Make `bootinfo` consistent. Some slot positions in the rootnode would depend on configuration. However that
+  makes it difficult to add new root caps, especially if multiple caps only exist based on configuration. Make all caps
+  always there, but null if not configured.
+* `libsel4`: Eliminate unnamed enums
+* Improved consistency and completeness of user manual
+* Added manual for bitfield generator
+* `bitfield_gen`: allow non-contiguous tag fields. A tagged union can now optionally use multiple fields to indicate the
+  tag. These are called "sliced" tags in the code. The tag fields have to be at the same position and width in each
+  block of the tagged unions, and all tag fields have to be within the same word. See the manual for details.
+* Make `CONFIG_PRINTING` and `CONFIG_DEBUG_BUILD` usable independently from each other
+* Overall debug printing improvements
+* Fix invisible chars due to ANSI escape codes. On terminals with black background some debug output was invisible due
+  to black foreground colour. Use bold instead.
+* Rename libsel4 config option `ENABLE_SMP_SUPPORT` to `CONFIG_ENABLE_SMP_SUPPORT` to be namespace compliant.
+* Removed obsolete define `HAVE_AUTOCONF`
+* Remove userError from `seL4_ReplyRecv` path, because it too often incorrectly warns about legitimate operations
+* Update GDB macros
+* Add support for `cmake --install <dir>` for final build and config artefacts
+* `cmake`: support supplying custom device trees overrides
+* `cmake`: provide `gen_config.json` with kernel config settings
+* Provide `platform_gen.json` in addition to `platform_gen.yaml`
+* Allow build with GNU `binutils` >= 2.38
+* Allow compilation with clang 12
+* `cmake`: detect x86 cross-compiler for Arm host (e.g. on Apple M1)
+* Consistently use `/usr/bin/env` for bash/sh invocations
+* Require Python 3 consistently everywhere
+* Improved support for compiling on MacOS
+* General minor build system improvements and clean-up
+* Set up automated tests for CI and GitHub pull requests on seL4
+* Add vulnerability disclosure policy
+
+### Upgrade Notes
+
+* The change in `seL4_MinSchedContextBits` can lead to failure where code previously created
+  scheduling contexts with size `seL4_MinSchedContextBits` and expected more than the 2 minimum
+  refills to be available for that size. Either use a larger size (the previous value 8 of
+  `seL4_MinSchedContextBits`) in retyping, or request fewer refills.
+
+---
+
+## 12.1.0 2021-06-10: SOURCE COMPATIBLE
+
+### Changes
+
+* Moved kernel configuration header to libsel4.
+* Improved benchmarking:
+  - Made the kernel log buffer to be derived from cmake config.
+  - Added x86_64 kernel log buffer.
+  - Implemented RISC-V benchmark timestamping.
+  - Implemented benchmark log buffer for RISC-V.
+* Moved cap functions out of inline to make changing cap bitfields less noisy.
+* Removed weak definition of the __sel4_ipc_buffer variable which was causing large thread local storages to be
+  required.
+* Prepared the bitfield generator for Isabelle 2021.
+* Made a number of improvements to the CMake build scripts.
+* Added pre-processor 'include guards' for auto-generated files.
+* Added missing CONFIG_PLAT_IMX7 pre-processor '#define's.
+* Added `#pragma once` to the autoconf headers.
+* Removed `HAVE_AUTOCONF` guards in `sel4/config.h`.
+* Improved the manual:
+  - Corrected descriptions of CNode addressing.
+  - Documented initial thread's SMMU caps.
+* Improved libsel4:
+  - Removed redundant `HAVE_AUTOCONF` header guards in libsel4.
+  - Added missing `macros.h` #include in libsel4.
+  - Cleaned-up `macros.h` in libsel4.
+  - Added checks to use `_Static_assert()` in libsel4 if it is available.
+  - Unified definitions in `simple_types.h` in libsel4.
+  - Added `printf` format specifier `PRI_sel4_word` for printing word types.
+  - Unified seL4 type definitions.
+* Added specific `printf` formatting for seL4_Word.
+* Changed some variables to use `BOOT_BSS` instead of `BOOT_DATA` to save space in the ELF file.
+* Replaced the `capDL()` function with a generic `debug_capDL` function that is intended to be implemented by all
+  architectures.
+* Reduced `printf`s stack usage.
+* Fixed `ksnprintf()` corner case handling.
+* Fixed NULL `printf` output wrapper handling.
+* Cleaned up the printing API implementation.
+* Changed code to pass buffer to `printf` output channel.
+* Refactored the kernel console handling.
+* Added support for `PRIu64` and `SEL4_PRIu_word` in the kernel.
+* Changed various `printf` conversion specifiers to use `SEL4_PRIx_word` specifiers.
+
+#### MCS
+
+* Fixed a physical counter access issue on MCS on EL2.
+* Added MCS support for the ZynqMP.
+* Changed invokeSchedControl_Configure to always produce a scheduling context that is active and has configured
+  refills.
+* Prevented the binding of scheduling contexts to blocked TCBs.
+* Fixed conversions of ticks to microseconds on aarch64.
+* Added an additional sporadic flag to `seL4_SchedControl_Configure` which allows the option to create a sporadic
+  scheduling context.
+* Added explicit checks to not unblock the current scheduling context.
+* Fixed MCS and aarch64 VCPU interrupt interaction.
+* Renamed MCS kernel configuration option `KernelStaticMaxBudgetUs` to `KernelStaticMaxPeriodUs`.
+* Added check to make sure that the current thread will not yield to multiple threads.
+* Added check to account for an inactive scheduling context at preemption.
+* Deferred charging time budget in a preempted invocation.
+* Added code to update `ksDomainTime` in `updateTimestamp`.
+* Added call to `updateTimestamp` in a preemption point.
+* Added code to clear ksConsume when charging time to a revoked scheduling context.
+* Added code to cancel IPC when finalising reply caps.
+* Fixed a dereference of a scheduling context after it's removed from the associated TCB.
+* Added MCS to the preprocess check.
+
+#### x86
+
+* Removed a redundant de-reference for `seL4_X86DangerousRDMSR` in ia32.
+* Added a config option to set the frequency of the TSC.
+* Optimized the boot image size for x86_64.
+* Removed the PT_PHDR segment from the linker script to work around an issue in a variant of syslinux that treats a
+  PT_PHDR segment as distinct from a PT_LOAD segment.
+
+#### Arm
+
+* FPU ownership is now also given away on thread deletion instead of only on FPU exception.
+* Added basic build support for A35 core.
+* Fixed read/write of the VCPU CPACR register.
+* Fixed invalidation of the VIPI I-cache in hypervisor mode.
+* Removed duplicate interrupts for the zynqmp in its DTS.
+* Updated device definitions for the exynos5.
+* Added Raspberry Pi 4 support.
+* Updated Ethernet interrupts in the ZynqMP.
+* Added i.MX6 Nitrogen6_SoloX support.
+* Fixed CMake configurations for the ZynqMP and the Ultra96.
+* Fixed the platform `#define` for the i.MX6 Nitrogen6_SoloX.
+* Fixed I-cache invalidation on aarch64 SMP.
+* Fixed the usage of KernelPaddrUserTop on Arm platforms.
+* Added support for the i.MX low-power UART.
+* Added an option to ignore SErrors which is enabled on default for the TX2.
+
+#### RISC-V
+
+* Added PLIC driver and updated the DTS for the Ariane.
+* Merged the PLIC drivers for the Ariane and the Hifive.
+* Updated default timer frequency for the Ariane.
+* Map devices with large pages on 32 and 64-bit kernel.
+* Replaced mentions of BBL with OpenSBI.
+* Added definitions of the KernelOpenSBIPlatform variable for RISC-V platforms.
+* Removed instances of passing `extra_caps_t` by value for binary verification purposes.
+* Removed `slot_range_t` for binary verification purposes.
+* Removed `DONT_TRANSLATE` tag on 'read_sip' for binary verification purposes.
+* Added more efficient clz and ctz implementations to substitute the lack of machine instructions to count leading and
+  trailing zeroes.
+* Updated kernel bootstrap message to be the same as the one on Arm.
+* Added some fastpath improvements for RISC-V.
+* Added extra snippets of code to track kernel entries for RISC-V.
+* Added a configuration guard for fastpath on RISC-V.
+* Reorganised `traps.S` so that syscalls and fastpath checks were done after interrupts and exceptions checks to avoid
+  exceptions being interpreted as null-syscalls.
+* Added support for `riscv64-elf-` toolchain.
+* Fixed a register bug in the assembly entry point for SMP with regards to the elfloader passing HART and core IDs.
+
+### Upgrade Notes
+
+* Scheduling contexts can now be configured as constant-bandwidth or sporadic server.
+  - Constant bandwidth observes a continuous constant bandwidth of budget/period.
+  - Sporadic server behaves as described by Sprunt et. al.
+  - In an overcommitted system, sporadic preserves accumulated time.
+* There are new `PRIx` and `SEL4_PRIx` `printf` conversion specifiers that can now be used inside the kernel.
+* x86_64 kernel binaries are now smaller and may be structured differently compared to previous kernel binaries.
+* Kernel entry benchmarking can now be done on RISC-V.
+* AUTOCONF_INCLUDED is no longer defined. The seL4 build system has stopped
+  using autoconf a long time ago and this define has been kept for compatibility
+  since then. It is no longer used anywhere by now, so it can be removed.
+
+---
+
+## 12.0.0 2020-10-30: BREAKING
+
+### Changes
+
+
+* Update licensing to reflect project transfer to seL4 Foundation. SPDX tags are now used to identify the licenses for
+  each file in the project. Generally, kernel-level code is licensed under GPLv2 and user-level code under the 2-clause
+  BSD license.
+* Update contribution guidelines:
+  * the seL4 foundation requires DCO process instead of a CLA
+* Functional correctness verification for the RISC-V 64-bit HiFive Unleashed platform configuration
+  (RISCV64_verified.cmake with no fastpath or FPU enabled)
+* Update caveats file:
+  - The recycle operation has been removed
+  - More detail on what versions are verified
+  - Update comments on real time use of seL4
+* Improve seL4 manual.
+  - Fix aarch64 seL4_ARM_PageDirectory object API docs:
+    seL4_ARM_PageDirectory_Map is passed a vspace cap not an upper page directory cap.
+  - Increase documentation coverage for Arm object invocations
+  - Rework introduction of system calls in Kernel Services and Objects chapter.
+  - Improve discussion of Receive and Wait syscall behaviour between MCS and non-MCS systems.
+  - Explicitly mention grantreply rights in the exceptions section.
+  - Document schedcontext size_bits meaning.
+  - Remove metion of system criticality.
+  - Add SchedContext to object size discussion.
+  - Fix initial thread's CNode guard size.
+  - Update BootInfo struct table.
+  - Update padding field in UntypedDesc table
+* Update seL4_DebugSnapshot to provide a CapDL dump of the capability layout of
+  a running system for Arm, x86_64 and riscv32 configurations.
+* KernelBenchmarksTrackUtilisation:
+  - Add feature support for SMP configurations
+  - For each thread also track number of times scheduled, number of kernel entries and amount of cycles spent inside the
+    kernel and also add core-wide totals for each.
+* Add 2 new benchmark utilization syscalls
+  - seL4_BenchmarkDumpAllThreadsUtilisation: Prints a JSON formatted record of total and per-thread utilisation
+    statistics about the system. This currently includes a thread's total cycles scheduled, total number of times
+    scheduled, total cycles spent in the kernel and total number of times entering the kernel and then totals of each
+    for all threads on the current core.
+  - seL4_BenchmarkResetAllThreadsUtilisation: Resets the current counts of every user thread on the current core.
+* Added seL4_DebugPutString libsel4 function for printing a null-terminated string via calling seL4_DebugPutChar().
+* Introduced a new config flag, KernelInvocationReportErrorIPC, to enable userError format strings to be written to
+  the IPC buffer. Another config bool has been introduced to toggle printing the error out and this can also be set at
+  runtime. LibSel4PrintInvocationErrors is a libsel4 config used to print any kernel error messages reported in the IPC
+  buffer.
+* Repair barriers in clh_lock_acquire (SMP kernel lock). Strengthen the clh_lock_acquire to use release on the
+  atomic_exchange that makes the node public. Otherwise, (on ARM & RISCV) the store to the node value which sets its
+  state to CLHState_Pending can become visible some time after the node is visible. In that window of time, the next
+  thread which attempts to acquire the lock will still see the old state (CLHState_Granted) and enters the critical
+  section, leading to a mutual exclusion violation.
+* Replace all #ifdef header guards with #pragma once directives in libsel4 header files
+* gcc.cmake:
+  - Add option for coloured gcc output. Setting GCC_COLORS in the environment will result in -fdiagnostics-color=always
+    being provided to gcc. Ordinarily gcc would suppress coloured output when ninja redirects its stderr during normal
+    builds.
+  - Remember CROSS_COMPILER_PREFIX across CMake invocations. The variable would become unset in certain contexts.
+  - Add support for Arm cross-compilers on Red Hat distros.
+* Fastpath optimisation:
+  - Reorganise the code layout on Arm.
+  - bitfield_gen: explicit branch predictions.
+  - Optimize instruction cache access for fastpath.
+* Extend Clang support to all kernel configurations. Support targets LLVM versions between 9 and 11.
+* hardware_gen.py: Add elfloader output target for hardware_gen script. This generates header files describing the
+  platform's CPU configuration as well as device information such as compatibility strings and memory regions to the
+  elfloader that are consistent with the kernel's own definitions.
+* Fix bootinfo allocation bug when user image pushed against page directory boundary. The bootinfo is mapped in at the
+  end of the user image in the initial thread's vspace. The kernel initialisation code wasn't calculating the
+  bootinfo size correctly which could lead to a kernel fault when trying to map the bootinfo in when the parent page
+  table object hadn't been allocated.
+* Use autoconf definition for `RetypeMaxObjects` in <sel4/types.h>. This ensures that the definition stays consistent
+  with what the kernel is configured with.
+* Fix up timers and clock frequencies
+  - Remove beaglebone kernel timer prescaling. Previously the timer frequency was incorrectly set to to half (12MHz) its
+    configured frequency (24MHz).
+  - Set TX1 kernel timer frequency config to 12MHz and not 19.2MHz as this is the standard frequency of the input clock
+    source (m_clock).
+  - Set KZM kernel timer frequency config to 35MHz and not 18.6MHz based on sampling the timer frequency.
+  - imx31: add missing dts entry for the epit2 timer.
+  - Set non-mcs i.MX6 kernel timer frequency config to 498MHz and not 400MHz as this is based on the frequency of the
+    input clock source (PLL1)
+  - Zynq7000: Set kernel timer frequency to 320MHz.
+  - Qemu-arm-virt: Set kernel timer frequency to 6.25MHz.
+* Do not generate data symbols for enums in libsel4 as they end up as bss symbols and cause linker errors on newer
+  compiler versions.
+* Update padding field definition in seL4_UntypedDesc to make the struct word aligned. Previously, this struct wasn't
+  correctly word aligned on 64-bit platforms. This change removes the padding1 and padding2 fields and replaces them
+  with a padding field that is a variable number of bytes depending on the platform.
+* Add GitHub actions scripts. These scripts replicate internal CI checks directly on GitHub
+
+#### MCS
+
+* Stop scheduling contexts from being bound to tcb's that already have scheduling contexts.
+* Fix x86 `KERNEL_TIMER_IRQ` definition. Previously, MCS preemption point handling would check the wrong interrupt on
+  x86 platforms.
+* smp: tcb affinity modification bug. When changing the affinity of a thread on a remote core, the reschedule
+  operation wasn't being performed.
+* Allow `replyGrant` for fault handlers. The MCS kernel so far insisted on full grant rights for fault handler caps,
+  but replyGrant is sufficient and consistent with the default kernel config.
+* All scheduling contexts compare their time with time in assigned core instead of currently executing core.
+* Prevent recursion on timeout faults by suspending a passive server that receives a timeout fault.
+* Add KernelStaticMaxBudgetUs to bound the time the user provides to configure scheduling contexts to avoid malicious
+  or erroneous overflows of the scheduling math. Make the default max period/budget 1 hour.
+* rockpro64: enable mcs configurations
+
+#### Arm
+
+* arm: Add seL4_BenchmarkFlushL1Caches syscall to manually flush L1 caches in benchmark configurations.
+* New fault type when running in Arm hypervisor mode: seL4_Fault_VPPIEvent
+  - The kernel can keep track of IRQ state for each VCPU for a reduced set of PPI IRQs and deliver IRQ events as
+    VCPU faults for these interrupt numbers.
+  - Additionally a new VCPU invocation is introduced: seL4_ARM_VCPU_AckVPPI.
+    This is used to acknowledge a virtual PPI that was delivered as a fault.
+* Virtualise Arm Timer and VTimer interrupts to support sharing across VCPUs.
+  - A VCPU will now save and restore VTimer registers for the generic timer and also deliver a VTimer IRQ via a
+    seL4_Fault_VPPIEvent fault. This enables multiple VCPUs bound to the same physical core to share this device.
+* Build config option for whether WFE/WFI traps on VCPUs when running in Arm hypervisor mode
+* Arm: Add VMPIDR and VMPIDR_EL2 registers to VCPU objects for programming a VCPU's 'Virtualization Multiprocessor
+  ID Register' on aarch32 and aarch64.
+* Arm, vcpu, smp: Remote IPI call support for VIRQS. Injecting a VIRQ into a vcpu running on a different core will
+  IPI the remote core to perform the IRQ injection.
+* zynqmp: Disable hardware debug APIs as the platform doesn't support kernel hardware debug API.
+* zynqmp: Add support for aarch32 hyp
+* Gicv3: include cluster id when sending ipis.
+* qemu-arm-virt:
+  - Generate platform dtb based on KernelMaxNumNodes config value.
+  - Reserve the first 512MiB of Ram as device untyped for use in virtualization configurations.
+
+##### Aarch32
+
+* Moved TPIDRURO (PL0 Read-Only Thread ID register) to TCB register context from VCPU registers. This means
+  changes to this register from user level have to go via seL4_TCB_Write Registers instead of seL4_ARM_VCPU_WriteRegs.
+* aarch32: Restrict cache flush operation address range in hyp mode. It's required that cache flushing in hyp mode
+  is performed through the kernel window mapping as the kernel is unable to flush addresses outside of this mapping
+  without causing an access fault.
+* arm_hyp: Move PGD definitions out of libsel4 as they don't correspond to any public interfaces and are only used
+  internally by the kernel to manage its own address space.
+
+##### Aarch64
+
+* aarch64: Fix a bug where saving ELR_EL1 when managing a VCPU object was reading from ELR_EL1 instead of writing to it.
+* aarch64: Fix a bug where saving FAR_EL1 when managing a VCPU object was only writing to the low 32 bits of the 64-bit
+  FAR_EL1 register.
+* aarch64: Add missing faults to seL4_getArchFault. seL4_getArchFault is a libsel4 helper that constructs fault messages
+  out of the IPC buffer message registers but it wasn't aware of all possible fault types.
+* aarch64,vcpu: Add CNTKCTL_EL1 register to `vcpu_t`. This register tracks timer delegation to EL0 from EL1 and
+  needs to be switched for different VCPUs.
+* aarch64: Adds missing vcpu cases for some aarch64-specific functions on capabilities.
+* cortex-a53,hyp: Reduce seL4_UserTop when on a cortex-a53 platform and KernelArmHypervisorSupport is set.
+  - This is because the kernel uses the last slot in the top level VSpace object for storing the assigned VMID and so
+    any addresses that are addressed by the final slot are not accessible. This would apply to any CPU that have 40bit
+    stage 2 translation input address.
+* Arm SMMUv2 kernel API and TX2 smmuv2 driver. This supports using an SMMU to provide address translation and memory
+  protection for device memory access to platforms that implement a compatible Arm SMMUv2 System mmu. The kernel
+  implementation supports using an SMMU to restrict memory access of VM guest pass-through devices, or for isolating
+  devices and their drivers' memory accesses to the rest of a running system.
+
+#### x86
+
+* Fix printf typo in `apic_init`.
+* x86_64: Fix PCID feature constant to use the correct bit.
+* Fix interrupt flag reset upon nested interrupt resume, `c_nested_interrupt`. This fixes an issue where ia32 kernels
+  would crash if receiving a nested interrupt.
+
+#### RISC-V
+
+* Functional correctness of seL4/RISCV now formally verified at the C level.
+* Hifive: Enable seL4_IRQControl_GetTrigger object method. This method allocates an IRQ handler by ID and whether it is
+  level or edge triggered. Note: HiFive PLIC interrupts are all positive-level triggered.
+* Add search for additonal gcc riscv toolchains if the first one cannot be found.
+* Add support for rocketchip soc. Support Rocketchip SoC maps to Xilinx ZC706 board and ZCU102 board
+* Add support for polarfire soc.
+* Clear reservation state on slowpath exit as the RISC-V ISA manual requires supervisor code to execute a dummy sc
+  instruction to clear reservations "during a preemptive context switch".
+* Pass DTB through to userlevel in extra bootinfo fields similar to on Arm.
+* Use full width of scause to prevent large exception numbers to be misinterpreted as syscalls.
+* Fix page map bug.
+  - Previously, it was possible in decodeRISCVFrameInvocation for the rwx rights of the new PTE to become 000 after
+    masking with cap rights. This would turn the frame PTE into a page table PTE instead, and allow the user to create
+    almost arbitrary mappings, including to kernel data and code. The defect was discovered in the C verification of the
+    RISC-V port.
+* Remove seL4_UserException_FLAGS. This field was unused and was never set to anything by the kernel.
+* Add FPU config options for RISCV
+  - Two options, KernelRiscvExtD and KernelRiscvExtF, are added to represent the D and F floating-point extensions.
+    KernelHaveFPU is enabled when the floating-point extensions are enabled. The compiler ABI will also be changed to
+    lp64d for hardfloat builds.
+* Add RISCV64_MCS_verified.cmake config for in-progress MCS verification
+* riscv32: Remove incorrectly provided constants for 512MiB 'huge pages' which is not part of the specification.
+* riscv: Lower .boot alignment to 4KiB. This makes the final kernel image more compact.
+
+### Upgrade Notes
+
+* The project's licensing updates don't change the general licensing availability of the sources.
+  More information can be found: <https://github.com/seL4/seL4/blob/master/LICENSE.md>
+* Any references to the padding1 or padding2 fields in seL4_UntypedDesc require updating to
+  the new padding field. It is expected that these fields are unused.
+* Any platforms that have had changed kernel timer frequencies will see different scheduling
+  behavior as kernel timer ticks will occur at different times as kernel ticks are configured
+  in microseconds but then converted to timer ticks via the timer frequency. Any time-sensitive
+  programs may need to be re-calibrated.
+* Any riscv32 programs that were using the constants RISCVGigaPageBits or seL4_HugePageBits will
+  see a compilation error as the constants have been deleted as they aren't supported in the riscv32 spec.
+* Any riscv programs that refer to the seL4_UserException_FLAGS field will need to remove this reference. This field was
+  never initialised by the kernel previously and has now been removed.
+* Any riscv programs using the LR/SC atomics instructions will see reservations invalidated after kernel entries. It is
+  expected that this will not require any changes as reservations becoming invalid is normal behavior.
+* On cortex-a53 platforms when KernelArmHypervisorSupport is set have 1 less GiB of virtual memory addresses available
+  or 2GiB less on TX2 with the SMMU feature enabled. This is captured by the change in definition of the seL4_UserTop
+  constant that holds the larges virtual address accessible by user level.
+* On aarch32 the TPIDRURO register(PL0 Read-Only Thread ID register) has been removed from the VCPU object and added to
+  the TCB object. A VCPU is typically bound to a TCB so after updating the access, a thread with a VCPU attached will
+  still support having a TPIDRURO managed.
+* On Arm hypervisor configurations, PPI virtual timer interrupts are now delivered via seL4_Fault_VPPIEvent faults and
+  it is not possible to allocate an interrupt handler for these interrupts using the normal interrupt APIs. A VPPI
+  interrupt is received via receiving a fault message on a VCPU fault handler, and acknowledged by an invocation on
+  the VCPU object. VPPI interrupts that target a particular VCPU can only be generated while the VCPU thread is
+  executing.
+
+---
+
+## 11.0.0 2019-11-19: BREAKING
+
+### Changes
+
+* Add GrantReply access right for endpoint capabilities.
+  - seL4_Call is permitted on endpoints with either the Grant or the GrantReply access rights.
+  - Capabilities can only be transferred in a reply message if receiver's endpoint capability has the Grant right.
+* `seL4_CapRights_new` now takes 4 parameters
+* seL4_CapRightsBits added to libsel4. seL4_CapRightsBits is the number of bits to encode seL4_CapRights.
+* `seL4_UserTop` added
+  - a new constant in libsel4 that contains the first virtual address unavailable to
+    user level.
+* Add Kernel log buffer to aarch64
+* Support added for Aarch64 hypervisor mode (EL2) for Nvidia TX1 and TX2. This is not verified.
+* Support for generating ARM machine header files (memory regions and interrupts) based on a device tree.
+* Support added for ARM kernel serial driver to be linked in at build time based on the device tree compatibility string.
+* Support added for compiling verified configurations of the kernel with Clang 7.
+* RISC-V: handle all faults
+  - Pass all non-VM faults as user exceptions.
+* arm-hyp: pass ESR in handleUserLevelFault
+* aarch64: return ESR as part of user level fault
+* Created new seL4_nbASIDPoolsBits constant to keep track of max nb of ASID pools.
+* Support added for Hardkernel ODROID-C2.
+* Added extended bootinfo header for device tree (SEL4_BOOTINFO_HEADER_FDT).
+* Support added for passing a device tree from the bootloader to the root task on ARM.
+* Add seL4_VSpaceBits, the size of the top level page table.
+* The root cnode size is now a minimum of 4K.
+* Hifive board support and RISC-V external interrupt support via a PLIC driver.
+* Update seL4_FaultType size to 4bits.
+* Fix seL4_MappingFailedLookupLevel() for EPTs on x86.
+  - add SEL4_MAPING_LOOKUP_NO_[EPTPDPT, EPTPD, EPTPT] which now correspond to
+    the value returned by seL4_MappingFailedLookupLevel on X86 EPT mapping calls.
+* BeagleBone Black renamed from am335x to am335x-boneblack.
+* Supported added for BeagleBone Blue (am335x-boneblue).
+* Remove IPC Buffer register in user space on all platforms
+* Add managed TLS register for all platforms
+* Add configurable system call allowing userspace to set TLS register without capability on all platforms.
+* Non-hyp support added for Arm GICv3 interrupt controller.
+* Add initial support for i.MX8M boards.
+  - Support for i.MX8M Quad evk AArch64 EL2 and EL1, AArch32 smode only is accessible via the imx8mq-evk platform.
+  - Support for i.MX8M Mini evk AArch64 EL2 and EL1, AArch32 smode only is accessible via the imx8mm-evk platform.
+* Add FVP platform with fixed configuration. This currently assumes A57 configuration described in tools/dts/fvp.dts.
+* Arm SMP invocation IRQControl_GetTriggerCore added
+  - Used to route a specify which core an IRQ should be delivered on.
+* Kernel log buffer: Specify on which core an IRQ was delivered.
+* Add new seL4_DebugSendIPI syscall to send arbitrary SGIs on ARM when SMP and DEBUG_BUILD are activated.
+* Support for aarch64-hyp configurations with 40-bit physical addresses (PA) added.
+  - The aarch64 api now refers to VSpaces rather than PageGlobalDirectories,
+    as depending on the PA the top level translation structure can change.
+  - all `seL4_ARM_PageGlobalDirectory` invocations are now `seL4_ARM_VSpace` invocations.
+  - new constants 'seL4_ARM_VSpaceObject` and `seL4_VSpaceIndexBits`.
+* Merged MCS kernel feature.
+  - this is not verified and is under active verification.
+  - The goals of the MCS kernel is to provide strong temporal isolation and a basis for reasoning about time.
+* Moved aarch64 kernel window
+  - aarch64 kernel window is now placed at 0, meaning the kernel can access memory
+    below where the kernel image is mapped.
+* aarch64: Moved TPIDRRO_EL0 (EL0 Read-Only Thread ID register) to TCB register context from VCPU registers. This means
+  changes to this register from user level have to go via seL4_TCB_Write Registers instead of seL4_ARM_VCPU_WriteRegs.
+* Merge ARCH_Page_Remap functionality into ARCH_Page_Map. Remap was used for updating the mapping attributes of a page
+  without changing its virtual address. Now ARCH_Page_Map can be performed on an existing mapping to achieve the same
+  result. The ARCH_Page_Remap invocation has been removed from all configurations.
+* riscv64: Experimental SMP support for RISCV64 on HiFive.
+* Support added for QEMU ARM virt platform, with 3 CPUs: cortex-a15, cortex-a53 and cortex-a57
+  - PLATFORM=qemu-arm-virt
+  - ARM_CPU={cortex-a15, cortex-a53, cortex-a57}
+  - QEMU_MEMORY=1024 (default)
+* Support added for rockpro64.
+* RISCV: Add support for Ariane SoC
+* Unify device untyped initialisation across x86, Arm and RISC-V
+  - Access to the entire physical address range is made available via untypes.
+  - The kernel reserves regions that user level is not able to access and doesn't hand out untypeds for it.
+  - Ram memory is part of this reservation and is instead handed out as regular Untypeds.
+  - Memory reserved for use by the kernel or other reserved regions are not accessible via any untypeds.
+  - Devices used by the kernel are also not accessible via any untypeds.
+
+### Upgrade Notes
+
+* Usages of Endpoints can now use seL4_Call without providing Grant rights by downgrading the Grant to GrantReply
+* The kernel no longer reserves a register for holding the address of a thread's IPC buffer. It is now expected that the
+  location of the IPC buffer is stored in a __thread local variable and a thread register is used to refer to each
+  thread's thread local variables. The sel4runtime is an seL4 runtime that provides program entry points that setup
+  the IPC buffer address and serves as a reference for how the IPC buffer is expected to be accessed.
+* All `seL4_ARM_PageGlobalDirectory` invocations need to be replaced with `seL4_ARM_VSpace`.
+* Usages of ARCH_Page_Remap can be replaced with ARCH_Page_Map and require the original mapping address to be provided.
+* Device untypeds are provided to user level in different sizes which may require more initial processing to break them
+  down for each device they refer to.
+
+---
+
+## 10.1.1 2018-11-12: BINARY COMPATIBLE
+
+### Changes
+
+* Remove theoretical uninitialised variable use in infer_cpu_gic_id for binary translation validation
+
+### Upgrade Notes
+
+* 10.1.0 has a known broken test in the proofs. 10.1.1 fixes this test.
+
+---
+
+## 10.1.0 2018-11-07: SOURCE COMPATIBLE
+
+### Changes
+
+* structures in the boot info are not declared 'packed'
+  - these were previously packed (in the GCC attribute sense)
+  - some field lengths are tweaked to avoid padding
+  - this is a source-compatible change
+* ARM platforms can now set the trigger of an IRQ Handler capability
+  - seL4_IRQControl_GetTrigger allows users to obtain an IRQ Handler capability
+    and set the trigger (edge or level) in the interrupt controller.
+* Initial support for NVIDIA Jetson TX2 (ARMv8a, Cortex A57)
+* AARCH64 support added for raspberry pi 3 platform.
+* Code generation now use jinja2 instead of tempita.
+* AARCH32 HYP support added for running multiple ARM VMs
+* AARCH32 HYP VCPU registers updated.
+* A new invocation for setting TLSBase on all platforms.
+  - seL4_TCB_SetTLSBase
+* Kbuild/Kconfig/Makefile build system removed.
+
+---
+
+## 10.0.0 2018-05-28: BREAKING
+
+* Final version of the kernel  which supports integration with Kbuild based projects
+* Future versions, including this one, provide a CMake based build system
+
+For more information see <https://docs.sel4.systems/Developing/Building>.
+
+### Changes
+
+* x86 IO ports now have an explicit IOPortControl capability to gate their creation. IOPort capabilities  may now only
+  be created through the IOPortControl capability that is passed to the rootserver. Additionally IOPort capabilities
+  may not be derived to have smaller ranges and the IOPortControl will not issue overlapping IOPorts
+* 32-bit support added for the initial prototype RISC-V architecture port
+
+### Upgrade Notes
+
+* A rootserver must now create IOPort capabilities from the provided IOPortControl capability. As IOPorts can not
+  have their ranges further restricted after creation it must create capabilities with the final desired granularity,
+  remembering that since ranges cannot overlap you cannot issue a larger and smaller range that have any IO ports
+  in common.
+
+---
+
+## 9.0.1 2018-04-18: BINARY COMPATIBLE
+
+### Changes
+
+* On 64-bit architectures, the `label` field of `seL4_MessageInfo` is now 52 bits wide. User-level programs
+  which use any of the following functions may break, if the program relies on these functions to mask the
+  `label` field to the previous width of 20 bits.
+  - `seL4_MessageInfo_new`
+  - `seL4_MessageInfo_get_label`
+  - `seL4_MessageInfo_set_label`
+* Initial prototype RISC-V architecture port. This port currently only supports running in 64-bit mode without FPU or
+  or multicore support on the Spike simulation platform. There is *no verification* for this platform.
+
+---
+
+## 9.0.0 2018-04-11: BREAKING
+
+### Changes
+
+* Debugging option on x86 for syscall interface to read/write MSRs (this is an, equally dangerous, alternative to
+  dangerous code injection)
+* Mitigation for Meltdown (<https://meltdownattack.com>) on x86-64 implemented. Mitigation is via a form of kernel
+  page table isolation through the use of a Static Kernel Image with Microstate (SKIM) window that is used for
+  trapping to and from the kernel address space. This can be enabled/disabled through the build configuration
+  depending on whether you are running on vulnerable hardware or not.
+* Mitigation for Spectre (<https://spectreattack.com>) on x86 against the kernel implemented. Default is software
+  mitigation and is the best performing so users need to do nothing. This does *not* prevent user processes from
+  exploiting each other.
+* x86 configuration option for performing branch prediction barrier on context switch to prevent Spectre style
+  attacks between user processes using the indirect branch predictor
+* x86 configuration option for flushing the RSB on context switch to prevent Spectre style attacks between user
+  processes using the RSB
+* Define extended bootinfo header for the x86 TSC frequency
+* x86 TSC frequency exported in extended bootinfo header
+* `archInfo` is no longer a member of the bootinfo struct. Its only use was for TSC frequency on x86, which
+  can now be retrieved through the extended bootinfo
+* Invocations to set thread priority and maximum control priority (MCP) have changed.
+  - For both invocations, users must now provide a TCB capability `auth`
+  - The requested MCP/priority is checked against the MCP of the `auth` capability.
+  - Previous behavior checked against the invoked TCB, which could be subject to the confused deputy
+   problem.
+* seL4_TCB_Configure no longer takes prio, mcp as an argument. Instead these fields must be set separately
+  with seL4_TCB_SetPriority and seL4_TCB_SetMCPriority.
+* seL4_TCB_SetPriority and seL4_TCB_SetMCPriority now take seL4_Word instead of seL4_Uint8.
+  - seL4_MaxPrio remains at 255.
+* seL4_TCB_SetSchedParams is a new method where MCP and priority can be set in the same sytsem call.
+* Size of the TCB object is increased for some build configurations
+
+### Upgrade notes
+
+* seL4_TCB_Configure calls that set priority should be changed to explicitly call seL4_TCB_SetSchedParams
+  or SetPriority
+* seL4_TCB_Configure calls that set MCP should be changed to explicitly call seL4_TCB_SetSchedParams
+  or seL4_TCB_SetMCPriority
+
+---
+
+## 8.0.0 2018-01-17
+
+### Changes
+
+* Support for additional zynq platform Zynq UltraScale+ MPSoC (Xilinx ZCU102, ARMv8a, Cortex A53)
+* Support for multiboot2 bootloaders on x86 (contributed change from Genode Labs)
+* Deprecate seL4_CapData_t type and functions related to it
+* A fastpath improvement means that when there are two runnable threads and the target thread is the highest priority in
+  the scheduler, the fastpath will be hit. Previously the fastpath would not be used on IPC from a high priority thread
+  to a low priority thread.
+* As a consequence of the above change, scheduling behaviour has changed in the case where a non-blocking IPC is sent
+  between two same priority threads: the sender will be scheduled, rather than the destination.
+* Benchmarking support for armv8/aarch64 is now available.
+* Additional x86 extra bootinfo type for retrieving frame buffer information from multiboot 2
+* Debugging option to export x86 Performance-Monitoring Counters to user level
+
+### Upgrade notes
+
+* seL4_CapData_t should be replaced with just seL4_Word. Construction of badges should just be `x` instead of
+  `seL4_CapData_Badge_new(x)` and guards should be `seL4_CNode_CapData_new(x, y)` instead of
+  `seL4_CapData_Guard_new(x, y)`
+* Code that relied on non-blocking IPC to switch between threads of the same priority may break.
+
+---
+
+## 7.0.0 2017-09-05
+
+### Changes
+
+* Support for building standalone ia32 kernel added
+* ia32: Set sensible defaults for FS and GS selectors
+* aarch64: Use tpidrro_el0 for IPC buffer instead of tpidr_el0
+* More seL4 manual documentation added for aarch64 object invocations
+* Default NUM_DOMAINS set to 16 for x86-64 standalone builds
+* libsel4: Return seL4_Error in invocation stubs in 8fb06eecff9 ''' This is a source code level breaking change '''
+* Add a CMake based build system
+* x86: Increase TCB size for debug builds
+* libsel4: x86: Remove nested struct declarations ''' This is a source code level breaking change '''
+* Bugfix: x86: Unmap pages when delete non final frame caps
+
+### Upgrade notes
+
+* This release is not source compatible with previous releases.
+* seL4 invocations that previously returned long now return seL4_Error which is an enum. Our libraries have already been
+  updated to reflect this change, but in other places where seL4 invocations are used directly, the return types will
+  need to be updated to reflect this change.
+* On x86 some structs in the Bootinfo have been rearranged. This only affects seL4_VBEModeInfoBlock_t which is used if
+  VESA BIOS Extensions (VBE) information is being used.
+
+### Known issues
+
+* One of our tests is non-deterministically becoming unresponsive on the SMP release build on the Sabre IMX.6 platform,
+  which is a non verified configuration of the kernel.  We are working on fixing this problem, and will likely do a
+  point release once it is fixed.
+
+---
+For previous releases see <https://docs.sel4.systems/releases/seL4.html>

--- a/pristine/CODE_OF_CONDUCT.md
+++ b/pristine/CODE_OF_CONDUCT.md
@@ -1,0 +1,12 @@
+<!--
+     Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Code of Conduct
+
+This repository and interactions with it fall under the [seL4 Code of Conduct][1] available from the [seL4 website][2].
+
+[1]: https://docs.sel4.systems/processes/conduct.html
+[2]: https://sel4.systems

--- a/pristine/CONTRIBUTING.md
+++ b/pristine/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+<!--
+     Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Contributions Welcome!
+
+Contributions to the seL4 kernel repository are welcome!
+
+## Kernel Development Process
+
+In addition to our general [contribution guidelines][1], the kernel has additional git history requirements:
+
+* Please try to make sure every commit is in a working state to facilitate bisecting.
+    + unless there is a concrete reason, if so please state that reason in the commit message.
+* Try to keep commits small for ease of reviewing.
+
+[1]: https://sel4.systems/Contribute
+
+## Build/Test
+
+Generally, any contributions should pass the tests in the project
+<https://github.com/seL4/sel4test>. If new features or platforms are added,
+they should add corresponding tests in `sel4test`.
+
+Contributions to `master` should additionally either be invisible to the proof
+in <https://github.com/seL4/l4v>, such as comments, documentation, style,
+unverified platform, etc, or they should come with proof updates to `l4v`.
+
+## Contact
+
+If you have larger changes or additions, it is a good idea to get in contact
+with us as <devel@sel4.systems>, so we can help you get started.
+
+The people responsible for the technical direction, procedures, and quality
+control are the [Technical Steering Committee][2] (TSC) of the seL4
+foundation. You can contact them either on the developer mailing list or on
+directly via email available from their profile pages.
+
+[2]: https://sel4.systems/Foundation/TSC
+
+## Developer Certificate of Origin (DCO)
+
+This repository uses the same sign-off process as the Linux kernel. For every
+commit, use
+
+    git commit -s
+
+to add a sign-off line to your commit message, which will come out as:
+
+    Signed-off-by: name <email>
+
+By adding this line, you make the declaration that you have the right to make
+this contribution under the open source license the files use that you changed
+or contributed.
+
+The full text of the declaration is at <https://developercertificate.org>.

--- a/pristine/CONTRIBUTORS.md
+++ b/pristine/CONTRIBUTORS.md
@@ -1,0 +1,157 @@
+<!--
+     Copyright 2020 Data61, CSIRO (ABN 41 687 119 230)
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+Contributors
+============
+
+People who contributed to the seL4 code, design, or documentation in this
+repository (in alphabetical order).
+
+* Markku Ahvenjärvi, TII
+* Ali Akguel, NICTA
+* Hesham Almatary, Data61
+* June Andronick, Proofcraft, NICTA & UNSW
+* Ryan Barry, Proofcraft
+* Andy Bui, UNSW
+* Joel Beeren, NICTA
+* Bernard Blackham, NICTA & UNSW
+* Alexander Boettcher, Genode Labs
+* Timothy Bourke, NICTA
+* Andrew Boyton, NICTA & UNSW
+* G. Branden Robinson, Data61
+* Matthew Brassil, NICTA
+* Birgit Brecknell, seL4 Foundation, UNSW
+* Matthew Brecknell, Kry10, Data61
+* Jimmy Brush
+* Mitchell Buckley, Data61
+* Aleksander Budzynowski, NICTA & UNSW
+* Manuel Chakravarty, NICTA & UNSW
+* Xi Ma Chen, NICTA
+* Luca (Wei) Chen, Data61
+* Nahida Chowdhury, NICTA
+* Ahmed Charles
+* Peter Chubb, UNSW, NICTA, Data61
+* Jonas Claeson
+* David Cock, NICTA & UNSW
+* Adrian Danis, NICTA, Data61
+* Matthias Daum, NICTA & UNSW
+* Berkus Decker
+* Philip Derrin, NICTA
+* Kofi Doku Atuah, Data61
+* Dhammika Elkaduwe, NICTA & UNSW
+* Kevin Elphinstone, NICTA & UNSW
+* Alexander Fasching
+* Alison Felizzi, Data61
+* Matthew Fernandez, NICTA & UNSW, Data61
+* Peter Gammie, NICTA
+* Xin Gao, NICTA, Data61
+* Sylvain Gauthier, Data61
+* Alejandro Gomez-Londono, Data61
+* Lukas Graber, Hensoldt Cyber
+* David Greenaway, NICTA & UNSW
+* Matthew Grosvenor, NICTA
+* Karol Gugala, Antmicro
+* Chris Guikema, Dornerworks
+* Lukas Haenel, NICTA
+* Bao Haojun
+* Axel Heider, Codasip, Hensoldt Cyber
+* Gernot Heiser, NICTA & UNSW
+* Christian Helmuth, Genode Labs
+* Florian Hofhammer
+* Sebastian Holzapfel, Data61
+* Yu Hou
+* Peter S. Housel
+* Mark Jenkinson, Cap Gemini
+* Cao Jianlong
+* Alwin Joshy, UNSW
+* Robert Kaiser
+* Benjamin Kalman, NICTA
+* Felix Kam, NICTA
+* Justin King-Lacroix, NICTA
+* Gerwin Klein, Proofcraft, NICTA & UNSW, Data61
+* Rafal Kolanski, Proofcraft, NICTA & UNSW, Data61
+* Nataliya Korovkina
+* Alexander Kroh, NICTA
+* Ramana Kumar, Data61
+* Damon Lee, Kry10, Data61
+* Ben Leslie, Breakaway
+* Corey Lewis, Proofcraft, NICTA, Data61
+* Frank Li, Data61
+* Japheth Lim, NICTA, Data61
+* Chang Liu, Brown University
+* Cindy Liu
+* Jasper Lowell, Data61
+* Anna Lyons, NICTA & UNSW, Data61
+* Hannu Lyytinen, TII
+* Daniel Matichuk, NICTA & UNSW
+* Stephanie McArthur, NICTA
+* Craig McLaughlin, UNSW
+* Kent McLeod, Kry10, Data61
+* Michael McInerney, Proofcraft, UNSW
+* Sam McNally, NICTA
+* Bin Meng
+* Curtis Millar, Data61 & UNSW
+* Jesse Millwood, Dornerworks
+* Bruce Mitchener
+* Mathieu Mirmont
+* Luke Mondy, Data61
+* Toby Murray, NICTA & UNSW
+* Seiya Nuta
+* Tim Newsham
+* Joonas Onatsu, TII
+* Stefan O'Rear
+* Ameya Palande, NICTA
+* Max R.D. Parmer
+* Alex Pavey, Dornerworks
+* Thibaut Pérami, Data61
+* Jorge Pereira, TII
+* Sean Peters, NICTA
+* Victor Phan, Data61
+* Edward Pierzchalski, Data61
+* Matt Rice
+* Corey Richardson, Data61
+* Simon Rodgers, NICTA
+* Juan Pablo Ruiz, TII
+* Viktor Sannum
+* Wink Saville
+* Oliver Scott, Data61
+* Sean Seefried, NICTA
+* Thomas Sewell, NICTA & UNSW, Data61
+* Dan Shea
+* Yanyan Shen, NIO, Cog, Data61
+* Stephen Sherratt, NICTA, Data61
+* Simon Shields, Data61
+* Wojciech Sipak, Antmicro
+* Nick Spinale, Colias Group
+* Nathan Studer, Dornerworks
+* Jack Suann, Data61
+* Etienne Le Sueur, NICTA & UNSW
+* Partha Susarla, Data61
+* Miki Tanaka, Data61
+* Michael von Tessin, NICTA & UNSW
+* Klim Tsoutsman
+* Claudia Tu, UNSW
+* Ivan Velickovic, UNSW
+* Robbie Van Vossen, Dornerworks
+* Bertrand Virfollet
+* Adam Walker, NICTA
+* Jeff Waugh
+* Zhicheng Wei
+* James Wilmot, NICTA
+* Krishnan Winter, UNSW
+* Simon Winwood, NICTA
+* Marcin Witkowski, Antmicro
+* Addo Wondo, Data61
+* Jiawei Xie, NICTA
+* Donny Yang, Data61
+* Ilya Yanok
+* James Ye, Data61
+* Qiao Yongchang
+* Finn Zhang
+* Amirreza Zarrabi, Data61
+* Jingyao Zhou, UNSW, Data61
+* Siwei Zhuang, NICTA, Data61
+* Indan Zupancic, seL4 Foundation, MEP

--- a/pristine/LICENSE.md
+++ b/pristine/LICENSE.md
@@ -1,0 +1,31 @@
+<!--
+     Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# License
+
+The files in this repository are released under standard open source
+licenses, identified by [SPDX license tags][1]. Generally, kernel-level
+code is licensed under GPLv2 and user-level code under the 2-clause BSD
+license. See the individual file headers for details, or use one of the
+publicly available SPDX tools to generate a bill of materials. The
+directory `LICENSES` contains the text for all licenses that are
+mentioned by files in this repository.
+
+
+## GPL syscall note
+
+Note that, as in the [Linux syscall note for the GPL][2], the seL4
+kernel GPL license does *not* cover user-level code that uses kernel
+services by normal system calls - this is merely considered normal use
+of the kernel, and does *not* fall under the heading of "derived work".
+Syscall headers are provided under BSD.
+
+For a longer explanation of how the seL4 license does or does not affect
+your own code see also [the seL4 website][3].
+
+[1]: https://spdx.org
+[2]: https://spdx.org/licenses/Linux-syscall-note.html
+[3]: https://sel4.systems/Legal/license.html

--- a/pristine/LICENSES/Apache-2.0.txt
+++ b/pristine/LICENSES/Apache-2.0.txt
@@ -1,0 +1,208 @@
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/ TERMS AND CONDITIONS FOR USE, REPRODUCTION,
+AND DISTRIBUTION
+
+   1. Definitions.
+
+      
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution
+as defined by Sections 1 through 9 of this document.
+
+      
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+      
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct
+or indirect, to cause the direction or management of such entity, whether
+by contract or otherwise, or (ii) ownership of fifty percent (50%) or more
+of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+      
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions
+granted by this License.
+
+      
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+      
+
+"Object" form shall mean any form resulting from mechanical transformation
+or translation of a Source form, including but not limited to compiled object
+code, generated documentation, and conversions to other media types.
+
+      
+
+"Work" shall mean the work of authorship, whether in Source or Object form,
+made available under the License, as indicated by a copyright notice that
+is included in or attached to the work (an example is provided in the Appendix
+below).
+
+      
+
+"Derivative Works" shall mean any work, whether in Source or Object form,
+that is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative
+Works shall not include works that remain separable from, or merely link (or
+bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+      
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative
+Works thereof, that is intentionally submitted to Licensor for inclusion in
+the Work by the copyright owner or by an individual or Legal Entity authorized
+to submit on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication
+sent to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor
+for the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+      
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently incorporated
+within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable copyright license to reproduce, prepare
+Derivative Works of, publicly display, publicly perform, sublicense, and distribute
+the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License,
+each Contributor hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section) patent
+license to make, have made, use, offer to sell, sell, import, and otherwise
+transfer the Work, where such license applies only to those patent claims
+licensable by such Contributor that are necessarily infringed by their Contribution(s)
+alone or by combination of their Contribution(s) with the Work to which such
+Contribution(s) was submitted. If You institute patent litigation against
+any entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that the Work or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses granted to You
+under this License for that Work shall terminate as of the date such litigation
+is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or
+Derivative Works thereof in any medium, with or without modifications, and
+in Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy
+of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that
+You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source
+form of the Work, excluding those notices that do not pertain to any part
+of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution,
+then any Derivative Works that You distribute must include a readable copy
+of the attribution notices contained within such NOTICE file, excluding those
+notices that do not pertain to any part of the Derivative Works, in at least
+one of the following places: within a NOTICE text file distributed as part
+of the Derivative Works; within the Source form or documentation, if provided
+along with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works
+that You distribute, alongside or as an addendum to the NOTICE text from the
+Work, provided that such additional attribution notices cannot be construed
+as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction,
+or distribution of Your modifications, or for any such Derivative Works as
+a whole, provided Your use, reproduction, and distribution of the Work otherwise
+complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any
+Contribution intentionally submitted for inclusion in the Work by You to the
+Licensor shall be under the terms and conditions of this License, without
+any additional terms or conditions. Notwithstanding the above, nothing herein
+shall supersede or modify the terms of any separate license agreement you
+may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names,
+trademarks, service marks, or product names of the Licensor, except as required
+for reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to
+in writing, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied, including, without limitation, any warranties
+or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR
+A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness
+of using or redistributing the Work and assume any risks associated with Your
+exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether
+in tort (including negligence), contract, or otherwise, unless required by
+applicable law (such as deliberate and grossly negligent acts) or agreed to
+in writing, shall any Contributor be liable to You for damages, including
+any direct, indirect, special, incidental, or consequential damages of any
+character arising as a result of this License or out of the use or inability
+to use the Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all other commercial
+damages or losses), even if such Contributor has been advised of the possibility
+of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work
+or Derivative Works thereof, You may choose to offer, and charge a fee for,
+acceptance of support, warranty, indemnity, or other liability obligations
+and/or rights consistent with this License. However, in accepting such obligations,
+You may act only on Your own behalf and on Your sole responsibility, not on
+behalf of any other Contributor, and only if You agree to indemnify, defend,
+and hold each Contributor harmless for any liability incurred by, or claims
+asserted against, such Contributor by reason of your accepting any such warranty
+or additional liability. END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own identifying
+information. (Don't include the brackets!) The text should be enclosed in
+the appropriate comment syntax for the file format. We also recommend that
+a file or class name and description of purpose be included on the same "printed
+page" as the copyright notice for easier identification within third-party
+archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+
+distributed under the License is distributed on an "AS IS" BASIS,
+
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+
+limitations under the License.

--- a/pristine/LICENSES/BSD-2-Clause.txt
+++ b/pristine/LICENSES/BSD-2-Clause.txt
@@ -1,0 +1,22 @@
+Copyright (c) <year> <owner>. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pristine/LICENSES/BSD-3-Clause.txt
+++ b/pristine/LICENSES/BSD-3-Clause.txt
@@ -1,0 +1,26 @@
+Copyright (c) <year> <owner>. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pristine/LICENSES/CC-BY-SA-4.0.txt
+++ b/pristine/LICENSES/CC-BY-SA-4.0.txt
@@ -1,0 +1,350 @@
+Creative Commons Attribution-ShareAlike 4.0 International Creative Commons
+Corporation ("Creative Commons") is not a law firm and does not provide legal
+services or legal advice. Distribution of Creative Commons public licenses
+does not create a lawyer-client or other relationship. Creative Commons makes
+its licenses and related information available on an "as-is" basis. Creative
+Commons gives no warranties regarding its licenses, any material licensed
+under their terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the fullest
+extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and conditions
+that creators and other rights holders may use to share original works of
+authorship and other material subject to copyright and certain other rights
+specified in the public license below. The following considerations are for
+informational purposes only, are not exhaustive, and do not form part of our
+licenses.
+
+Considerations for licensors: Our public licenses are intended for use by
+those authorized to give the public permission to use material in ways otherwise
+restricted by copyright and certain other rights. Our licenses are irrevocable.
+Licensors should read and understand the terms and conditions of the license
+they choose before applying it. Licensors should also secure all rights necessary
+before applying our licenses so that the public can reuse the material as
+expected. Licensors should clearly mark any material not subject to the license.
+This includes other CC-licensed material, or material used under an exception
+or limitation to copyright. More considerations for licensors : wiki.creativecommons.org/Considerations_for_licensors
+
+Considerations for the public: By using one of our public licenses, a licensor
+grants the public permission to use the licensed material under specified
+terms and conditions. If the licensor's permission is not necessary for any
+reason–for example, because of any applicable exception or limitation to copyright–then
+that use is not regulated by the license. Our licenses grant only permissions
+under copyright and certain other rights that a licensor has authority to
+grant. Use of the licensed material may still be restricted for other reasons,
+including because others have copyright or other rights in the material. A
+licensor may make special requests, such as asking that all changes be marked
+or described.
+
+Although not required by our licenses, you are encouraged to respect those
+requests where reasonable. More considerations for the public : wiki.creativecommons.org/Considerations_for_licensees
+
+Creative Commons Attribution-ShareAlike 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree to
+be bound by the terms and conditions of this Creative Commons Attribution-ShareAlike
+4.0 International Public License ("Public License"). To the extent this Public
+License may be interpreted as a contract, You are granted the Licensed Rights
+in consideration of Your acceptance of these terms and conditions, and the
+Licensor grants You such rights in consideration of benefits the Licensor
+receives from making the Licensed Material available under these terms and
+conditions.
+
+Section 1 – Definitions.
+
+a. Adapted Material means material subject to Copyright and Similar Rights
+that is derived from or based upon the Licensed Material and in which the
+Licensed Material is translated, altered, arranged, transformed, or otherwise
+modified in a manner requiring permission under the Copyright and Similar
+Rights held by the Licensor. For purposes of this Public License, where the
+Licensed Material is a musical work, performance, or sound recording, Adapted
+Material is always produced where the Licensed Material is synched in timed
+relation with a moving image.
+
+b. Adapter's License means the license You apply to Your Copyright and Similar
+Rights in Your contributions to Adapted Material in accordance with the terms
+and conditions of this Public License.
+
+c. BY-SA Compatible License means a license listed at creativecommons.org/compatiblelicenses,
+approved by Creative Commons as essentially the equivalent of this Public
+License.
+
+d. Copyright and Similar Rights means copyright and/or similar rights closely
+related to copyright including, without limitation, performance, broadcast,
+sound recording, and Sui Generis Database Rights, without regard to how the
+rights are labeled or categorized. For purposes of this Public License, the
+rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+e. Effective Technological Measures means those measures that, in the absence
+of proper authority, may not be circumvented under laws fulfilling obligations
+under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996,
+and/or similar international agreements.
+
+f. Exceptions and Limitations means fair use, fair dealing, and/or any other
+exception or limitation to Copyright and Similar Rights that applies to Your
+use of the Licensed Material.
+
+g. License Elements means the license attributes listed in the name of a Creative
+Commons Public License. The License Elements of this Public License are Attribution
+and ShareAlike.
+
+h. Licensed Material means the artistic or literary work, database, or other
+material to which the Licensor applied this Public License.
+
+i. Licensed Rights means the rights granted to You subject to the terms and
+conditions of this Public License, which are limited to all Copyright and
+Similar Rights that apply to Your use of the Licensed Material and that the
+Licensor has authority to license.
+
+j. Licensor means the individual(s) or entity(ies) granting rights under this
+Public License.
+
+k. Share means to provide material to the public by any means or process that
+requires permission under the Licensed Rights, such as reproduction, public
+display, public performance, distribution, dissemination, communication, or
+importation, and to make material available to the public including in ways
+that members of the public may access the material from a place and at a time
+individually chosen by them.
+
+l. Sui Generis Database Rights means rights other than copyright resulting
+from Directive 96/9/EC of the European Parliament and of the Council of 11
+March 1996 on the legal protection of databases, as amended and/or succeeded,
+as well as other essentially equivalent rights anywhere in the world.
+
+m. You means the individual or entity exercising the Licensed Rights under
+this Public License. Your has a corresponding meaning.
+
+Section 2 – Scope.
+
+   a. License grant.
+
+1. Subject to the terms and conditions of this Public License, the Licensor
+hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive,
+irrevocable license to exercise the Licensed Rights in the Licensed Material
+to:
+
+         A. reproduce and Share the Licensed Material, in whole or in part; and
+
+         B. produce, reproduce, and Share Adapted Material.
+
+2. Exceptions and Limitations. For the avoidance of doubt, where Exceptions
+and Limitations apply to Your use, this Public License does not apply, and
+You do not need to comply with its terms and conditions.
+
+      3. Term. The term of this Public License is specified in Section 6(a).
+
+4. Media and formats; technical modifications allowed. The Licensor authorizes
+You to exercise the Licensed Rights in all media and formats whether now known
+or hereafter created, and to make technical modifications necessary to do
+so. The Licensor waives and/or agrees not to assert any right or authority
+to forbid You from making technical modifications necessary to exercise the
+Licensed Rights, including technical modifications necessary to circumvent
+Effective Technological Measures. For purposes of this Public License, simply
+making modifications authorized by this Section 2(a)(4) never produces Adapted
+Material.
+
+      5. Downstream recipients.
+
+A. Offer from the Licensor – Licensed Material. Every recipient of the Licensed
+Material automatically receives an offer from the Licensor to exercise the
+Licensed Rights under the terms and conditions of this Public License.
+
+B. Additional offer from the Licensor – Adapted Material. Every recipient
+of Adapted Material from You automatically receives an offer from the Licensor
+to exercise the Licensed Rights in the Adapted Material under the conditions
+of the Adapter's License You apply.
+
+C. No downstream restrictions. You may not offer or impose any additional
+or different terms or conditions on, or apply any Effective Technological
+Measures to, the Licensed Material if doing so restricts exercise of the Licensed
+Rights by any recipient of the Licensed Material.
+
+6. No endorsement. Nothing in this Public License constitutes or may be construed
+as permission to assert or imply that You are, or that Your use of the Licensed
+Material is, connected with, or sponsored, endorsed, or granted official status
+by, the Licensor or others designated to receive attribution as provided in
+Section 3(a)(1)(A)(i).
+
+   b. Other rights.
+
+1. Moral rights, such as the right of integrity, are not licensed under this
+Public License, nor are publicity, privacy, and/or other similar personality
+rights; however, to the extent possible, the Licensor waives and/or agrees
+not to assert any such rights held by the Licensor to the limited extent necessary
+to allow You to exercise the Licensed Rights, but not otherwise.
+
+2. Patent and trademark rights are not licensed under this Public License.
+
+3. To the extent possible, the Licensor waives any right to collect royalties
+from You for the exercise of the Licensed Rights, whether directly or through
+a collecting society under any voluntary or waivable statutory or compulsory
+licensing scheme. In all other cases the Licensor expressly reserves any right
+to collect such royalties.
+
+Section 3 – License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the following
+conditions.
+
+   a. Attribution.
+
+1. If You Share the Licensed Material (including in modified form), You must:
+
+A. retain the following if it is supplied by the Licensor with the Licensed
+Material:
+
+i. identification of the creator(s) of the Licensed Material and any others
+designated to receive attribution, in any reasonable manner requested by the
+Licensor (including by pseudonym if designated);
+
+            ii. a copyright notice;
+
+            iii. a notice that refers to this Public License;
+
+            iv. a notice that refers to the disclaimer of warranties;
+
+v. a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+
+B. indicate if You modified the Licensed Material and retain an indication
+of any previous modifications; and
+
+C. indicate the Licensed Material is licensed under this Public License, and
+include the text of, or the URI or hyperlink to, this Public License.
+
+2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner
+based on the medium, means, and context in which You Share the Licensed Material.
+For example, it may be reasonable to satisfy the conditions by providing a
+URI or hyperlink to a resource that includes the required information.
+
+3. If requested by the Licensor, You must remove any of the information required
+by Section 3(a)(1)(A) to the extent reasonably practicable.
+
+b. ShareAlike.In addition to the conditions in Section 3(a), if You Share
+Adapted Material You produce, the following conditions also apply.
+
+1. The Adapter's License You apply must be a Creative Commons license with
+the same License Elements, this version or later, or a BY-SA Compatible License.
+
+2. You must include the text of, or the URI or hyperlink to, the Adapter's
+License You apply. You may satisfy this condition in any reasonable manner
+based on the medium, means, and context in which You Share Adapted Material.
+
+3. You may not offer or impose any additional or different terms or conditions
+on, or apply any Effective Technological Measures to, Adapted Material that
+restrict exercise of the rights granted under the Adapter's License You apply.
+
+Section 4 – Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that apply to
+Your use of the Licensed Material:
+
+a. for the avoidance of doubt, Section 2(a)(1) grants You the right to extract,
+reuse, reproduce, and Share all or a substantial portion of the contents of
+the database;
+
+b. if You include all or a substantial portion of the database contents in
+a database in which You have Sui Generis Database Rights, then the database
+in which You have Sui Generis Database Rights (but not its individual contents)
+is Adapted Material, including for purposes of Section 3(b); and
+
+c. You must comply with the conditions in Section 3(a) if You Share all or
+a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not replace
+Your obligations under this Public License where the Licensed Rights include
+other Copyright and Similar Rights.
+
+Section 5 – Disclaimer of Warranties and Limitation of Liability.
+
+a. Unless otherwise separately undertaken by the Licensor, to the extent possible,
+the Licensor offers the Licensed Material as-is and as-available, and makes
+no representations or warranties of any kind concerning the Licensed Material,
+whether express, implied, statutory, or other. This includes, without limitation,
+warranties of title, merchantability, fitness for a particular purpose, non-infringement,
+absence of latent or other defects, accuracy, or the presence or absence of
+errors, whether or not known or discoverable. Where disclaimers of warranties
+are not allowed in full or in part, this disclaimer may not apply to You.
+
+b. To the extent possible, in no event will the Licensor be liable to You
+on any legal theory (including, without limitation, negligence) or otherwise
+for any direct, special, indirect, incidental, consequential, punitive, exemplary,
+or other losses, costs, expenses, or damages arising out of this Public License
+or use of the Licensed Material, even if the Licensor has been advised of
+the possibility of such losses, costs, expenses, or damages. Where a limitation
+of liability is not allowed in full or in part, this limitation may not apply
+to You.
+
+c. The disclaimer of warranties and limitation of liability provided above
+shall be interpreted in a manner that, to the extent possible, most closely
+approximates an absolute disclaimer and waiver of all liability.
+
+Section 6 – Term and Termination.
+
+a. This Public License applies for the term of the Copyright and Similar Rights
+licensed here. However, if You fail to comply with this Public License, then
+Your rights under this Public License terminate automatically.
+
+b. Where Your right to use the Licensed Material has terminated under Section
+6(a), it reinstates:
+
+1. automatically as of the date the violation is cured, provided it is cured
+within 30 days of Your discovery of the violation; or
+
+      2. upon express reinstatement by the Licensor.
+
+c. For the avoidance of doubt, this Section 6(b) does not affect any right
+the Licensor may have to seek remedies for Your violations of this Public
+License.
+
+d. For the avoidance of doubt, the Licensor may also offer the Licensed Material
+under separate terms or conditions or stop distributing the Licensed Material
+at any time; however, doing so will not terminate this Public License.
+
+   e. Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
+
+Section 7 – Other Terms and Conditions.
+
+a. The Licensor shall not be bound by any additional or different terms or
+conditions communicated by You unless expressly agreed.
+
+b. Any arrangements, understandings, or agreements regarding the Licensed
+Material not stated herein are separate from and independent of the terms
+and conditions of this Public License.
+
+Section 8 – Interpretation.
+
+a. For the avoidance of doubt, this Public License does not, and shall not
+be interpreted to, reduce, limit, restrict, or impose conditions on any use
+of the Licensed Material that could lawfully be made without permission under
+this Public License.
+
+b. To the extent possible, if any provision of this Public License is deemed
+unenforceable, it shall be automatically reformed to the minimum extent necessary
+to make it enforceable. If the provision cannot be reformed, it shall be severed
+from this Public License without affecting the enforceability of the remaining
+terms and conditions.
+
+c. No term or condition of this Public License will be waived and no failure
+to comply consented to unless expressly agreed to by the Licensor.
+
+d. Nothing in this Public License constitutes or may be interpreted as a limitation
+upon, or waiver of, any privileges and immunities that apply to the Licensor
+or You, including from the legal processes of any jurisdiction or authority.
+
+Creative Commons is not a party to its public licenses. Notwithstanding, Creative
+Commons may elect to apply one of its public licenses to material it publishes
+and in those instances will be considered the "Licensor." The text of the
+Creative Commons public licenses is dedicated to the public domain under the
+CC0 Public Domain Dedication. Except for the limited purpose of indicating
+that material is shared under a Creative Commons public license or as otherwise
+permitted by the Creative Commons policies published at creativecommons.org/policies,
+Creative Commons does not authorize the use of the trademark "Creative Commons"
+or any other trademark or logo of Creative Commons without its prior written
+consent including, without limitation, in connection with any unauthorized
+modifications to any of its public licenses or any other arrangements, understandings,
+or agreements concerning use of licensed material. For the avoidance of doubt,
+this paragraph does not form part of the public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/pristine/LICENSES/GPL-2.0-only.txt
+++ b/pristine/LICENSES/GPL-2.0-only.txt
@@ -1,0 +1,319 @@
+GNU GENERAL PUBLIC LICENSE
+
+Version 2, June 1991
+
+Copyright (C) 1989, 1991 Free Software Foundation, Inc. 
+
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
+Everyone is permitted to copy and distribute verbatim copies of this license
+document, but changing it is not allowed.
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share
+and change it. By contrast, the GNU General Public License is intended to
+guarantee your freedom to share and change free software--to make sure the
+software is free for all its users. This General Public License applies to
+most of the Free Software Foundation's software and to any other program whose
+authors commit to using it. (Some other Free Software Foundation software
+is covered by the GNU Lesser General Public License instead.) You can apply
+it to your programs, too.
+
+When we speak of free software, we are referring to freedom, not price. Our
+General Public Licenses are designed to make sure that you have the freedom
+to distribute copies of free software (and charge for this service if you
+wish), that you receive source code or can get it if you want it, that you
+can change the software or use pieces of it in new free programs; and that
+you know you can do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to
+deny you these rights or to ask you to surrender the rights. These restrictions
+translate to certain responsibilities for you if you distribute copies of
+the software, or if you modify it.
+
+For example, if you distribute copies of such a program, whether gratis or
+for a fee, you must give the recipients all the rights that you have. You
+must make sure that they, too, receive or can get the source code. And you
+must show them these terms so they know their rights.
+
+We protect your rights with two steps: (1) copyright the software, and (2)
+offer you this license which gives you legal permission to copy, distribute
+and/or modify the software.
+
+Also, for each author's protection and ours, we want to make certain that
+everyone understands that there is no warranty for this free software. If
+the software is modified by someone else and passed on, we want its recipients
+to know that what they have is not the original, so that any problems introduced
+by others will not reflect on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software patents. We
+wish to avoid the danger that redistributors of a free program will individually
+obtain patent licenses, in effect making the program proprietary. To prevent
+this, we have made it clear that any patent must be licensed for everyone's
+free use or not licensed at all.
+
+The precise terms and conditions for copying, distribution and modification
+follow.
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License applies to any program or other work which contains a notice
+placed by the copyright holder saying it may be distributed under the terms
+of this General Public License. The "Program", below, refers to any such program
+or work, and a "work based on the Program" means either the Program or any
+derivative work under copyright law: that is to say, a work containing the
+Program or a portion of it, either verbatim or with modifications and/or translated
+into another language. (Hereinafter, translation is included without limitation
+in the term "modification".) Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not covered
+by this License; they are outside its scope. The act of running the Program
+is not restricted, and the output from the Program is covered only if its
+contents constitute a work based on the Program (independent of having been
+made by running the Program). Whether that is true depends on what the Program
+does.
+
+1. You may copy and distribute verbatim copies of the Program's source code
+as you receive it, in any medium, provided that you conspicuously and appropriately
+publish on each copy an appropriate copyright notice and disclaimer of warranty;
+keep intact all the notices that refer to this License and to the absence
+of any warranty; and give any other recipients of the Program a copy of this
+License along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and you
+may at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Program or any portion of it,
+thus forming a work based on the Program, and copy and distribute such modifications
+or work under the terms of Section 1 above, provided that you also meet all
+of these conditions:
+
+a) You must cause the modified files to carry prominent notices stating that
+you changed the files and the date of any change.
+
+b) You must cause any work that you distribute or publish, that in whole or
+in part contains or is derived from the Program or any part thereof, to be
+licensed as a whole at no charge to all third parties under the terms of this
+License.
+
+c) If the modified program normally reads commands interactively when run,
+you must cause it, when started running for such interactive use in the most
+ordinary way, to print or display an announcement including an appropriate
+copyright notice and a notice that there is no warranty (or else, saying that
+you provide a warranty) and that users may redistribute the program under
+these conditions, and telling the user how to view a copy of this License.
+(Exception: if the Program itself is interactive but does not normally print
+such an announcement, your work based on the Program is not required to print
+an announcement.)
+
+These requirements apply to the modified work as a whole. If identifiable
+sections of that work are not derived from the Program, and can be reasonably
+considered independent and separate works in themselves, then this License,
+and its terms, do not apply to those sections when you distribute them as
+separate works. But when you distribute the same sections as part of a whole
+which is a work based on the Program, the distribution of the whole must be
+on the terms of this License, whose permissions for other licensees extend
+to the entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest your
+rights to work written entirely by you; rather, the intent is to exercise
+the right to control the distribution of derivative or collective works based
+on the Program.
+
+In addition, mere aggregation of another work not based on the Program with
+the Program (or with a work based on the Program) on a volume of a storage
+or distribution medium does not bring the other work under the scope of this
+License.
+
+3. You may copy and distribute the Program (or a work based on it, under Section
+2) in object code or executable form under the terms of Sections 1 and 2 above
+provided that you also do one of the following:
+
+a) Accompany it with the complete corresponding machine-readable source code,
+which must be distributed under the terms of Sections 1 and 2 above on a medium
+customarily used for software interchange; or,
+
+b) Accompany it with a written offer, valid for at least three years, to give
+any third party, for a charge no more than your cost of physically performing
+source distribution, a complete machine-readable copy of the corresponding
+source code, to be distributed under the terms of Sections 1 and 2 above on
+a medium customarily used for software interchange; or,
+
+c) Accompany it with the information you received as to the offer to distribute
+corresponding source code. (This alternative is allowed only for noncommercial
+distribution and only if you received the program in object code or executable
+form with such an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for making
+modifications to it. For an executable work, complete source code means all
+the source code for all modules it contains, plus any associated interface
+definition files, plus the scripts used to control compilation and installation
+of the executable. However, as a special exception, the source code distributed
+need not include anything that is normally distributed (in either source or
+binary form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component itself
+accompanies the executable.
+
+If distribution of executable or object code is made by offering access to
+copy from a designated place, then offering equivalent access to copy the
+source code from the same place counts as distribution of the source code,
+even though third parties are not compelled to copy the source along with
+the object code.
+
+4. You may not copy, modify, sublicense, or distribute the Program except
+as expressly provided under this License. Any attempt otherwise to copy, modify,
+sublicense or distribute the Program is void, and will automatically terminate
+your rights under this License. However, parties who have received copies,
+or rights, from you under this License will not have their licenses terminated
+so long as such parties remain in full compliance.
+
+5. You are not required to accept this License, since you have not signed
+it. However, nothing else grants you permission to modify or distribute the
+Program or its derivative works. These actions are prohibited by law if you
+do not accept this License. Therefore, by modifying or distributing the Program
+(or any work based on the Program), you indicate your acceptance of this License
+to do so, and all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+6. Each time you redistribute the Program (or any work based on the Program),
+the recipient automatically receives a license from the original licensor
+to copy, distribute or modify the Program subject to these terms and conditions.
+You may not impose any further restrictions on the recipients' exercise of
+the rights granted herein. You are not responsible for enforcing compliance
+by third parties to this License.
+
+7. If, as a consequence of a court judgment or allegation of patent infringement
+or for any other reason (not limited to patent issues), conditions are imposed
+on you (whether by court order, agreement or otherwise) that contradict the
+conditions of this License, they do not excuse you from the conditions of
+this License. If you cannot distribute so as to satisfy simultaneously your
+obligations under this License and any other pertinent obligations, then as
+a consequence you may not distribute the Program at all. For example, if a
+patent license would not permit royalty-free redistribution of the Program
+by all those who receive copies directly or indirectly through you, then the
+only way you could satisfy both it and this License would be to refrain entirely
+from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply and
+the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents
+or other property right claims or to contest validity of any such claims;
+this section has the sole purpose of protecting the integrity of the free
+software distribution system, which is implemented by public license practices.
+Many people have made generous contributions to the wide range of software
+distributed through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing to
+distribute software through any other system and a licensee cannot impose
+that choice.
+
+This section is intended to make thoroughly clear what is believed to be a
+consequence of the rest of this License.
+
+8. If the distribution and/or use of the Program is restricted in certain
+countries either by patents or by copyrighted interfaces, the original copyright
+holder who places the Program under this License may add an explicit geographical
+distribution limitation excluding those countries, so that distribution is
+permitted only in or among countries not thus excluded. In such case, this
+License incorporates the limitation as if written in the body of this License.
+
+9. The Free Software Foundation may publish revised and/or new versions of
+the General Public License from time to time. Such new versions will be similar
+in spirit to the present version, but may differ in detail to address new
+problems or concerns.
+
+Each version is given a distinguishing version number. If the Program specifies
+a version number of this License which applies to it and "any later version",
+you have the option of following the terms and conditions either of that version
+or of any later version published by the Free Software Foundation. If the
+Program does not specify a version number of this License, you may choose
+any version ever published by the Free Software Foundation.
+
+10. If you wish to incorporate parts of the Program into other free programs
+whose distribution conditions are different, write to the author to ask for
+permission. For software which is copyrighted by the Free Software Foundation,
+write to the Free Software Foundation; we sometimes make exceptions for this.
+Our decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing and reuse
+of software generally.
+
+   NO WARRANTY
+
+11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR
+THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE
+STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM
+"AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE
+OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE
+OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA
+OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES
+OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH
+HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible
+use to the public, the best way to achieve this is to make it free software
+which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program. It is safest to attach
+them to the start of each source file to most effectively convey the exclusion
+of warranty; and each file should have at least the "copyright" line and a
+pointer to where the full notice is found.
+
+<one line to give the program's name and an idea of what it does.>
+
+Copyright (C)< yyyy> <name of author>
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation; either version 2 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this when
+it starts in an interactive mode:
+
+Gnomovision version 69, Copyright (C) year name of author Gnomovision comes
+with ABSOLUTELY NO WARRANTY; for details type `show w'. This is free software,
+and you are welcome to redistribute it under certain conditions; type `show
+c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License. Of course, the commands you use may be
+called something other than `show w' and `show c'; they could even be mouse-clicks
+or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your school,
+if any, to sign a "copyright disclaimer" for the program, if necessary. Here
+is a sample; alter the names:
+
+Yoyodyne, Inc., hereby disclaims all copyright interest in the program `Gnomovision'
+(which makes passes at compilers) written by James Hacker.
+
+<signature of Ty Coon >, 1 April 1989 Ty Coon, President of Vice This General
+Public License does not permit incorporating your program into proprietary
+programs. If your program is a subroutine library, you may consider it more
+useful to permit linking proprietary applications with the library. If this
+is what you want to do, use the GNU Lesser General Public License instead
+of this License.

--- a/pristine/LICENSES/GPL-2.0-or-later.txt
+++ b/pristine/LICENSES/GPL-2.0-or-later.txt
@@ -1,0 +1,319 @@
+GNU GENERAL PUBLIC LICENSE
+
+Version 2, June 1991
+
+Copyright (C) 1989, 1991 Free Software Foundation, Inc. 
+
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
+Everyone is permitted to copy and distribute verbatim copies of this license
+document, but changing it is not allowed.
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share
+and change it. By contrast, the GNU General Public License is intended to
+guarantee your freedom to share and change free software--to make sure the
+software is free for all its users. This General Public License applies to
+most of the Free Software Foundation's software and to any other program whose
+authors commit to using it. (Some other Free Software Foundation software
+is covered by the GNU Lesser General Public License instead.) You can apply
+it to your programs, too.
+
+When we speak of free software, we are referring to freedom, not price. Our
+General Public Licenses are designed to make sure that you have the freedom
+to distribute copies of free software (and charge for this service if you
+wish), that you receive source code or can get it if you want it, that you
+can change the software or use pieces of it in new free programs; and that
+you know you can do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to
+deny you these rights or to ask you to surrender the rights. These restrictions
+translate to certain responsibilities for you if you distribute copies of
+the software, or if you modify it.
+
+For example, if you distribute copies of such a program, whether gratis or
+for a fee, you must give the recipients all the rights that you have. You
+must make sure that they, too, receive or can get the source code. And you
+must show them these terms so they know their rights.
+
+We protect your rights with two steps: (1) copyright the software, and (2)
+offer you this license which gives you legal permission to copy, distribute
+and/or modify the software.
+
+Also, for each author's protection and ours, we want to make certain that
+everyone understands that there is no warranty for this free software. If
+the software is modified by someone else and passed on, we want its recipients
+to know that what they have is not the original, so that any problems introduced
+by others will not reflect on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software patents. We
+wish to avoid the danger that redistributors of a free program will individually
+obtain patent licenses, in effect making the program proprietary. To prevent
+this, we have made it clear that any patent must be licensed for everyone's
+free use or not licensed at all.
+
+The precise terms and conditions for copying, distribution and modification
+follow.
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License applies to any program or other work which contains a notice
+placed by the copyright holder saying it may be distributed under the terms
+of this General Public License. The "Program", below, refers to any such program
+or work, and a "work based on the Program" means either the Program or any
+derivative work under copyright law: that is to say, a work containing the
+Program or a portion of it, either verbatim or with modifications and/or translated
+into another language. (Hereinafter, translation is included without limitation
+in the term "modification".) Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not covered
+by this License; they are outside its scope. The act of running the Program
+is not restricted, and the output from the Program is covered only if its
+contents constitute a work based on the Program (independent of having been
+made by running the Program). Whether that is true depends on what the Program
+does.
+
+1. You may copy and distribute verbatim copies of the Program's source code
+as you receive it, in any medium, provided that you conspicuously and appropriately
+publish on each copy an appropriate copyright notice and disclaimer of warranty;
+keep intact all the notices that refer to this License and to the absence
+of any warranty; and give any other recipients of the Program a copy of this
+License along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and you
+may at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Program or any portion of it,
+thus forming a work based on the Program, and copy and distribute such modifications
+or work under the terms of Section 1 above, provided that you also meet all
+of these conditions:
+
+a) You must cause the modified files to carry prominent notices stating that
+you changed the files and the date of any change.
+
+b) You must cause any work that you distribute or publish, that in whole or
+in part contains or is derived from the Program or any part thereof, to be
+licensed as a whole at no charge to all third parties under the terms of this
+License.
+
+c) If the modified program normally reads commands interactively when run,
+you must cause it, when started running for such interactive use in the most
+ordinary way, to print or display an announcement including an appropriate
+copyright notice and a notice that there is no warranty (or else, saying that
+you provide a warranty) and that users may redistribute the program under
+these conditions, and telling the user how to view a copy of this License.
+(Exception: if the Program itself is interactive but does not normally print
+such an announcement, your work based on the Program is not required to print
+an announcement.)
+
+These requirements apply to the modified work as a whole. If identifiable
+sections of that work are not derived from the Program, and can be reasonably
+considered independent and separate works in themselves, then this License,
+and its terms, do not apply to those sections when you distribute them as
+separate works. But when you distribute the same sections as part of a whole
+which is a work based on the Program, the distribution of the whole must be
+on the terms of this License, whose permissions for other licensees extend
+to the entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest your
+rights to work written entirely by you; rather, the intent is to exercise
+the right to control the distribution of derivative or collective works based
+on the Program.
+
+In addition, mere aggregation of another work not based on the Program with
+the Program (or with a work based on the Program) on a volume of a storage
+or distribution medium does not bring the other work under the scope of this
+License.
+
+3. You may copy and distribute the Program (or a work based on it, under Section
+2) in object code or executable form under the terms of Sections 1 and 2 above
+provided that you also do one of the following:
+
+a) Accompany it with the complete corresponding machine-readable source code,
+which must be distributed under the terms of Sections 1 and 2 above on a medium
+customarily used for software interchange; or,
+
+b) Accompany it with a written offer, valid for at least three years, to give
+any third party, for a charge no more than your cost of physically performing
+source distribution, a complete machine-readable copy of the corresponding
+source code, to be distributed under the terms of Sections 1 and 2 above on
+a medium customarily used for software interchange; or,
+
+c) Accompany it with the information you received as to the offer to distribute
+corresponding source code. (This alternative is allowed only for noncommercial
+distribution and only if you received the program in object code or executable
+form with such an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for making
+modifications to it. For an executable work, complete source code means all
+the source code for all modules it contains, plus any associated interface
+definition files, plus the scripts used to control compilation and installation
+of the executable. However, as a special exception, the source code distributed
+need not include anything that is normally distributed (in either source or
+binary form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component itself
+accompanies the executable.
+
+If distribution of executable or object code is made by offering access to
+copy from a designated place, then offering equivalent access to copy the
+source code from the same place counts as distribution of the source code,
+even though third parties are not compelled to copy the source along with
+the object code.
+
+4. You may not copy, modify, sublicense, or distribute the Program except
+as expressly provided under this License. Any attempt otherwise to copy, modify,
+sublicense or distribute the Program is void, and will automatically terminate
+your rights under this License. However, parties who have received copies,
+or rights, from you under this License will not have their licenses terminated
+so long as such parties remain in full compliance.
+
+5. You are not required to accept this License, since you have not signed
+it. However, nothing else grants you permission to modify or distribute the
+Program or its derivative works. These actions are prohibited by law if you
+do not accept this License. Therefore, by modifying or distributing the Program
+(or any work based on the Program), you indicate your acceptance of this License
+to do so, and all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+6. Each time you redistribute the Program (or any work based on the Program),
+the recipient automatically receives a license from the original licensor
+to copy, distribute or modify the Program subject to these terms and conditions.
+You may not impose any further restrictions on the recipients' exercise of
+the rights granted herein. You are not responsible for enforcing compliance
+by third parties to this License.
+
+7. If, as a consequence of a court judgment or allegation of patent infringement
+or for any other reason (not limited to patent issues), conditions are imposed
+on you (whether by court order, agreement or otherwise) that contradict the
+conditions of this License, they do not excuse you from the conditions of
+this License. If you cannot distribute so as to satisfy simultaneously your
+obligations under this License and any other pertinent obligations, then as
+a consequence you may not distribute the Program at all. For example, if a
+patent license would not permit royalty-free redistribution of the Program
+by all those who receive copies directly or indirectly through you, then the
+only way you could satisfy both it and this License would be to refrain entirely
+from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply and
+the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents
+or other property right claims or to contest validity of any such claims;
+this section has the sole purpose of protecting the integrity of the free
+software distribution system, which is implemented by public license practices.
+Many people have made generous contributions to the wide range of software
+distributed through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing to
+distribute software through any other system and a licensee cannot impose
+that choice.
+
+This section is intended to make thoroughly clear what is believed to be a
+consequence of the rest of this License.
+
+8. If the distribution and/or use of the Program is restricted in certain
+countries either by patents or by copyrighted interfaces, the original copyright
+holder who places the Program under this License may add an explicit geographical
+distribution limitation excluding those countries, so that distribution is
+permitted only in or among countries not thus excluded. In such case, this
+License incorporates the limitation as if written in the body of this License.
+
+9. The Free Software Foundation may publish revised and/or new versions of
+the General Public License from time to time. Such new versions will be similar
+in spirit to the present version, but may differ in detail to address new
+problems or concerns.
+
+Each version is given a distinguishing version number. If the Program specifies
+a version number of this License which applies to it and "any later version",
+you have the option of following the terms and conditions either of that version
+or of any later version published by the Free Software Foundation. If the
+Program does not specify a version number of this License, you may choose
+any version ever published by the Free Software Foundation.
+
+10. If you wish to incorporate parts of the Program into other free programs
+whose distribution conditions are different, write to the author to ask for
+permission. For software which is copyrighted by the Free Software Foundation,
+write to the Free Software Foundation; we sometimes make exceptions for this.
+Our decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing and reuse
+of software generally.
+
+   NO WARRANTY
+
+11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR
+THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE
+STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM
+"AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE
+OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE
+OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA
+OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES
+OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH
+HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible
+use to the public, the best way to achieve this is to make it free software
+which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program. It is safest to attach
+them to the start of each source file to most effectively convey the exclusion
+of warranty; and each file should have at least the "copyright" line and a
+pointer to where the full notice is found.
+
+<one line to give the program's name and an idea of what it does.>
+
+Copyright (C) <yyyy> <name of author>
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation; either version 2 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this when
+it starts in an interactive mode:
+
+Gnomovision version 69, Copyright (C) year name of author Gnomovision comes
+with ABSOLUTELY NO WARRANTY; for details type `show w'. This is free software,
+and you are welcome to redistribute it under certain conditions; type `show
+c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License. Of course, the commands you use may be
+called something other than `show w' and `show c'; they could even be mouse-clicks
+or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your school,
+if any, to sign a "copyright disclaimer" for the program, if necessary. Here
+is a sample; alter the names:
+
+Yoyodyne, Inc., hereby disclaims all copyright interest in the program `Gnomovision'
+(which makes passes at compilers) written by James Hacker.
+
+<signature of Ty Coon>, 1 April 1989 Ty Coon, President of Vice This General
+Public License does not permit incorporating your program into proprietary
+programs. If your program is a subroutine library, you may consider it more
+useful to permit linking proprietary applications with the library. If this
+is what you want to do, use the GNU Lesser General Public License instead
+of this License.

--- a/pristine/LICENSES/LPPL-1.3c.txt
+++ b/pristine/LICENSES/LPPL-1.3c.txt
@@ -1,0 +1,392 @@
+The LaTeX Project Public License
+
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+LPPL Version 1.3c 2008-05-04 Copyright 1999 2002-2008 LaTeX3 Project
+
+Everyone is allowed to distribute verbatim copies of this license document,
+but modification of it is not allowed.
+
+PREAMBLE
+
+========
+
+The LaTeX Project Public License (LPPL) is the primary license under which
+the LaTeX kernel and the base LaTeX packages are distributed.
+
+You may use this license for any work of which you hold the copyright and
+which you wish to distribute. This license may be particularly suitable if
+your work is TeX-related (such as a LaTeX package), but it is written in such
+a way that you can use it even if your work is unrelated to TeX.
+
+The section `WHETHER AND HOW TO DISTRIBUTE WORKS UNDER THIS LICENSE', below,
+gives instructions, examples, and recommendations for authors who are considering
+distributing their works under this license.
+
+This license gives conditions under which a work may be distributed and modified,
+as well as conditions under which modified versions of that work may be distributed.
+
+We, the LaTeX3 Project, believe that the conditions below give you the freedom
+to make and distribute modified versions of your work that conform with whatever
+technical specifications you wish while maintaining the availability, integrity,
+and reliability of that work. If you do not see how to achieve your goal while
+meeting these conditions, then read the document `cfgguide.tex' and `modguide.tex'
+in the base LaTeX distribution for suggestions.
+
+DEFINITIONS
+
+===========
+
+In this license document the following terms are used:
+
+`Work' Any work being distributed under this License. `Derived Work' Any work
+that under any applicable law is derived from the Work.
+
+`Modification' Any procedure that produces a Derived Work under any applicable
+law -- for example, the production of a file containing an original file associated
+with the Work or a significant portion of such a file, either verbatim or
+with modifications and/or translated into another language.
+
+`Modify' To apply any procedure that produces a Derived Work under any applicable
+law. `Distribution' Making copies of the Work available from one person to
+another, in whole or in part. Distribution includes (but is not limited to)
+making any electronic components of the Work accessible by file transfer protocols
+such as FTP or HTTP or by shared file systems such as Sun's Network File System
+(NFS).
+
+`Compiled Work' A version of the Work that has been processed into a form
+where it is directly usable on a computer system. This processing may include
+using installation facilities provided by the Work, transformations of the
+Work, copying of components of the Work, or other activities. Note that modification
+of any installation facilities provided by the Work constitutes modification
+of the Work.
+
+`Current Maintainer' A person or persons nominated as such within the Work.
+If there is no such explicit nomination then it is the `Copyright Holder'
+under any applicable law.
+
+`Base Interpreter' A program or process that is normally needed for running
+or interpreting a part or the whole of the Work.
+
+A Base Interpreter may depend on external components but these are not considered
+part of the Base Interpreter provided that each external component clearly
+identifies itself whenever it is used interactively. Unless explicitly specified
+when applying the license to the Work, the only applicable Base Interpreter
+is a `LaTeX-Format' or in the case of files belonging to the `LaTeX-format'
+a program implementing the `TeX language'.
+
+CONDITIONS ON DISTRIBUTION AND MODIFICATION
+
+===========================================
+
+1. Activities other than distribution and/or modification of the Work are
+not covered by this license; they are outside its scope. In particular, the
+act of running the Work is not restricted and no requirements are made concerning
+any offers of support for the Work.
+
+2. You may distribute a complete, unmodified copy of the Work as you received
+it. Distribution of only part of the Work is considered modification of the
+Work, and no right to distribute such a Derived Work may be assumed under
+the terms of this clause.
+
+3. You may distribute a Compiled Work that has been generated from a complete,
+unmodified copy of the Work as distributed under Clause 2 above, as long as
+that Compiled Work is distributed in such a way that the recipients may install
+the Compiled Work on their system exactly as it would have been installed
+if they generated a Compiled Work directly from the Work.
+
+4. If you are the Current Maintainer of the Work, you may, without restriction,
+modify the Work, thus creating a Derived Work. You may also distribute the
+Derived Work without restriction, including Compiled Works generated from
+the Derived Work. Derived Works distributed in this manner by the Current
+Maintainer are considered to be updated versions of the Work.
+
+5. If you are not the Current Maintainer of the Work, you may modify your
+copy of the Work, thus creating a Derived Work based on the Work, and compile
+this Derived Work, thus creating a Compiled Work based on the Derived Work.
+
+6. If you are not the Current Maintainer of the Work, you may distribute a
+Derived Work provided the following conditions are met for every component
+of the Work unless that component clearly states in the copyright notice that
+it is exempt from that condition. Only the Current Maintainer is allowed to
+add such statements of exemption to a component of the Work.
+
+a. If a component of this Derived Work can be a direct replacement for a component
+of the Work when that component is used with the Base Interpreter, then, wherever
+this component of the Work identifies itself to the user when used interactively
+with that Base Interpreter, the replacement component of this Derived Work
+clearly and unambiguously identifies itself as a modified version of this
+component to the user when used interactively with that Base Interpreter.
+
+b. Every component of the Derived Work contains prominent notices detailing
+the nature of the changes to that component, or a prominent reference to another
+file that is distributed as part of the Derived Work and that contains a complete
+and accurate log of the changes.
+
+c. No information in the Derived Work implies that any persons, including
+(but not limited to) the authors of the original version of the Work, provide
+any support, including (but not limited to) the reporting and handling of
+errors, to recipients of the Derived Work unless those persons have stated
+explicitly that they do provide such support for the Derived Work.
+
+      d. You distribute at least one of the following with the Derived Work:
+
+1. A complete, unmodified copy of the Work; if your distribution of a modified
+component is made by offering access to copy the modified component from a
+designated place, then offering equivalent access to copy the Work from the
+same or some similar place meets this condition, even though third parties
+are not compelled to copy the Work along with the modified component;
+
+2. Information that is sufficient to obtain a complete, unmodified copy of
+the Work.
+
+7. If you are not the Current Maintainer of the Work, you may distribute a
+Compiled Work generated from a Derived Work, as long as the Derived Work is
+distributed to all recipients of the Compiled Work, and as long as the conditions
+of Clause 6, above, are met with regard to the Derived Work.
+
+8. The conditions above are not intended to prohibit, and hence do not apply
+to, the modification, by any method, of any component so that it becomes identical
+to an updated version of that component of the Work as it is distributed by
+the Current Maintainer under Clause 4, above.
+
+9. Distribution of the Work or any Derived Work in an alternative format,
+where the Work or that Derived Work (in whole or in part) is then produced
+by applying some process to that format, does not relax or nullify any sections
+of this license as they pertain to the results of applying that process.
+
+   10.
+
+a. A Derived Work may be distributed under a different license provided that
+license itself honors the conditions listed in Clause 6 above, in regard to
+the Work, though it does not have to honor the rest of the conditions in this
+license.
+
+b. If a Derived Work is distributed under a different license, that Derived
+Work must provide sufficient documentation as part of itself to allow each
+recipient of that Derived Work to honor the restrictions in Clause 6 above,
+concerning changes from the Work.
+
+11. This license places no restrictions on works that are unrelated to the
+Work, nor does this license place any restrictions on aggregating such works
+with the Work by any means.
+
+12. Nothing in this license is intended to, or may be used to, prevent complete
+compliance by all parties with all applicable laws.
+
+NO WARRANTY
+
+===========
+
+There is no warranty for the Work. Except when otherwise stated in writing,
+the Copyright Holder provides the Work `as is', without warranty of any kind,
+either expressed or implied, including, but not limited to, the implied warranties
+of merchantability and fitness for a particular purpose. The entire risk as
+to the quality and performance of the Work is with you. Should the Work prove
+defective, you assume the cost of all necessary servicing, repair, or correction.
+
+In no event unless required by applicable law or agreed to in writing will
+The Copyright Holder, or any author named in the components of the Work, or
+any other party who may distribute and/or modify the Work as permitted above,
+be liable to you for damages, including any general, special, incidental or
+consequential damages arising out of any use of the Work or out of inability
+to use the Work (including, but not limited to, loss of data, data being rendered
+inaccurate, or losses sustained by anyone as a result of any failure of the
+Work to operate with any other programs), even if the Copyright Holder or
+said author or said other party has been advised of the possibility of such
+damages.
+
+MAINTENANCE OF THE WORK
+
+=======================
+
+The Work has the status `author-maintained' if the Copyright Holder explicitly
+and prominently states near the primary copyright notice in the Work that
+the Work can only be maintained by the Copyright Holder or simply that it
+is `author-maintained'.
+
+The Work has the status `maintained' if there is a Current Maintainer who
+has indicated in the Work that they are willing to receive error reports for
+the Work (for example, by supplying a valid e-mail address). It is not required
+for the Current Maintainer to acknowledge or act upon these error reports.
+
+The Work changes from status `maintained' to `unmaintained' if there is no
+Current Maintainer, or the person stated to be Current Maintainer of the work
+cannot be reached through the indicated means of communication for a period
+of six months, and there are no other significant signs of active maintenance.
+
+You can become the Current Maintainer of the Work by agreement with any existing
+Current Maintainer to take over this role.
+
+If the Work is unmaintained, you can become the Current Maintainer of the
+Work through the following steps:
+
+1. Make a reasonable attempt to trace the Current Maintainer (and the Copyright
+Holder, if the two differ) through the means of an Internet or similar search.
+
+2. If this search is successful, then enquire whether the Work is still maintained.
+
+a. If it is being maintained, then ask the Current Maintainer to update their
+communication data within one month.
+
+b. If the search is unsuccessful or no action to resume active maintenance
+is taken by the Current Maintainer, then announce within the pertinent community
+your intention to take over maintenance. (If the Work is a LaTeX work, this
+could be done, for example, by posting to comp.text.tex.)
+
+3a. If the Current Maintainer is reachable and agrees to pass maintenance
+of the Work to you, then this takes effect immediately upon announcement.
+
+b. If the Current Maintainer is not reachable and the Copyright Holder agrees
+that maintenance of the Work be passed to you, then this takes effect immediately
+upon announcement.
+
+4. If you make an `intention announcement' as described in 2b. above and after
+three months your intention is challenged neither by the Current Maintainer
+nor by the Copyright Holder nor by other people, then you may arrange for
+the Work to be changed so as to name you as the (new) Current Maintainer.
+
+5. If the previously unreachable Current Maintainer becomes reachable once
+more within three months of a change completed under the terms of 3b) or 4),
+then that Current Maintainer must become or remain the Current Maintainer
+upon request provided they then update their communication data within one
+month.
+
+A change in the Current Maintainer does not, of itself, alter the fact that
+the Work is distributed under the LPPL license.
+
+If you become the Current Maintainer of the Work, you should immediately provide,
+within the Work, a prominent and unambiguous statement of your status as Current
+Maintainer. You should also announce your new status to the same pertinent
+community as in 2b) above.
+
+WHETHER AND HOW TO DISTRIBUTE WORKS UNDER THIS LICENSE
+
+======================================================
+
+This section contains important instructions, examples, and recommendations
+for authors who are considering distributing their works under this license.
+These authors are addressed as `you' in this section.
+
+Choosing This License or Another License
+
+----------------------------------------
+
+If for any part of your work you want or need to use *distribution* conditions
+that differ significantly from those in this license, then do not refer to
+this license anywhere in your work but, instead, distribute your work under
+a different license. You may use the text of this license as a model for your
+own license, but your license should not refer to the LPPL or otherwise give
+the impression that your work is distributed under the LPPL.
+
+The document `modguide.tex' in the base LaTeX distribution explains the motivation
+behind the conditions of this license. It explains, for example, why distributing
+LaTeX under the GNU General Public License (GPL) was considered inappropriate.
+Even if your work is unrelated to LaTeX, the discussion in `modguide.tex'
+may still be relevant, and authors intending to distribute their works under
+any license are encouraged to read it.
+
+A Recommendation on Modification Without Distribution
+
+-----------------------------------------------------
+
+It is wise never to modify a component of the Work, even for your own personal
+use, without also meeting the above conditions for distributing the modified
+component. While you might intend that such modifications will never be distributed,
+often this will happen by accident -- you may forget that you have modified
+that component; or it may not occur to you when allowing others to access
+the modified version that you are thus distributing it and violating the conditions
+of this license in ways that could have legal implications and, worse, cause
+problems for the community. It is therefore usually in your best interest
+to keep your copy of the Work identical with the public one. Many works provide
+ways to control the behavior of that work without altering any of its licensed
+components.
+
+How to Use This License
+
+-----------------------
+
+To use this license, place in each of the components of your work both an
+explicit copyright notice including your name and the year the work was authored
+and/or last substantially modified. Include also a statement that the distribution
+and/or modification of that component is constrained by the conditions in
+this license.
+
+Here is an example of such a notice and statement:
+
+%% pig.dtx
+
+%% Copyright 2005 M. Y. Name
+
+%
+
+% This work may be distributed and/or modified under the
+
+% conditions of the LaTeX Project Public License, either version 1.3
+
+% of this license or (at your option) any later version.
+
+% The latest version of this license is in
+
+% http://www.latex-project.org/lppl.txt
+
+% and version 1.3 or later is part of all distributions of LaTeX
+
+% version 2005/12/01 or later.
+
+%
+
+% This work has the LPPL maintenance status " maintained ".
+
+%
+
+% The Current Maintainer of this work is M. Y. Name .
+
+%
+
+% This work consists of the files pig.dtx and pig.ins
+
+% and the derived file pig.sty .
+
+Given such a notice and statement in a file, the conditions given in this
+license document would apply, with the `Work' referring to the three files
+`pig.dtx', `pig.ins', and `pig.sty' (the last being generated from `pig.dtx'
+using `pig.ins'), the `Base Interpreter' referring to any `LaTeX-Format',
+and both `Copyright Holder' and `Current Maintainer' referring to the person
+`M. Y. Name'.
+
+If you do not want the Maintenance section of LPPL to apply to your Work,
+change `maintained' above into `author-maintained'. However, we recommend
+that you use `maintained', as the Maintenance section was added in order to
+ensure that your Work remains useful to the community even when you can no
+longer maintain and support it yourself.
+
+Derived Works That Are Not Replacements
+
+---------------------------------------
+
+Several clauses of the LPPL specify means to provide reliability and stability
+for the user community. They therefore concern themselves with the case that
+a Derived Work is intended to be used as a (compatible or incompatible) replacement
+of the original Work. If this is not the case (e.g., if a few lines of code
+are reused for a completely different task), then clauses 6b and 6d shall
+not apply.
+
+Important Recommendations
+
+-------------------------
+
+Defining What Constitutes the Work
+
+The LPPL requires that distributions of the Work contain all the files of
+the Work. It is therefore important that you provide a way for the licensee
+to determine which files constitute the Work. This could, for example, be
+achieved by explicitly listing all the files of the Work near the copyright
+notice of each file or by using a line such as:
+
+% This work consists of all files listed in manifest.txt.
+
+in that place. In the absence of an unequivocal list it might be impossible
+for the licensee to determine what is considered by you to comprise the Work
+and, in such a case, the licensee would be entitled to make reasonable conjectures
+as to which files comprise the Work.

--- a/pristine/LICENSES/LicenseRef-Trademark.txt
+++ b/pristine/LICENSES/LicenseRef-Trademark.txt
@@ -1,0 +1,8 @@
+The files in directory `manual/logos/` are trademarks of their
+respective owners.
+
+For license and usage guidelines on the seL4 trademark and logo,
+including the seL4 Foundation logo, see
+https://sel4.systems/Foundation/Trademark/
+
+No further license is granted from use in this repository.

--- a/pristine/LICENSES/MIT.txt
+++ b/pristine/LICENSES/MIT.txt
@@ -1,0 +1,19 @@
+MIT License Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next
+paragraph) shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF
+OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/pristine/LICENSES/SHL-0.51.txt
+++ b/pristine/LICENSES/SHL-0.51.txt
@@ -1,0 +1,213 @@
+SOLDERPAD HARDWARE LICENSE version 0.51
+
+This license is based closely on the Apache License Version 2.0, but is not
+approved or endorsed by the Apache Foundation. A copy of the non-modified
+Apache License 2.0 can be found at http://www.apache.org/licenses/LICENSE-2.0.
+
+As this license is not currently OSI or FSF approved, the Licensor permits
+any Work licensed under this License, at the option of the Licensee, to be
+treated as licensed under the Apache License Version 2.0 (which is so approved).
+
+This License is licensed under the terms of this License and in particular
+clause 7 below (Disclaimer of Warranties) applies in relation to its use.
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution
+as defined by Sections 1 through 9 of this document.
+
+      
+
+"Licensor" shall mean the Rights owner or entity authorized by the Rights
+owner that is granting the License.
+
+      
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct
+or indirect, to cause the direction or management of such entity, whether
+by contract or otherwise, or (ii) ownership of fifty percent (50%) or more
+of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+      
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions
+granted by this License.
+
+      
+
+"Rights" means copyright and any similar right including design right (whether
+registered or unregistered), semiconductor topography (mask) rights and database
+rights (but excluding Patents and Trademarks).
+
+      
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to source code, net lists, board layouts, CAD files, documentation
+source, and configuration files.
+
+      
+
+"Object" form shall mean any form resulting from mechanical transformation
+or translation of a Source form, including but not limited to compiled object
+code, generated documentation, the instantiation of a hardware design and
+conversions to other media types, including intermediate forms such as bytecodes,
+FPGA bitstreams, artwork and semiconductor topographies (mask works).
+
+      
+
+"Work" shall mean the work of authorship, whether in Source form or other
+Object form, made available under the License, as indicated by a Rights notice
+that is included in or attached to the work (an example is provided in the
+Appendix below).
+
+      
+
+"Derivative Works" shall mean any work, whether in Source or Object form,
+that is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative
+Works shall not include works that remain separable from, or merely link (or
+bind by name) or physically connect to or interoperate with the interfaces
+of, the Work and Derivative Works thereof.
+
+      
+
+"Contribution" shall mean any design or work of authorship, including the
+original version of the Work and any modifications or additions to that Work
+or Derivative Works thereof, that is intentionally submitted to Licensor for
+inclusion in the Work by the Rights owner or by an individual or Legal Entity
+authorized to submit on behalf of the Rights owner. For the purposes of this
+definition, "submitted" means any form of electronic, verbal, or written communication
+sent to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor
+for the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the Rights
+owner as "Not a Contribution."
+
+      
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently incorporated
+within the Work.
+
+2. Grant of License. Subject to the terms and conditions of this License,
+each Contributor hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable license under the Rights to reproduce,
+prepare Derivative Works of, publicly display, publicly perform, sublicense,
+and distribute the Work and such Derivative Works in Source or Object form
+and do anything in relation to the Work as if the Rights did not exist.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License,
+each Contributor hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section) patent
+license to make, have made, use, offer to sell, sell, import, and otherwise
+transfer the Work, where such license applies only to those patent claims
+licensable by such Contributor that are necessarily infringed by their Contribution(s)
+alone or by combination of their Contribution(s) with the Work to which such
+Contribution(s) was submitted. If You institute patent litigation against
+any entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that the Work or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses granted to You
+under this License for that Work shall terminate as of the date such litigation
+is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or
+Derivative Works thereof in any medium, with or without modifications, and
+in Source or Object form, provided that You meet the following conditions:
+
+1. You must give any other recipients of the Work or Derivative Works a copy
+of this License; and
+
+2. You must cause any modified files to carry prominent notices stating that
+You changed the files; and
+
+3. You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source
+form of the Work, excluding those notices that do not pertain to any part
+of the Derivative Works; and
+
+4. If the Work includes a "NOTICE" text file as part of its distribution,
+then any Derivative Works that You distribute must include a readable copy
+of the attribution notices contained within such NOTICE file, excluding those
+notices that do not pertain to any part of the Derivative Works, in at least
+one of the following places: within a NOTICE text file distributed as part
+of the Derivative Works; within the Source form or documentation, if provided
+along with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works
+that You distribute, alongside or as an addendum to the NOTICE text from the
+Work, provided that such additional attribution notices cannot be construed
+as modifying the License. You may add Your own copyright statement to Your
+modifications and may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or for any such
+Derivative Works as a whole, provided Your use, reproduction, and distribution
+of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any
+Contribution intentionally submitted for inclusion in the Work by You to the
+Licensor shall be under the terms and conditions of this License, without
+any additional terms or conditions. Notwithstanding the above, nothing herein
+shall supersede or modify the terms of any separate license agreement you
+may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names,
+trademarks, service marks, or product names of the Licensor, except as required
+for reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to
+in writing, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied, including, without limitation, any warranties
+or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR
+A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness
+of using or redistributing the Work and assume any risks associated with Your
+exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether
+in tort (including negligence), contract, or otherwise, unless required by
+applicable law (such as deliberate and grossly negligent acts) or agreed to
+in writing, shall any Contributor be liable to You for damages, including
+any direct, indirect, special, incidental, or consequential damages of any
+character arising as a result of this License or out of the use or inability
+to use the Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all other commercial
+damages or losses), even if such Contributor has been advised of the possibility
+of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work
+or Derivative Works thereof, You may choose to offer, and charge a fee for,
+acceptance of support, warranty, indemnity, or other liability obligations
+and/or rights consistent with this License. However, in accepting such obligations,
+You may act only on Your own behalf and on Your sole responsibility, not on
+behalf of any other Contributor, and only if You agree to indemnify, defend,
+and hold each Contributor harmless for any liability incurred by, or claims
+asserted against, such Contributor by reason of your accepting any such warranty
+or additional liability. END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply this license to your work
+
+To apply this license to your work, attach the following boilerplate notice,
+with the fields enclosed by brackets "[]" replaced with your own identifying
+information. (Don't include the brackets!) The text should be enclosed in
+the appropriate comment syntax for the file format. We also recommend that
+a file or class name and description of purpose be included on the same "printed
+page" as the copyright notice for easier identification within third-party
+archives.
+
+Copyright [yyyy] [name of copyright owner] Copyright and related rights are
+licensed under the Solderpad Hardware License, Version 0.51 (the "License");
+you may not use this file except in compliance with the License. You may obtain
+a copy of the License at http://solderpad.org/licenses/SHL-0.51. Unless required
+by applicable law or agreed to in writing, software, hardware and materials
+distributed under this License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+for the specific language governing permissions and limitations under the
+License.

--- a/pristine/SECURITY.md
+++ b/pristine/SECURITY.md
@@ -1,0 +1,99 @@
+<!--
+     Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Vulnerability disclosure policy
+
+Security is a core value of the seL4 Foundation. If you believe you have
+found a security vulnerability in seL4, we ask you to work with us to
+resolve it according to principles of responsible disclosure. This
+policy outlines what we ask of you, and what you can expect of us.
+
+## Scope
+
+This policy currently applies to the most recent released versions, and
+the heads of the default branches of the software in the following seL4
+Foundation repositories:
+- https://github.com/seL4/seL4
+- https://github.com/seL4/capdl
+- https://github.com/seL4/camkes-tool
+
+Note that these repositories include various code generation tools, for
+example the seL4 [bitfield generator], the [capDL-tool] and the
+[camkes-tool]. This policy applies to the code these tools ultimately
+generate, but not to the code generators themselves. In other words,
+it's the code that ends up running on seL4-based systems that we care
+about.
+
+[bitfield generator]: https://github.com/seL4/seL4/blob/master/tools/bitfield_gen.py
+[capDL-tool]: https://github.com/seL4/capdl/tree/master/capDL-tool
+[camkes-tool]: https://github.com/seL4/camkes-tool
+
+## What we ask of you
+
+- Report any vulnerabilities you discover as soon as you can, using the
+  official channel below.
+- Provide enough detail to allow us to understand the vulnerability and
+  its impact.
+- Be patient with us if we have questions.
+- Allow us reasonable time to fix the vulnerability before you disclose
+  it publicly.
+- Be mindful that updating the proofs for a fix might take longer than
+  you imagine.
+- Avoid violating the privacy of others, disrupting the normal operation
+  of our systems, or destroying data.
+
+## What you can expect of us
+
+- We will respond to your report within 14 days, and usually sooner.
+- We will work with you to understand and reproduce the vulnerability
+  you are reporting.
+- We will try to reach agreement on an appropriate timeframe for fixing
+  the vulnerability. We will usually aim for 90 days, but sometimes we
+  will need significantly longer to complete difficult proofs.
+- We will work to fix the vulnerability in a timely manner, and will
+  keep you informed of our progress.
+- When we have developed a fix, we will publicly acknowledge the
+  vulnerability.
+- If you agree, we will publicly acknowledge your role in finding and
+  helping us fix the vulnerability.
+- We will protect your privacy, and will not disclose your personally
+  identifying information to third parties without your explicit
+  permission.
+
+Unfortunately, we are not currently able to offer bug bounties.
+
+## Official channel
+
+Please send vulnerability reports by email to security@seL4.systems,
+optionally encrypted using our security officer's [OpenPGP key].
+
+[OpenPGP key]: https://seL4.systems/security.asc
+
+## FAQ
+
+### How can formally verified software contain security vulnerabilities?
+
+seL4 supports many configurations, and only some of these are verified.
+For unverified configurations, we want to know about vulnerabilities, so
+we can provide the level of support that you would expect from any
+well-engineered software.
+
+Even verified configurations contain some code that is assumed to do the
+right thing, including boot code, assembly stubs, and cache management.
+If that code does the wrong thing, there might be a security
+vulnerability in a verified configuration, and we want to know about
+that.
+
+The proofs also make a number of assumptions about the way hardware
+works. If our assumptions are not valid for real hardware, there might
+be a security vulnerability, and we want to know so we can try to fix
+our assumptions. Some assumptions might not be possible to fix. For
+example, the assumption that memory is incorruptible may be violated by
+Rowhammer, but it is quite fundamental to the proofs.
+
+For more information about what the proofs mean, see the [seL4 FAQ].
+
+[seL4 FAQ]: https://docs.sel4.systems/projects/sel4/frequently-asked-questions.html


### PR DESCRIPTION
## Summary
- mirror the upstream release notes, contributor docs, and licensing files into `pristine/` so the baseline metadata sits next to the clean source snapshot
- refresh the reorganization plan with the new `pristine/` path counts and notes about the mirrored metadata

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d31ca3c6cc832bb606becf509ad27b