### PR TITLE
Replace long long constants with C89-friendly helpers

### DIFF
--- a/C89-PROJECT.md
+++ b/C89-PROJECT.md
@@ -12,6 +12,8 @@ resulting compiler diagnostics.
 - [x] Run the replay build to capture the resulting diagnostics.
 - [ ] Update the source tree to resolve the new C90 compilation issues.
   - [x] Introduce compatibility shims for inline and attribute annotations.
+  - [x] Replace obvious C99-only integer literals in shared headers with
+    portable constructors.
   - [ ] Address the remaining diagnostics reported by the strict build.
 
 ## Build Attempt Summary
@@ -20,11 +22,15 @@ resulting compiler diagnostics.
   header sources due to strict C90 semantics.
 
 ### Key Diagnostic Themes
-1. **C99 integer literals**: Generated capability helpers emit `ULL` and `LL`
-   constants that trigger `-Werror=long-long` under strict C90.
+1. **C99 integer literals**: The generated capability helpers and several x86
+   machine shims still emit `ULL` and `LL` constants that trigger
+   `-Werror=long-long` under strict C90. We converted the obvious library and
+   userspace headers to portable constructors, but the architecture generators
+   still need dedicated helpers.
    - *Potential remedies*: route these constants through macros that expand to
      `unsigned long` arithmetic, or provide custom constructors that avoid
-     `long long` suffixes when C99 is unavailable.
+     `long long` suffixes when C99 is unavailable, and teach the code
+     generators to use them.
 2. **Preprocessor usage assumes variadic macros**: The PC99 interrupt helpers
    expand `config_set(...)` in contexts that result in empty `__VA_ARGS__`,
    provoking "requires at least one argument" diagnostics.
@@ -45,8 +51,8 @@ resulting compiler diagnostics.
      that the compiler can prove a value is always produced.
 
 ## Next Steps
-- Replace C99-only `long long` literals with portable helpers or constant
-  constructors that satisfy C89.
+- Extend the new portable constant helpers to the generated capability tables
+  and x86 machine helpers that still rely on `ULL` literals.
 - Rework the PC99 interrupt helpers so that the generated statements avoid
   declaration-after-statement issues and variadic macro misuse under strict C90.
 - Audit architecture helpers for unused parameters and modern inline idioms

--- a/preconfigured/libsel4/include/sel4/macros.h
+++ b/preconfigured/libsel4/include/sel4/macros.h
@@ -63,6 +63,6 @@
  * the same size as a 'long'.
  */
 #define SEL4_FORCE_LONG_ENUM(type) \
-    _enum_pad_ ## type = ((1ULL << ((sizeof(long)*8) - 1)) - 1)
+    _enum_pad_ ## type = ((long)((~0ul) >> 1))
 
 #define LIBSEL4_BIT(n)  (1ul<<(n))

--- a/preconfigured/sysdeps/file-5.45/src/cdf.c
+++ b/preconfigured/sysdeps/file-5.45/src/cdf.c
@@ -60,7 +60,7 @@ FILE_RCSID("@(#)$File: cdf.c,v 1.123 2022/09/24 20:30:13 christos Exp $")
 #endif
 
 #ifndef SIZE_T_MAX
-#define SIZE_T_MAX CAST(size_t, ~0ULL)
+#define SIZE_T_MAX (~CAST(size_t, 0))
 #endif
 
 #include "cdf.h"
@@ -1527,7 +1527,7 @@ cdf_dump_property_info(const cdf_property_info_t *info, size_t count)
 			break;
 		case CDF_FILETIME:
 			tp = info[i].pi_tp;
