### PR TITLE
Add C89 compatibility macros for inline and attributes

### DIFF
--- a/preconfigured/include/arch/x86/arch/object/structures.h
+++ b/preconfigured/include/arch/x86/arch/object/structures.h
@@ -128,7 +128,7 @@ typedef struct rdmsr_safe_result rdmsr_safe_result_t;
 typedef struct gdt_idt_ptr {
     uint16_t limit;
     word_t base;
-} __attribute__((packed)) gdt_idt_ptr_t;
+} PACKED gdt_idt_ptr_t;
 
 enum vm_rights {
     VMKernelOnly = 1,

--- a/preconfigured/include/basic_types.h
+++ b/preconfigured/include/basic_types.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <compiler.h>
 #include <arch/types.h>
 
 /* arch/types.h is supposed to define word_t and _seL4_word_fmt */
@@ -75,7 +76,7 @@ typedef struct v_region {
 
 /* equivalent to a word_t except that we tell the compiler that we may alias with
  * any other type (similar to a char pointer) */
-typedef word_t __attribute__((__may_alias__)) word_t_may_alias;
+typedef word_t SEL4_MAY_ALIAS_ATTR word_t_may_alias;
 
 /* for libsel4 headers that the kernel shares */
 typedef uint8_t seL4_Uint8;

--- a/preconfigured/include/compiler.h
+++ b/preconfigured/include/compiler.h
@@ -1,0 +1,56 @@
+/*
+ * Compatibility macros for compilers that enforce strict C89/C90 semantics.
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#pragma once
+
+/* Determine whether we are targeting a pre-C99 dialect. */
+#if defined(__STDC_VERSION__)
+#define SEL4_STDC_VERSION __STDC_VERSION__
+#else
+#define SEL4_STDC_VERSION 0L
+#endif
+
+#if SEL4_STDC_VERSION >= 199901L
+#define SEL4_C89_COMPAT 0
+#else
+#define SEL4_C89_COMPAT 1
+#endif
+
+#if SEL4_C89_COMPAT && !defined(__cplusplus)
+#ifndef inline
+#if defined(__GNUC__)
+#define inline __inline__
+#else
+#define inline
+#endif
+#endif
+#endif
+
+#if SEL4_C89_COMPAT
+#define SEL4_ATTR(attrs)
+#else
+#define SEL4_ATTR(attrs) __attribute__ attrs
+#endif
+
+#define SEL4_INLINE inline
+#define SEL4_STATIC_INLINE static inline
+#define SEL4_FORCE_INLINE SEL4_ATTR((always_inline))
+#define SEL4_NORETURN_ATTR SEL4_ATTR((__noreturn__))
+#define SEL4_CONST_ATTR SEL4_ATTR((__const__))
+#define SEL4_PURE_ATTR SEL4_ATTR((__pure__))
+#define SEL4_ALIGN_ATTR(n) SEL4_ATTR((__aligned__(n)))
+#define SEL4_PACKED_ATTR SEL4_ATTR((packed))
+#define SEL4_SECTION_ATTR(sec) SEL4_ATTR((__section__(sec)))
+#define SEL4_UNUSED_ATTR SEL4_ATTR((unused))
+#define SEL4_USED_ATTR SEL4_ATTR((used))
+#define SEL4_WEAK_ATTR SEL4_ATTR((weak))
+#define SEL4_FASTCALL_ATTR SEL4_ATTR((fastcall))
+#define SEL4_NAKED_ATTR SEL4_ATTR((naked))
+#define SEL4_PRINTF_ATTR(fmt_index, first_arg) \
+    SEL4_ATTR((format(printf, fmt_index, first_arg)))
+#define SEL4_OPTIMIZE_ATTR(level) SEL4_ATTR((optimize(level)))
+#define SEL4_EXTERNALLY_VISIBLE_ATTR SEL4_ATTR((externally_visible))
+#define SEL4_MAY_ALIAS_ATTR SEL4_ATTR((may_alias))

--- a/preconfigured/include/machine/io.h
+++ b/preconfigured/include/machine/io.h
@@ -17,6 +17,7 @@ unsigned char kernel_getDebugChar(void);
 #ifdef CONFIG_PRINTING
 
 #include <arch/types.h>
+#include <compiler.h>
 #include <stdarg.h>
 
 /* the actual output function */
@@ -78,7 +79,7 @@ static inline int puts(
 /* There should only be a kprintf() that all kernel code must use for printing,
  * but for convenience we provide a printf() here.
  */
-static inline __attribute__((format(printf, 1, 2))) int printf(
+static inline SEL4_PRINTF_ATTR(1, 2) int printf(
     const char *format,
     ...)
 {
@@ -92,7 +93,7 @@ static inline __attribute__((format(printf, 1, 2))) int printf(
 /* Provide the standard snprintf() for write formatted data into a buffer, which
  * can then be printed or stored.
  */
-static inline __attribute__((format(printf, 3, 4))) int snprintf(
+static inline SEL4_PRINTF_ATTR(3, 4) int snprintf(
     char *buf,
     word_t size,
     const char *format,

--- a/preconfigured/include/util.h
+++ b/preconfigured/include/util.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <compiler.h>
+
 #define PASTE(a, b) a ## b
 #define _STRINGIFY(a) #a
 #define STRINGIFY(a) _STRINGIFY(a)
@@ -69,31 +71,31 @@
 
 #ifndef __ASSEMBLER__
 
-#define PACKED       __attribute__((packed))
-#define NORETURN     __attribute__((__noreturn__))
-#define CONST        __attribute__((__const__))
-#define PURE         __attribute__((__pure__))
-#define ALIGN(n)     __attribute__((__aligned__(n)))
-#define FASTCALL     __attribute__((fastcall))
+#define PACKED       SEL4_PACKED_ATTR
+#define NORETURN     SEL4_NORETURN_ATTR
+#define CONST        SEL4_CONST_ATTR
+#define PURE         SEL4_PURE_ATTR
+#define ALIGN(n)     SEL4_ALIGN_ATTR(n)
+#define FASTCALL     SEL4_FASTCALL_ATTR
 #ifdef __clang__
 #define VISIBLE      /* nothing */
 #else
-#define VISIBLE      __attribute__((externally_visible))
+#define VISIBLE      SEL4_EXTERNALLY_VISIBLE_ATTR
 #endif
-#define NO_INLINE    __attribute__((noinline))
-#define FORCE_INLINE __attribute__((always_inline))
-#define SECTION(sec) __attribute__((__section__(sec)))
-#define UNUSED       __attribute__((unused))
-#define USED         __attribute__((used))
+#define NO_INLINE    SEL4_ATTR((noinline))
+#define FORCE_INLINE SEL4_FORCE_INLINE
+#define SECTION(sec) SEL4_SECTION_ATTR(sec)
+#define UNUSED       SEL4_UNUSED_ATTR
+#define USED         SEL4_USED_ATTR
 #ifdef __clang__
 #define FORCE_O2     /* nothing */
 #else
-#define FORCE_O2     __attribute__((optimize("O2")))
+#define FORCE_O2     SEL4_OPTIMIZE_ATTR("O2")
 #endif
 /** MODIFIES: */
 void __builtin_unreachable(void);
 #define UNREACHABLE()  __builtin_unreachable()
-#define MAY_ALIAS    __attribute__((may_alias))
+#define MAY_ALIAS    SEL4_MAY_ALIAS_ATTR
 
 #define OFFSETOF(type, member)   __builtin_offsetof(type, member)
 

--- a/preconfigured/libsel4/include/sel4/compiler.h
+++ b/preconfigured/libsel4/include/sel4/compiler.h
@@ -1,0 +1,9 @@
+/*
+ * Share compiler compatibility helpers with the kernel headers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "../../include/compiler.h"

--- a/preconfigured/libsel4/include/sel4/macros.h
+++ b/preconfigured/libsel4/include/sel4/macros.h
@@ -7,22 +7,23 @@
 #pragma once
 
 #include <sel4/config.h>
+#include <sel4/compiler.h>
 
 #ifndef CONST
-#define CONST   __attribute__((__const__))
+#define CONST   SEL4_CONST_ATTR
 #endif
 
 #ifndef PURE
-#define PURE    __attribute__((__pure__))
+#define PURE    SEL4_PURE_ATTR
 #endif
 
-#define SEL4_PACKED             __attribute__((packed))
-#define SEL4_DEPRECATED(x)      __attribute__((deprecated(x)))
+#define SEL4_PACKED             SEL4_PACKED_ATTR
+#define SEL4_DEPRECATED(x)      SEL4_ATTR((deprecated(x)))
 #define SEL4_DEPRECATE_MACRO(x) _Pragma("deprecated") x
 
-#define LIBSEL4_UNUSED          __attribute__((unused))
-#define LIBSEL4_WEAK            __attribute__((weak))
-#define LIBSEL4_NOINLINE        __attribute__((noinline))
+#define LIBSEL4_UNUSED          SEL4_UNUSED_ATTR
+#define LIBSEL4_WEAK            SEL4_WEAK_ATTR
+#define LIBSEL4_NOINLINE        SEL4_ATTR((noinline))
 
 
 #ifdef CONFIG_LIB_SEL4_INLINE_INVOCATIONS

--- a/preconfigured/libsel4/include/sel4/objecttype.h
+++ b/preconfigured/libsel4/include/sel4/objecttype.h
@@ -5,6 +5,8 @@
  */
 
 #pragma once
+
+#include <sel4/compiler.h>
 typedef enum api_object {
     seL4_UntypedObject,
     seL4_TCBObject,
@@ -18,7 +20,7 @@ typedef enum api_object {
     seL4_NonArchObjectTypeCount,
 } seL4_ObjectType;
 
-__attribute__((deprecated("use seL4_NotificationObject"))) static const seL4_ObjectType seL4_AsyncEndpointObject =
+SEL4_ATTR((deprecated("use seL4_NotificationObject"))) static const seL4_ObjectType seL4_AsyncEndpointObject =
     seL4_NotificationObject;
 
 typedef seL4_Word api_object_t;

--- a/preconfigured/libsel4/include/sel4/shared_types.h
+++ b/preconfigured/libsel4/include/sel4/shared_types.h
@@ -8,6 +8,8 @@
 
 /* this file is shared between the kernel and libsel4 */
 
+#include <sel4/compiler.h>
+
 typedef struct seL4_IPCBuffer_ {
     seL4_MessageInfo_t tag;
     seL4_Word msg[seL4_MsgMaxLength];
@@ -16,7 +18,7 @@ typedef struct seL4_IPCBuffer_ {
     seL4_CPtr receiveCNode;
     seL4_CPtr receiveIndex;
     seL4_Word receiveDepth;
-} seL4_IPCBuffer __attribute__((__aligned__(sizeof(struct seL4_IPCBuffer_))));
+} seL4_IPCBuffer SEL4_ALIGN_ATTR(sizeof(struct seL4_IPCBuffer_));
 
 typedef enum {
     seL4_CapFault_IP,

--- a/preconfigured/src/arch/x86/idle.c
+++ b/preconfigured/src/arch/x86/idle.c
@@ -15,7 +15,7 @@
  * always eliminates the function prologue by declaring the
  * idle_thread with the naked attribute.
  */
-__attribute__((naked)) NORETURN void idle_thread(void)
+SEL4_NAKED_ATTR NORETURN void idle_thread(void)
 {
     /* We cannot use for-loop or while-loop here because they may
      * involve stack manipulations (the compiler will not allow

--- a/preconfigured/src/util.c
+++ b/preconfigured/src/util.c
@@ -13,7 +13,7 @@
  * memzero needs a custom type that allows us to use a word
  * that has the aliasing properties of a char.
  */
-typedef unsigned long __attribute__((__may_alias__)) ulong_alias;
+typedef unsigned long MAY_ALIAS ulong_alias;
 
 /*
  * Zero 'n' bytes of memory starting from 's'.


### PR DESCRIPTION
## Summary
- add a shared `compiler.h` helper that normalises inline and attribute usage when the compiler enforces C89 rules
- update kernel and libsel4 headers to consume the new compatibility shims instead of raw GNU attributes
- refresh the C89 porting plan after rerunning the strict build to capture the next wave of failures

## Testing
- `./preconfigured/replay_preconfigured_build.sh` *(fails: expected strict C90 diagnostics remain)*

------
https://chatgpt.com/codex/tasks/task_e_68d333af4b90832b87fd6de45a22a551