-			if (tp < 1000000000000000LL) {
+			if (tp < CDF_FILETIME_THRESHOLD) {
 				cdf_print_elapsed_time(buf, sizeof(buf), tp);
 				(void)fprintf(stderr, "timestamp %s\n", buf);
 			} else {

--- a/preconfigured/sysdeps/file-5.45/src/cdf.h
+++ b/preconfigured/sysdeps/file-5.45/src/cdf.h
@@ -58,7 +58,7 @@ typedef int32_t cdf_secid_t;
 
 typedef struct {
 	uint64_t	h_magic;
-#define CDF_MAGIC	0xE11AB1A1E011CFD0LL
+#define CDF_MAGIC	FILE_UINT64_CONST(0xE11AB1A1, 0xE011CFD0)
 	uint64_t	h_uuid[2];
 	uint16_t	h_revision;
 	uint16_t	h_version;
@@ -88,6 +88,7 @@ typedef int32_t cdf_dirid_t;
 typedef int64_t cdf_timestamp_t;
 #define CDF_BASE_YEAR	1601
 #define CDF_TIME_PREC	10000000
+#define CDF_FILETIME_THRESHOLD	FILE_UINT64_CONST(0x38d7e, 0xa4c68000)
 
 typedef struct {
 	uint16_t	d_name[32];

--- a/preconfigured/sysdeps/file-5.45/src/cdf_time.c
+++ b/preconfigured/sysdeps/file-5.45/src/cdf_time.c
@@ -188,7 +188,8 @@ main(int argc, char *argv[])
 {
 	struct timespec ts;
 	char buf[25];
-	static const cdf_timestamp_t tst = 0x01A5E403C2D59C00ULL;
+	static const cdf_timestamp_t tst =
+	    FILE_INT64_CONST(0x01A5E403, 0xC2D59C00);
 	static const char *ref = "Sat Apr 23 01:30:00 1977";
 	char *p, *q;
 

--- a/preconfigured/sysdeps/file-5.45/src/file.h
+++ b/preconfigured/sysdeps/file-5.45/src/file.h
@@ -123,6 +123,12 @@
 #define __arraycount(a) (sizeof(a) / sizeof(a[0]))
 #endif
 
+#define FILE_UINT64_CONST(hi, lo) \
+    ((((uint64_t)(uint32_t)(hi)) << 32) | (uint64_t)(uint32_t)(lo))
+
+#define FILE_INT64_CONST(hi, lo) \
+    ((int64_t)FILE_UINT64_CONST(hi, lo))
+
 #ifndef __GNUC_PREREQ__
 #ifdef __GNUC__
 #define	__GNUC_PREREQ__(x, y)						\
@@ -163,7 +169,8 @@
  * to be running on a system with a 32 bit time_t, then it is even less.
  */
 #define	MAX_CTIME \
-    CAST(time_t, sizeof(time_t) > 4 ? 0x3afff487cfULL : 0x7fffffffULL)
+    CAST(time_t, sizeof(time_t) > 4 ? \
+        FILE_UINT64_CONST(0x3a, 0xfff487cf) : FILE_UINT64_CONST(0x0, 0x7fffffff))
 
 #define FILE_BADSIZE CAST(size_t, ~0ul)
 #define MAXDESC	64		/* max len of text description/MIME type */

--- a/preconfigured/sysdeps/file-5.45/src/readcdf.c
+++ b/preconfigured/sysdeps/file-5.45/src/readcdf.c
@@ -76,7 +76,7 @@ static const struct cv {
 	const char *mime;
 } clsid2mime[] = {
 	{
-		{ 0x00000000000c1084ULL, 0x46000000000000c0ULL  },
+		{ FILE_UINT64_CONST(0x00000000, 0x000c1084), FILE_UINT64_CONST(0x46000000, 0x000000c0)  },
 		"x-msi",
 	},
 	{	{ 0,			 0			},
@@ -84,7 +84,7 @@ static const struct cv {
 	},
 }, clsid2desc[] = {
 	{
-		{ 0x00000000000c1084ULL, 0x46000000000000c0ULL  },
+		{ FILE_UINT64_CONST(0x00000000, 0x000c1084), FILE_UINT64_CONST(0x46000000, 0x000000c0)  },
 		"MSI Installer",
 	},
 	{	{ 0,			 0			},
@@ -227,7 +227,7 @@ cdf_file_property_info(struct magic_set *ms, const cdf_property_info_t *info,
 			tp = info[i].pi_tp;
 			if (tp != 0) {
 				char tbuf[64];
-				if (tp < 1000000000000000LL) {
+				if (tp < CDF_FILETIME_THRESHOLD) {
 					cdf_print_elapsed_time(tbuf,
 					    sizeof(tbuf), tp);
 					if (NOTMIME(ms) && file_printf(ms,

--- a/preconfigured/sysdeps/libxml2-2.9.14+dfsg/timsort.h
+++ b/preconfigured/sysdeps/libxml2-2.9.14+dfsg/timsort.h
@@ -130,7 +130,7 @@ static __inline int compute_minrun(const uint64_t size) {
   const int top_bit = 64 - CLZ(size);
   const int shift = MAX(top_bit, 6) - 6;
   const int minrun = size >> shift;
-  const uint64_t mask = (1ULL << shift) - 1;
+  const uint64_t mask = ((uint64_t)1 << shift) - (uint64_t)1;
 
   if (mask & size) {
     return minrun + 1;


### PR DESCRIPTION
## Summary
- replace long long-based enum padding with a long-sized mask
- add helper macros so file(1) CDF code and libxml2 timsort build constants without ULL suffixes
- capture the progress in C89-PROJECT.md and note the next literal-cleanup targets

## Testing
- ./preconfigured/replay_preconfigured_build.sh (fails: remaining C90 diagnostics)


------
https://chatgpt.com/codex/tasks/task_e_68d3373204b4832ba8308258aa96c924