### PR TITLE
Refine constant helpers for generated tables

### DIFF
--- a/C89-PROJECT.md
+++ b/C89-PROJECT.md
@@ -14,6 +14,8 @@ resulting compiler diagnostics.
   - [x] Introduce compatibility shims for inline and attribute annotations.
   - [x] Replace obvious C99-only integer literals in shared headers with
     portable constructors.
+  - [x] Route the generated capability tables and x86 helpers through the new
+    portable constant macros.
   - [ ] Address the remaining diagnostics reported by the strict build.
 
 ## Build Attempt Summary
@@ -51,8 +53,13 @@ resulting compiler diagnostics.
      that the compiler can prove a value is always produced.
 
 ## Next Steps
-- Extend the new portable constant helpers to the generated capability tables
-  and x86 machine helpers that still rely on `ULL` literals.
+- Replace the remaining C99 constructs uncovered by the latest strict build
+  run:
+  - Drop the C++-style comments emitted in the generated wrapper sources.
+  - Provide C89-friendly definitions for the 64-bit typedefs and helpers in
+    `stdint.h`/`util.h` so they no longer rely on `long long`.
+  - Resolve the duplicated seL4 basic types between `simple_types.h` and the
+    shared kernel headers.
 - Rework the PC99 interrupt helpers so that the generated statements avoid
   declaration-after-statement issues and variadic macro misuse under strict C90.
 - Audit architecture helpers for unused parameters and modern inline idioms

--- a/preconfigured/X64_verified/generated/arch/object/structures_gen.h
+++ b/preconfigured/X64_verified/generated/arch/object/structures_gen.h
@@ -324,12 +324,12 @@ cr3_new(uint64_t pml4_base_address, uint64_t pcid) {
     cr3_t cr3;
 
     /* fail if user has passed bits that we will override */  
-    assert((pml4_base_address & ~0x7fffffffff000ull) == ((0 && (pml4_base_address & (1ull << 50))) ? 0x0 : 0));  
-    assert((pcid & ~0xfffull) == ((0 && (pcid & (1ull << 50))) ? 0x0 : 0));
+    assert((pml4_base_address & ~ULL_CONST(0x7fffffffff000)) == ((0 && (pml4_base_address & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((pcid & ~ULL_CONST(0xfff)) == ((0 && (pcid & (ULL_CONST(1) << 50))) ? 0x0 : 0));
 
     cr3.words[0] = 0
-        | (pml4_base_address & 0x7fffffffff000ull) >> 0
-        | (pcid & 0xfffull) << 0;
+        | (pml4_base_address & ULL_CONST(0x7fffffffff000)) >> 0
+        | (pcid & ULL_CONST(0xfff)) << 0;
 
     return cr3;
 }
@@ -337,9 +337,9 @@ cr3_new(uint64_t pml4_base_address, uint64_t pcid) {
 static inline uint64_t CONST
 cr3_get_pml4_base_address(cr3_t cr3) {
     uint64_t ret;
-    ret = (cr3.words[0] & 0x7fffffffff000ull) << 0;
+    ret = (cr3.words[0] & ULL_CONST(0x7fffffffff000)) << 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (50)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (50)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -353,9 +353,9 @@ typedef struct endpoint endpoint_t;
 static inline uint64_t PURE
 endpoint_ptr_get_epQueue_head(endpoint_t *endpoint_ptr) {
     uint64_t ret;
-    ret = (endpoint_ptr->words[1] & 0xffffffffffffffffull) >> 0;
+    ret = (endpoint_ptr->words[1] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -364,17 +364,17 @@ endpoint_ptr_get_epQueue_head(endpoint_t *endpoint_ptr) {
 static inline void
 endpoint_ptr_set_epQueue_head(endpoint_t *endpoint_ptr, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
-    endpoint_ptr->words[1] &= ~0xffffffffffffffffull;
+    assert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
+    endpoint_ptr->words[1] &= ~ULL_CONST(0xffffffffffffffff);
     endpoint_ptr->words[1] |= (v64 << 0) & 0xffffffffffffffff;
 }
 
 static inline uint64_t PURE
 endpoint_ptr_get_epQueue_tail(endpoint_t *endpoint_ptr) {
     uint64_t ret;
-    ret = (endpoint_ptr->words[0] & 0xfffffffffffcull) << 0;
+    ret = (endpoint_ptr->words[0] & ULL_CONST(0xfffffffffffc)) << 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(1 && (ret & (1ull << (47)))), 1)) {
+    if (__builtin_expect(!!(1 && (ret & (ULL_CONST(1) << (47)))), 1)) {
         ret |= 0xffff000000000000;
     }
     return ret;
@@ -383,17 +383,17 @@ endpoint_ptr_get_epQueue_tail(endpoint_t *endpoint_ptr) {
 static inline void
 endpoint_ptr_set_epQueue_tail(endpoint_t *endpoint_ptr, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0xfffffffffffcull << 0) | 0xffff000000000000) & v64) == ((1 && (v64 & (1ull << (47)))) ? 0xffff000000000000 : 0));
-    endpoint_ptr->words[0] &= ~0xfffffffffffcull;
+    assert((((~ULL_CONST(0xfffffffffffc) << 0) | 0xffff000000000000) & v64) == ((1 && (v64 & (ULL_CONST(1) << (47)))) ? 0xffff000000000000 : 0));
+    endpoint_ptr->words[0] &= ~ULL_CONST(0xfffffffffffc);
     endpoint_ptr->words[0] |= (v64 >> 0) & 0xfffffffffffc;
 }
 
 static inline uint64_t PURE
 endpoint_ptr_get_state(endpoint_t *endpoint_ptr) {
     uint64_t ret;
-    ret = (endpoint_ptr->words[0] & 0x3ull) >> 0;
+    ret = (endpoint_ptr->words[0] & ULL_CONST(0x3)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -402,8 +402,8 @@ endpoint_ptr_get_state(endpoint_t *endpoint_ptr) {
 static inline void
 endpoint_ptr_set_state(endpoint_t *endpoint_ptr, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0x3ull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
-    endpoint_ptr->words[0] &= ~0x3ull;
+    assert((((~ULL_CONST(0x3) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
+    endpoint_ptr->words[0] &= ~ULL_CONST(0x3);
     endpoint_ptr->words[0] |= (v64 << 0) & 0x3;
 }
 
@@ -417,31 +417,31 @@ gdt_tss_new(uint64_t base_63_32, uint64_t base_31_24, uint64_t granularity, uint
     gdt_tss_t gdt_tss;
 
     /* fail if user has passed bits that we will override */  
-    assert((base_63_32 & ~0xffffffffull) == ((1 && (base_63_32 & (1ull << 47))) ? 0x0 : 0));  
-    assert((base_31_24 & ~0xffull) == ((1 && (base_31_24 & (1ull << 47))) ? 0x0 : 0));  
-    assert((granularity & ~0x1ull) == ((1 && (granularity & (1ull << 47))) ? 0x0 : 0));  
-    assert((avl & ~0x1ull) == ((1 && (avl & (1ull << 47))) ? 0x0 : 0));  
-    assert((limit_high & ~0xfull) == ((1 && (limit_high & (1ull << 47))) ? 0x0 : 0));  
-    assert((present & ~0x1ull) == ((1 && (present & (1ull << 47))) ? 0x0 : 0));  
-    assert((dpl & ~0x3ull) == ((1 && (dpl & (1ull << 47))) ? 0x0 : 0));  
-    assert((desc_type & ~0xfull) == ((1 && (desc_type & (1ull << 47))) ? 0x0 : 0));  
-    assert((base_23_16 & ~0xffull) == ((1 && (base_23_16 & (1ull << 47))) ? 0x0 : 0));  
-    assert((base_15_0 & ~0xffffull) == ((1 && (base_15_0 & (1ull << 47))) ? 0x0 : 0));  
-    assert((limit_low & ~0xffffull) == ((1 && (limit_low & (1ull << 47))) ? 0x0 : 0));
+    assert((base_63_32 & ~ULL_CONST(0xffffffff)) == ((1 && (base_63_32 & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((base_31_24 & ~ULL_CONST(0xff)) == ((1 && (base_31_24 & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((granularity & ~ULL_CONST(0x1)) == ((1 && (granularity & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((avl & ~ULL_CONST(0x1)) == ((1 && (avl & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((limit_high & ~ULL_CONST(0xf)) == ((1 && (limit_high & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((present & ~ULL_CONST(0x1)) == ((1 && (present & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((dpl & ~ULL_CONST(0x3)) == ((1 && (dpl & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((desc_type & ~ULL_CONST(0xf)) == ((1 && (desc_type & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((base_23_16 & ~ULL_CONST(0xff)) == ((1 && (base_23_16 & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((base_15_0 & ~ULL_CONST(0xffff)) == ((1 && (base_15_0 & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((limit_low & ~ULL_CONST(0xffff)) == ((1 && (limit_low & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     gdt_tss.words[0] = 0
-        | (base_31_24 & 0xffull) << 56
-        | (granularity & 0x1ull) << 55
-        | (avl & 0x1ull) << 52
-        | (limit_high & 0xfull) << 48
-        | (present & 0x1ull) << 47
-        | (dpl & 0x3ull) << 45
-        | (desc_type & 0xfull) << 40
-        | (base_23_16 & 0xffull) << 32
-        | (base_15_0 & 0xffffull) << 16
-        | (limit_low & 0xffffull) << 0;
+        | (base_31_24 & ULL_CONST(0xff)) << 56
+        | (granularity & ULL_CONST(0x1)) << 55
+        | (avl & ULL_CONST(0x1)) << 52
+        | (limit_high & ULL_CONST(0xf)) << 48
+        | (present & ULL_CONST(0x1)) << 47
+        | (dpl & ULL_CONST(0x3)) << 45
+        | (desc_type & ULL_CONST(0xf)) << 40
+        | (base_23_16 & ULL_CONST(0xff)) << 32
+        | (base_15_0 & ULL_CONST(0xffff)) << 16
+        | (limit_low & ULL_CONST(0xffff)) << 0;
     gdt_tss.words[1] = 0
-        | (base_63_32 & 0xffffffffull) << 0;
+        | (base_63_32 & ULL_CONST(0xffffffff)) << 0;
 
     return gdt_tss;
 }
@@ -483,16 +483,16 @@ mdb_node_new(uint64_t mdbNext, uint64_t mdbRevocable, uint64_t mdbFirstBadged, u
     mdb_node_t mdb_node;
 
     /* fail if user has passed bits that we will override */  
-    assert((mdbNext & ~0xfffffffffffcull) == ((1 && (mdbNext & (1ull << 47))) ? 0xffff000000000000 : 0));  
-    assert((mdbRevocable & ~0x1ull) == ((1 && (mdbRevocable & (1ull << 47))) ? 0x0 : 0));  
-    assert((mdbFirstBadged & ~0x1ull) == ((1 && (mdbFirstBadged & (1ull << 47))) ? 0x0 : 0));
+    assert((mdbNext & ~ULL_CONST(0xfffffffffffc)) == ((1 && (mdbNext & (ULL_CONST(1) << 47))) ? 0xffff000000000000 : 0));  
+    assert((mdbRevocable & ~ULL_CONST(0x1)) == ((1 && (mdbRevocable & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((mdbFirstBadged & ~ULL_CONST(0x1)) == ((1 && (mdbFirstBadged & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     mdb_node.words[0] = 0
         | mdbPrev << 0;;
     mdb_node.words[1] = 0
-        | (mdbNext & 0xfffffffffffcull) >> 0
-        | (mdbRevocable & 0x1ull) << 1
-        | (mdbFirstBadged & 0x1ull) << 0;
+        | (mdbNext & ULL_CONST(0xfffffffffffc)) >> 0
+        | (mdbRevocable & ULL_CONST(0x1)) << 1
+        | (mdbFirstBadged & ULL_CONST(0x1)) << 0;
 
     return mdb_node;
 }
@@ -500,9 +500,9 @@ mdb_node_new(uint64_t mdbNext, uint64_t mdbRevocable, uint64_t mdbFirstBadged, u
 static inline uint64_t CONST
 mdb_node_get_mdbNext(mdb_node_t mdb_node) {
     uint64_t ret;
-    ret = (mdb_node.words[1] & 0xfffffffffffcull) << 0;
+    ret = (mdb_node.words[1] & ULL_CONST(0xfffffffffffc)) << 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(1 && (ret & (1ull << (47)))), 1)) {
+    if (__builtin_expect(!!(1 && (ret & (ULL_CONST(1) << (47)))), 1)) {
         ret |= 0xffff000000000000;
     }
     return ret;
@@ -511,17 +511,17 @@ mdb_node_get_mdbNext(mdb_node_t mdb_node) {
 static inline void
 mdb_node_ptr_set_mdbNext(mdb_node_t *mdb_node_ptr, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0xfffffffffffcull << 0) | 0xffff000000000000) & v64) == ((1 && (v64 & (1ull << (47)))) ? 0xffff000000000000 : 0));
-    mdb_node_ptr->words[1] &= ~0xfffffffffffcull;
+    assert((((~ULL_CONST(0xfffffffffffc) << 0) | 0xffff000000000000) & v64) == ((1 && (v64 & (ULL_CONST(1) << (47)))) ? 0xffff000000000000 : 0));
+    mdb_node_ptr->words[1] &= ~ULL_CONST(0xfffffffffffc);
     mdb_node_ptr->words[1] |= (v64 >> 0) & 0xfffffffffffc;
 }
 
 static inline uint64_t CONST
 mdb_node_get_mdbRevocable(mdb_node_t mdb_node) {
     uint64_t ret;
-    ret = (mdb_node.words[1] & 0x2ull) >> 1;
+    ret = (mdb_node.words[1] & ULL_CONST(0x2)) >> 1;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -530,26 +530,26 @@ mdb_node_get_mdbRevocable(mdb_node_t mdb_node) {
 static inline mdb_node_t CONST
 mdb_node_set_mdbRevocable(mdb_node_t mdb_node, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0x2ull >> 1 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
-    mdb_node.words[1] &= ~0x2ull;
-    mdb_node.words[1] |= (v64 << 1) & 0x2ull;
+    assert((((~ULL_CONST(0x2) >> 1 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
+    mdb_node.words[1] &= ~ULL_CONST(0x2);
+    mdb_node.words[1] |= (v64 << 1) & ULL_CONST(0x2);
     return mdb_node;
 }
 
 static inline void
 mdb_node_ptr_set_mdbRevocable(mdb_node_t *mdb_node_ptr, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0x2ull >> 1) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
-    mdb_node_ptr->words[1] &= ~0x2ull;
+    assert((((~ULL_CONST(0x2) >> 1) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
+    mdb_node_ptr->words[1] &= ~ULL_CONST(0x2);
     mdb_node_ptr->words[1] |= (v64 << 1) & 0x2;
 }
 
 static inline uint64_t CONST
 mdb_node_get_mdbFirstBadged(mdb_node_t mdb_node) {
     uint64_t ret;
-    ret = (mdb_node.words[1] & 0x1ull) >> 0;
+    ret = (mdb_node.words[1] & ULL_CONST(0x1)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -558,26 +558,26 @@ mdb_node_get_mdbFirstBadged(mdb_node_t mdb_node) {
 static inline mdb_node_t CONST
 mdb_node_set_mdbFirstBadged(mdb_node_t mdb_node, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0x1ull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
-    mdb_node.words[1] &= ~0x1ull;
-    mdb_node.words[1] |= (v64 << 0) & 0x1ull;
+    assert((((~ULL_CONST(0x1) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
+    mdb_node.words[1] &= ~ULL_CONST(0x1);
+    mdb_node.words[1] |= (v64 << 0) & ULL_CONST(0x1);
     return mdb_node;
 }
 
 static inline void
 mdb_node_ptr_set_mdbFirstBadged(mdb_node_t *mdb_node_ptr, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0x1ull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
-    mdb_node_ptr->words[1] &= ~0x1ull;
+    assert((((~ULL_CONST(0x1) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
+    mdb_node_ptr->words[1] &= ~ULL_CONST(0x1);
     mdb_node_ptr->words[1] |= (v64 << 0) & 0x1;
 }
 
 static inline uint64_t CONST
 mdb_node_get_mdbPrev(mdb_node_t mdb_node) {
     uint64_t ret;
-    ret = (mdb_node.words[0] & 0xffffffffffffffffull) >> 0;
+    ret = (mdb_node.words[0] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -586,17 +586,17 @@ mdb_node_get_mdbPrev(mdb_node_t mdb_node) {
 static inline mdb_node_t CONST
 mdb_node_set_mdbPrev(mdb_node_t mdb_node, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
-    mdb_node.words[0] &= ~0xffffffffffffffffull;
-    mdb_node.words[0] |= (v64 << 0) & 0xffffffffffffffffull;
+    assert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
+    mdb_node.words[0] &= ~ULL_CONST(0xffffffffffffffff);
+    mdb_node.words[0] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return mdb_node;
 }
 
 static inline void
 mdb_node_ptr_set_mdbPrev(mdb_node_t *mdb_node_ptr, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
-    mdb_node_ptr->words[0] &= ~0xffffffffffffffffull;
+    assert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
+    mdb_node_ptr->words[0] &= ~ULL_CONST(0xffffffffffffffff);
     mdb_node_ptr->words[0] |= (v64 << 0) & 0xffffffffffffffff;
 }
 
@@ -608,9 +608,9 @@ typedef struct notification notification_t;
 static inline uint64_t PURE
 notification_ptr_get_ntfnBoundTCB(notification_t *notification_ptr) {
     uint64_t ret;
-    ret = (notification_ptr->words[3] & 0xffffffffffffull) << 0;
+    ret = (notification_ptr->words[3] & ULL_CONST(0xffffffffffff)) << 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(1 && (ret & (1ull << (47)))), 1)) {
+    if (__builtin_expect(!!(1 && (ret & (ULL_CONST(1) << (47)))), 1)) {
         ret |= 0xffff000000000000;
     }
     return ret;
@@ -619,17 +619,17 @@ notification_ptr_get_ntfnBoundTCB(notification_t *notification_ptr) {
 static inline void
 notification_ptr_set_ntfnBoundTCB(notification_t *notification_ptr, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0xffffffffffffull << 0) | 0xffff000000000000) & v64) == ((1 && (v64 & (1ull << (47)))) ? 0xffff000000000000 : 0));
-    notification_ptr->words[3] &= ~0xffffffffffffull;
+    assert((((~ULL_CONST(0xffffffffffff) << 0) | 0xffff000000000000) & v64) == ((1 && (v64 & (ULL_CONST(1) << (47)))) ? 0xffff000000000000 : 0));
+    notification_ptr->words[3] &= ~ULL_CONST(0xffffffffffff);
     notification_ptr->words[3] |= (v64 >> 0) & 0xffffffffffff;
 }
 
 static inline uint64_t PURE
 notification_ptr_get_ntfnMsgIdentifier(notification_t *notification_ptr) {
     uint64_t ret;
-    ret = (notification_ptr->words[2] & 0xffffffffffffffffull) >> 0;
+    ret = (notification_ptr->words[2] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -638,17 +638,17 @@ notification_ptr_get_ntfnMsgIdentifier(notification_t *notification_ptr) {
 static inline void
 notification_ptr_set_ntfnMsgIdentifier(notification_t *notification_ptr, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
-    notification_ptr->words[2] &= ~0xffffffffffffffffull;
+    assert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
+    notification_ptr->words[2] &= ~ULL_CONST(0xffffffffffffffff);
     notification_ptr->words[2] |= (v64 << 0) & 0xffffffffffffffff;
 }
 
 static inline uint64_t PURE
 notification_ptr_get_ntfnQueue_head(notification_t *notification_ptr) {
     uint64_t ret;
-    ret = (notification_ptr->words[1] & 0xffffffffffffull) << 0;
+    ret = (notification_ptr->words[1] & ULL_CONST(0xffffffffffff)) << 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(1 && (ret & (1ull << (47)))), 1)) {
+    if (__builtin_expect(!!(1 && (ret & (ULL_CONST(1) << (47)))), 1)) {
         ret |= 0xffff000000000000;
     }
     return ret;
@@ -657,17 +657,17 @@ notification_ptr_get_ntfnQueue_head(notification_t *notification_ptr) {
 static inline void
 notification_ptr_set_ntfnQueue_head(notification_t *notification_ptr, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0xffffffffffffull << 0) | 0xffff000000000000) & v64) == ((1 && (v64 & (1ull << (47)))) ? 0xffff000000000000 : 0));
-    notification_ptr->words[1] &= ~0xffffffffffffull;
+    assert((((~ULL_CONST(0xffffffffffff) << 0) | 0xffff000000000000) & v64) == ((1 && (v64 & (ULL_CONST(1) << (47)))) ? 0xffff000000000000 : 0));
+    notification_ptr->words[1] &= ~ULL_CONST(0xffffffffffff);
     notification_ptr->words[1] |= (v64 >> 0) & 0xffffffffffff;
 }
 
 static inline uint64_t PURE
 notification_ptr_get_ntfnQueue_tail(notification_t *notification_ptr) {
     uint64_t ret;
-    ret = (notification_ptr->words[0] & 0xffffffffffff0000ull) >> 16;
+    ret = (notification_ptr->words[0] & ULL_CONST(0xffffffffffff0000)) >> 16;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(1 && (ret & (1ull << (47)))), 1)) {
+    if (__builtin_expect(!!(1 && (ret & (ULL_CONST(1) << (47)))), 1)) {
         ret |= 0xffff000000000000;
     }
     return ret;
@@ -676,17 +676,17 @@ notification_ptr_get_ntfnQueue_tail(notification_t *notification_ptr) {
 static inline void
 notification_ptr_set_ntfnQueue_tail(notification_t *notification_ptr, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0xffffffffffff0000ull >> 16) | 0xffff000000000000) & v64) == ((1 && (v64 & (1ull << (47)))) ? 0xffff000000000000 : 0));
-    notification_ptr->words[0] &= ~0xffffffffffff0000ull;
+    assert((((~ULL_CONST(0xffffffffffff0000) >> 16) | 0xffff000000000000) & v64) == ((1 && (v64 & (ULL_CONST(1) << (47)))) ? 0xffff000000000000 : 0));
+    notification_ptr->words[0] &= ~ULL_CONST(0xffffffffffff0000);
     notification_ptr->words[0] |= (v64 << 16) & 0xffffffffffff0000;
 }
 
 static inline uint64_t PURE
 notification_ptr_get_state(notification_t *notification_ptr) {
     uint64_t ret;
-    ret = (notification_ptr->words[0] & 0x3ull) >> 0;
+    ret = (notification_ptr->words[0] & ULL_CONST(0x3)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -695,8 +695,8 @@ notification_ptr_get_state(notification_t *notification_ptr) {
 static inline void
 notification_ptr_set_state(notification_t *notification_ptr, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0x3ull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
-    notification_ptr->words[0] &= ~0x3ull;
+    assert((((~ULL_CONST(0x3) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
+    notification_ptr->words[0] &= ~ULL_CONST(0x3);
     notification_ptr->words[0] |= (v64 << 0) & 0x3;
 }
 
@@ -710,24 +710,24 @@ pml4e_new(uint64_t xd, uint64_t pdpt_base_address, uint64_t accessed, uint64_t c
     pml4e_t pml4e;
 
     /* fail if user has passed bits that we will override */  
-    assert((xd & ~0x1ull) == ((0 && (xd & (1ull << 50))) ? 0x0 : 0));  
-    assert((pdpt_base_address & ~0x7fffffffff000ull) == ((0 && (pdpt_base_address & (1ull << 50))) ? 0x0 : 0));  
-    assert((accessed & ~0x1ull) == ((0 && (accessed & (1ull << 50))) ? 0x0 : 0));  
-    assert((cache_disabled & ~0x1ull) == ((0 && (cache_disabled & (1ull << 50))) ? 0x0 : 0));  
-    assert((write_through & ~0x1ull) == ((0 && (write_through & (1ull << 50))) ? 0x0 : 0));  
-    assert((super_user & ~0x1ull) == ((0 && (super_user & (1ull << 50))) ? 0x0 : 0));  
-    assert((read_write & ~0x1ull) == ((0 && (read_write & (1ull << 50))) ? 0x0 : 0));  
-    assert((present & ~0x1ull) == ((0 && (present & (1ull << 50))) ? 0x0 : 0));
+    assert((xd & ~ULL_CONST(0x1)) == ((0 && (xd & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((pdpt_base_address & ~ULL_CONST(0x7fffffffff000)) == ((0 && (pdpt_base_address & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((accessed & ~ULL_CONST(0x1)) == ((0 && (accessed & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((cache_disabled & ~ULL_CONST(0x1)) == ((0 && (cache_disabled & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((write_through & ~ULL_CONST(0x1)) == ((0 && (write_through & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((super_user & ~ULL_CONST(0x1)) == ((0 && (super_user & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((read_write & ~ULL_CONST(0x1)) == ((0 && (read_write & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((present & ~ULL_CONST(0x1)) == ((0 && (present & (ULL_CONST(1) << 50))) ? 0x0 : 0));
 
     pml4e.words[0] = 0
-        | (xd & 0x1ull) << 63
-        | (pdpt_base_address & 0x7fffffffff000ull) >> 0
-        | (accessed & 0x1ull) << 5
-        | (cache_disabled & 0x1ull) << 4
-        | (write_through & 0x1ull) << 3
-        | (super_user & 0x1ull) << 2
-        | (read_write & 0x1ull) << 1
-        | (present & 0x1ull) << 0;
+        | (xd & ULL_CONST(0x1)) << 63
+        | (pdpt_base_address & ULL_CONST(0x7fffffffff000)) >> 0
+        | (accessed & ULL_CONST(0x1)) << 5
+        | (cache_disabled & ULL_CONST(0x1)) << 4
+        | (write_through & ULL_CONST(0x1)) << 3
+        | (super_user & ULL_CONST(0x1)) << 2
+        | (read_write & ULL_CONST(0x1)) << 1
+        | (present & ULL_CONST(0x1)) << 0;
 
     return pml4e;
 }
@@ -735,9 +735,9 @@ pml4e_new(uint64_t xd, uint64_t pdpt_base_address, uint64_t accessed, uint64_t c
 static inline uint64_t PURE
 pml4e_ptr_get_pdpt_base_address(pml4e_t *pml4e_ptr) {
     uint64_t ret;
-    ret = (pml4e_ptr->words[0] & 0x7fffffffff000ull) << 0;
+    ret = (pml4e_ptr->words[0] & ULL_CONST(0x7fffffffff000)) << 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (50)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (50)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -746,9 +746,9 @@ pml4e_ptr_get_pdpt_base_address(pml4e_t *pml4e_ptr) {
 static inline uint64_t PURE
 pml4e_ptr_get_present(pml4e_t *pml4e_ptr) {
     uint64_t ret;
-    ret = (pml4e_ptr->words[0] & 0x1ull) >> 0;
+    ret = (pml4e_ptr->words[0] & ULL_CONST(0x1)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (50)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (50)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -764,30 +764,30 @@ pte_new(uint64_t xd, uint64_t page_base_address, uint64_t global, uint64_t pat, 
     pte_t pte;
 
     /* fail if user has passed bits that we will override */  
-    assert((xd & ~0x1ull) == ((0 && (xd & (1ull << 50))) ? 0x0 : 0));  
-    assert((page_base_address & ~0x7fffffffff000ull) == ((0 && (page_base_address & (1ull << 50))) ? 0x0 : 0));  
-    assert((global & ~0x1ull) == ((0 && (global & (1ull << 50))) ? 0x0 : 0));  
-    assert((pat & ~0x1ull) == ((0 && (pat & (1ull << 50))) ? 0x0 : 0));  
-    assert((dirty & ~0x1ull) == ((0 && (dirty & (1ull << 50))) ? 0x0 : 0));  
-    assert((accessed & ~0x1ull) == ((0 && (accessed & (1ull << 50))) ? 0x0 : 0));  
-    assert((cache_disabled & ~0x1ull) == ((0 && (cache_disabled & (1ull << 50))) ? 0x0 : 0));  
-    assert((write_through & ~0x1ull) == ((0 && (write_through & (1ull << 50))) ? 0x0 : 0));  
-    assert((super_user & ~0x1ull) == ((0 && (super_user & (1ull << 50))) ? 0x0 : 0));  
-    assert((read_write & ~0x1ull) == ((0 && (read_write & (1ull << 50))) ? 0x0 : 0));  
-    assert((present & ~0x1ull) == ((0 && (present & (1ull << 50))) ? 0x0 : 0));
+    assert((xd & ~ULL_CONST(0x1)) == ((0 && (xd & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((page_base_address & ~ULL_CONST(0x7fffffffff000)) == ((0 && (page_base_address & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((global & ~ULL_CONST(0x1)) == ((0 && (global & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((pat & ~ULL_CONST(0x1)) == ((0 && (pat & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((dirty & ~ULL_CONST(0x1)) == ((0 && (dirty & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((accessed & ~ULL_CONST(0x1)) == ((0 && (accessed & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((cache_disabled & ~ULL_CONST(0x1)) == ((0 && (cache_disabled & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((write_through & ~ULL_CONST(0x1)) == ((0 && (write_through & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((super_user & ~ULL_CONST(0x1)) == ((0 && (super_user & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((read_write & ~ULL_CONST(0x1)) == ((0 && (read_write & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((present & ~ULL_CONST(0x1)) == ((0 && (present & (ULL_CONST(1) << 50))) ? 0x0 : 0));
 
     pte.words[0] = 0
-        | (xd & 0x1ull) << 63
-        | (page_base_address & 0x7fffffffff000ull) >> 0
-        | (global & 0x1ull) << 8
-        | (pat & 0x1ull) << 7
-        | (dirty & 0x1ull) << 6
-        | (accessed & 0x1ull) << 5
-        | (cache_disabled & 0x1ull) << 4
-        | (write_through & 0x1ull) << 3
-        | (super_user & 0x1ull) << 2
-        | (read_write & 0x1ull) << 1
-        | (present & 0x1ull) << 0;
+        | (xd & ULL_CONST(0x1)) << 63
+        | (page_base_address & ULL_CONST(0x7fffffffff000)) >> 0
+        | (global & ULL_CONST(0x1)) << 8
+        | (pat & ULL_CONST(0x1)) << 7
+        | (dirty & ULL_CONST(0x1)) << 6
+        | (accessed & ULL_CONST(0x1)) << 5
+        | (cache_disabled & ULL_CONST(0x1)) << 4
+        | (write_through & ULL_CONST(0x1)) << 3
+        | (super_user & ULL_CONST(0x1)) << 2
+        | (read_write & ULL_CONST(0x1)) << 1
+        | (present & ULL_CONST(0x1)) << 0;
 
     return pte;
 }
@@ -795,9 +795,9 @@ pte_new(uint64_t xd, uint64_t page_base_address, uint64_t global, uint64_t pat, 
 static inline uint64_t PURE
 pte_ptr_get_page_base_address(pte_t *pte_ptr) {
     uint64_t ret;
-    ret = (pte_ptr->words[0] & 0x7fffffffff000ull) << 0;
+    ret = (pte_ptr->words[0] & ULL_CONST(0x7fffffffff000)) << 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (50)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (50)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -806,9 +806,9 @@ pte_ptr_get_page_base_address(pte_t *pte_ptr) {
 static inline uint64_t CONST
 pte_get_present(pte_t pte) {
     uint64_t ret;
-    ret = (pte.words[0] & 0x1ull) >> 0;
+    ret = (pte.words[0] & ULL_CONST(0x1)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (50)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (50)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -817,9 +817,9 @@ pte_get_present(pte_t pte) {
 static inline uint64_t PURE
 pte_ptr_get_present(pte_t *pte_ptr) {
     uint64_t ret;
-    ret = (pte_ptr->words[0] & 0x1ull) >> 0;
+    ret = (pte_ptr->words[0] & ULL_CONST(0x1)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (50)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (50)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -838,9 +838,9 @@ typedef struct thread_state thread_state_t;
 static inline uint64_t PURE
 thread_state_ptr_get_blockingIPCBadge(thread_state_t *thread_state_ptr) {
     uint64_t ret;
-    ret = (thread_state_ptr->words[2] & 0xffffffffffffffffull) >> 0;
+    ret = (thread_state_ptr->words[2] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -849,17 +849,17 @@ thread_state_ptr_get_blockingIPCBadge(thread_state_t *thread_state_ptr) {
 static inline void
 thread_state_ptr_set_blockingIPCBadge(thread_state_t *thread_state_ptr, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
-    thread_state_ptr->words[2] &= ~0xffffffffffffffffull;
+    assert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
+    thread_state_ptr->words[2] &= ~ULL_CONST(0xffffffffffffffff);
     thread_state_ptr->words[2] |= (v64 << 0) & 0xffffffffffffffff;
 }
 
 static inline uint64_t PURE
 thread_state_ptr_get_blockingIPCCanGrant(thread_state_t *thread_state_ptr) {
     uint64_t ret;
-    ret = (thread_state_ptr->words[1] & 0x8ull) >> 3;
+    ret = (thread_state_ptr->words[1] & ULL_CONST(0x8)) >> 3;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -868,17 +868,17 @@ thread_state_ptr_get_blockingIPCCanGrant(thread_state_t *thread_state_ptr) {
 static inline void
 thread_state_ptr_set_blockingIPCCanGrant(thread_state_t *thread_state_ptr, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0x8ull >> 3) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
-    thread_state_ptr->words[1] &= ~0x8ull;
+    assert((((~ULL_CONST(0x8) >> 3) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
+    thread_state_ptr->words[1] &= ~ULL_CONST(0x8);
     thread_state_ptr->words[1] |= (v64 << 3) & 0x8;
 }
 
 static inline uint64_t PURE
 thread_state_ptr_get_blockingIPCCanGrantReply(thread_state_t *thread_state_ptr) {
     uint64_t ret;
-    ret = (thread_state_ptr->words[1] & 0x4ull) >> 2;
+    ret = (thread_state_ptr->words[1] & ULL_CONST(0x4)) >> 2;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -887,17 +887,17 @@ thread_state_ptr_get_blockingIPCCanGrantReply(thread_state_t *thread_state_ptr) 
 static inline void
 thread_state_ptr_set_blockingIPCCanGrantReply(thread_state_t *thread_state_ptr, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0x4ull >> 2) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
-    thread_state_ptr->words[1] &= ~0x4ull;
+    assert((((~ULL_CONST(0x4) >> 2) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
+    thread_state_ptr->words[1] &= ~ULL_CONST(0x4);
     thread_state_ptr->words[1] |= (v64 << 2) & 0x4;
 }
 
 static inline uint64_t PURE
 thread_state_ptr_get_blockingIPCIsCall(thread_state_t *thread_state_ptr) {
     uint64_t ret;
-    ret = (thread_state_ptr->words[1] & 0x2ull) >> 1;
+    ret = (thread_state_ptr->words[1] & ULL_CONST(0x2)) >> 1;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -906,17 +906,17 @@ thread_state_ptr_get_blockingIPCIsCall(thread_state_t *thread_state_ptr) {
 static inline void
 thread_state_ptr_set_blockingIPCIsCall(thread_state_t *thread_state_ptr, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0x2ull >> 1) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
-    thread_state_ptr->words[1] &= ~0x2ull;
+    assert((((~ULL_CONST(0x2) >> 1) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
+    thread_state_ptr->words[1] &= ~ULL_CONST(0x2);
     thread_state_ptr->words[1] |= (v64 << 1) & 0x2;
 }
 
 static inline uint64_t CONST
 thread_state_get_tcbQueued(thread_state_t thread_state) {
     uint64_t ret;
-    ret = (thread_state.words[1] & 0x1ull) >> 0;
+    ret = (thread_state.words[1] & ULL_CONST(0x1)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -925,17 +925,17 @@ thread_state_get_tcbQueued(thread_state_t thread_state) {
 static inline void
 thread_state_ptr_set_tcbQueued(thread_state_t *thread_state_ptr, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0x1ull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
-    thread_state_ptr->words[1] &= ~0x1ull;
+    assert((((~ULL_CONST(0x1) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
+    thread_state_ptr->words[1] &= ~ULL_CONST(0x1);
     thread_state_ptr->words[1] |= (v64 << 0) & 0x1;
 }
 
 static inline uint64_t PURE
 thread_state_ptr_get_blockingObject(thread_state_t *thread_state_ptr) {
     uint64_t ret;
-    ret = (thread_state_ptr->words[0] & 0xfffffffffff0ull) << 0;
+    ret = (thread_state_ptr->words[0] & ULL_CONST(0xfffffffffff0)) << 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(1 && (ret & (1ull << (47)))), 1)) {
+    if (__builtin_expect(!!(1 && (ret & (ULL_CONST(1) << (47)))), 1)) {
         ret |= 0xffff000000000000;
     }
     return ret;
@@ -944,17 +944,17 @@ thread_state_ptr_get_blockingObject(thread_state_t *thread_state_ptr) {
 static inline void
 thread_state_ptr_set_blockingObject(thread_state_t *thread_state_ptr, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0xfffffffffff0ull << 0) | 0xffff000000000000) & v64) == ((1 && (v64 & (1ull << (47)))) ? 0xffff000000000000 : 0));
-    thread_state_ptr->words[0] &= ~0xfffffffffff0ull;
+    assert((((~ULL_CONST(0xfffffffffff0) << 0) | 0xffff000000000000) & v64) == ((1 && (v64 & (ULL_CONST(1) << (47)))) ? 0xffff000000000000 : 0));
+    thread_state_ptr->words[0] &= ~ULL_CONST(0xfffffffffff0);
     thread_state_ptr->words[0] |= (v64 >> 0) & 0xfffffffffff0;
 }
 
 static inline uint64_t CONST
 thread_state_get_tsType(thread_state_t thread_state) {
     uint64_t ret;
-    ret = (thread_state.words[0] & 0xfull) >> 0;
+    ret = (thread_state.words[0] & ULL_CONST(0xf)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -963,9 +963,9 @@ thread_state_get_tsType(thread_state_t thread_state) {
 static inline uint64_t PURE
 thread_state_ptr_get_tsType(thread_state_t *thread_state_ptr) {
     uint64_t ret;
-    ret = (thread_state_ptr->words[0] & 0xfull) >> 0;
+    ret = (thread_state_ptr->words[0] & ULL_CONST(0xf)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -974,8 +974,8 @@ thread_state_ptr_get_tsType(thread_state_t *thread_state_ptr) {
 static inline void
 thread_state_ptr_set_tsType(thread_state_t *thread_state_ptr, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0xfull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
-    thread_state_ptr->words[0] &= ~0xfull;
+    assert((((~ULL_CONST(0xf) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
+    thread_state_ptr->words[0] &= ~ULL_CONST(0xf);
     thread_state_ptr->words[0] |= (v64 << 0) & 0xf;
 }
 
@@ -989,62 +989,62 @@ tss_new(uint64_t io_map_base, uint64_t ist7_u, uint64_t ist7_l, uint64_t ist6_u,
     tss_t tss;
 
     /* fail if user has passed bits that we will override */  
-    assert((io_map_base & ~0xffffull) == ((1 && (io_map_base & (1ull << 47))) ? 0x0 : 0));  
-    assert((ist7_u & ~0xffffffffull) == ((1 && (ist7_u & (1ull << 47))) ? 0x0 : 0));  
-    assert((ist7_l & ~0xffffffffull) == ((1 && (ist7_l & (1ull << 47))) ? 0x0 : 0));  
-    assert((ist6_u & ~0xffffffffull) == ((1 && (ist6_u & (1ull << 47))) ? 0x0 : 0));  
-    assert((ist6_l & ~0xffffffffull) == ((1 && (ist6_l & (1ull << 47))) ? 0x0 : 0));  
-    assert((ist5_u & ~0xffffffffull) == ((1 && (ist5_u & (1ull << 47))) ? 0x0 : 0));  
-    assert((ist5_l & ~0xffffffffull) == ((1 && (ist5_l & (1ull << 47))) ? 0x0 : 0));  
-    assert((ist4_u & ~0xffffffffull) == ((1 && (ist4_u & (1ull << 47))) ? 0x0 : 0));  
-    assert((ist4_l & ~0xffffffffull) == ((1 && (ist4_l & (1ull << 47))) ? 0x0 : 0));  
-    assert((ist3_u & ~0xffffffffull) == ((1 && (ist3_u & (1ull << 47))) ? 0x0 : 0));  
-    assert((ist3_l & ~0xffffffffull) == ((1 && (ist3_l & (1ull << 47))) ? 0x0 : 0));  
-    assert((ist2_u & ~0xffffffffull) == ((1 && (ist2_u & (1ull << 47))) ? 0x0 : 0));  
-    assert((ist2_l & ~0xffffffffull) == ((1 && (ist2_l & (1ull << 47))) ? 0x0 : 0));  
-    assert((ist1_u & ~0xffffffffull) == ((1 && (ist1_u & (1ull << 47))) ? 0x0 : 0));  
-    assert((ist1_l & ~0xffffffffull) == ((1 && (ist1_l & (1ull << 47))) ? 0x0 : 0));  
-    assert((rsp2_u & ~0xffffffffull) == ((1 && (rsp2_u & (1ull << 47))) ? 0x0 : 0));  
-    assert((rsp2_l & ~0xffffffffull) == ((1 && (rsp2_l & (1ull << 47))) ? 0x0 : 0));  
-    assert((rsp1_u & ~0xffffffffull) == ((1 && (rsp1_u & (1ull << 47))) ? 0x0 : 0));  
-    assert((rsp1_l & ~0xffffffffull) == ((1 && (rsp1_l & (1ull << 47))) ? 0x0 : 0));  
-    assert((rsp0_u & ~0xffffffffull) == ((1 && (rsp0_u & (1ull << 47))) ? 0x0 : 0));  
-    assert((rsp0_l & ~0xffffffffull) == ((1 && (rsp0_l & (1ull << 47))) ? 0x0 : 0));
+    assert((io_map_base & ~ULL_CONST(0xffff)) == ((1 && (io_map_base & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((ist7_u & ~ULL_CONST(0xffffffff)) == ((1 && (ist7_u & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((ist7_l & ~ULL_CONST(0xffffffff)) == ((1 && (ist7_l & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((ist6_u & ~ULL_CONST(0xffffffff)) == ((1 && (ist6_u & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((ist6_l & ~ULL_CONST(0xffffffff)) == ((1 && (ist6_l & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((ist5_u & ~ULL_CONST(0xffffffff)) == ((1 && (ist5_u & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((ist5_l & ~ULL_CONST(0xffffffff)) == ((1 && (ist5_l & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((ist4_u & ~ULL_CONST(0xffffffff)) == ((1 && (ist4_u & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((ist4_l & ~ULL_CONST(0xffffffff)) == ((1 && (ist4_l & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((ist3_u & ~ULL_CONST(0xffffffff)) == ((1 && (ist3_u & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((ist3_l & ~ULL_CONST(0xffffffff)) == ((1 && (ist3_l & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((ist2_u & ~ULL_CONST(0xffffffff)) == ((1 && (ist2_u & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((ist2_l & ~ULL_CONST(0xffffffff)) == ((1 && (ist2_l & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((ist1_u & ~ULL_CONST(0xffffffff)) == ((1 && (ist1_u & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((ist1_l & ~ULL_CONST(0xffffffff)) == ((1 && (ist1_l & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((rsp2_u & ~ULL_CONST(0xffffffff)) == ((1 && (rsp2_u & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((rsp2_l & ~ULL_CONST(0xffffffff)) == ((1 && (rsp2_l & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((rsp1_u & ~ULL_CONST(0xffffffff)) == ((1 && (rsp1_u & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((rsp1_l & ~ULL_CONST(0xffffffff)) == ((1 && (rsp1_l & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((rsp0_u & ~ULL_CONST(0xffffffff)) == ((1 && (rsp0_u & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((rsp0_l & ~ULL_CONST(0xffffffff)) == ((1 && (rsp0_l & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     tss.words[0] = 0
-        | (rsp0_l & 0xffffffffull) << 32;
+        | (rsp0_l & ULL_CONST(0xffffffff)) << 32;
     tss.words[1] = 0
-        | (rsp1_l & 0xffffffffull) << 32
-        | (rsp0_u & 0xffffffffull) << 0;
+        | (rsp1_l & ULL_CONST(0xffffffff)) << 32
+        | (rsp0_u & ULL_CONST(0xffffffff)) << 0;
     tss.words[2] = 0
-        | (rsp2_l & 0xffffffffull) << 32
-        | (rsp1_u & 0xffffffffull) << 0;
+        | (rsp2_l & ULL_CONST(0xffffffff)) << 32
+        | (rsp1_u & ULL_CONST(0xffffffff)) << 0;
     tss.words[3] = 0
-        | (rsp2_u & 0xffffffffull) << 0;
+        | (rsp2_u & ULL_CONST(0xffffffff)) << 0;
     tss.words[4] = 0
-        | (ist1_l & 0xffffffffull) << 32;
+        | (ist1_l & ULL_CONST(0xffffffff)) << 32;
     tss.words[5] = 0
-        | (ist2_l & 0xffffffffull) << 32
-        | (ist1_u & 0xffffffffull) << 0;
+        | (ist2_l & ULL_CONST(0xffffffff)) << 32
+        | (ist1_u & ULL_CONST(0xffffffff)) << 0;
     tss.words[6] = 0
-        | (ist3_l & 0xffffffffull) << 32
-        | (ist2_u & 0xffffffffull) << 0;
+        | (ist3_l & ULL_CONST(0xffffffff)) << 32
+        | (ist2_u & ULL_CONST(0xffffffff)) << 0;
     tss.words[7] = 0
-        | (ist4_l & 0xffffffffull) << 32
-        | (ist3_u & 0xffffffffull) << 0;
+        | (ist4_l & ULL_CONST(0xffffffff)) << 32
+        | (ist3_u & ULL_CONST(0xffffffff)) << 0;
     tss.words[8] = 0
-        | (ist5_l & 0xffffffffull) << 32
-        | (ist4_u & 0xffffffffull) << 0;
+        | (ist5_l & ULL_CONST(0xffffffff)) << 32
+        | (ist4_u & ULL_CONST(0xffffffff)) << 0;
     tss.words[9] = 0
-        | (ist6_l & 0xffffffffull) << 32
-        | (ist5_u & 0xffffffffull) << 0;
+        | (ist6_l & ULL_CONST(0xffffffff)) << 32
+        | (ist5_u & ULL_CONST(0xffffffff)) << 0;
     tss.words[10] = 0
-        | (ist7_l & 0xffffffffull) << 32
-        | (ist6_u & 0xffffffffull) << 0;
+        | (ist7_l & ULL_CONST(0xffffffff)) << 32
+        | (ist6_u & ULL_CONST(0xffffffff)) << 0;
     tss.words[11] = 0
-        | (ist7_u & 0xffffffffull) << 0;
+        | (ist7_u & ULL_CONST(0xffffffff)) << 0;
     tss.words[12] = 0
-        | (io_map_base & 0xffffull) << 48;
+        | (io_map_base & ULL_CONST(0xffff)) << 48;
 
     return tss;
 }
@@ -1057,9 +1057,9 @@ typedef struct vm_attributes vm_attributes_t;
 static inline uint64_t CONST
 vm_attributes_get_x86PATBit(vm_attributes_t vm_attributes) {
     uint64_t ret;
-    ret = (vm_attributes.words[0] & 0x4ull) >> 2;
+    ret = (vm_attributes.words[0] & ULL_CONST(0x4)) >> 2;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1068,9 +1068,9 @@ vm_attributes_get_x86PATBit(vm_attributes_t vm_attributes) {
 static inline uint64_t CONST
 vm_attributes_get_x86PCDBit(vm_attributes_t vm_attributes) {
     uint64_t ret;
-    ret = (vm_attributes.words[0] & 0x2ull) >> 1;
+    ret = (vm_attributes.words[0] & ULL_CONST(0x2)) >> 1;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1079,9 +1079,9 @@ vm_attributes_get_x86PCDBit(vm_attributes_t vm_attributes) {
 static inline uint64_t CONST
 vm_attributes_get_x86PWTBit(vm_attributes_t vm_attributes) {
     uint64_t ret;
-    ret = (vm_attributes.words[0] & 0x1ull) >> 0;
+    ret = (vm_attributes.words[0] & ULL_CONST(0x1)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1160,7 +1160,7 @@ typedef enum asid_map_tag asid_map_tag_t;
 
 static inline uint64_t CONST
 asid_map_get_type(asid_map_t asid_map) {
-    return (asid_map.words[0] >> 0) & 0x3ull;
+    return (asid_map.words[0] >> 0) & ULL_CONST(0x3);
 }
 
 static inline asid_map_t CONST
@@ -1168,10 +1168,10 @@ asid_map_asid_map_none_new(void) {
     asid_map_t asid_map;
 
     /* fail if user has passed bits that we will override */  
-    assert(((uint64_t)asid_map_asid_map_none & ~0x3ull) == ((1 && ((uint64_t)asid_map_asid_map_none & (1ull << 47))) ? 0x0 : 0));
+    assert(((uint64_t)asid_map_asid_map_none & ~ULL_CONST(0x3)) == ((1 && ((uint64_t)asid_map_asid_map_none & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     asid_map.words[0] = 0
-        | ((uint64_t)asid_map_asid_map_none & 0x3ull) << 0;
+        | ((uint64_t)asid_map_asid_map_none & ULL_CONST(0x3)) << 0;
 
     return asid_map;
 }
@@ -1181,12 +1181,12 @@ asid_map_asid_map_vspace_new(uint64_t vspace_root) {
     asid_map_t asid_map;
 
     /* fail if user has passed bits that we will override */  
-    assert((vspace_root & ~0xffffffffffffull) == ((1 && (vspace_root & (1ull << 47))) ? 0xffff000000000000 : 0));  
-    assert(((uint64_t)asid_map_asid_map_vspace & ~0x3ull) == ((1 && ((uint64_t)asid_map_asid_map_vspace & (1ull << 47))) ? 0x0 : 0));
+    assert((vspace_root & ~ULL_CONST(0xffffffffffff)) == ((1 && (vspace_root & (ULL_CONST(1) << 47))) ? 0xffff000000000000 : 0));  
+    assert(((uint64_t)asid_map_asid_map_vspace & ~ULL_CONST(0x3)) == ((1 && ((uint64_t)asid_map_asid_map_vspace & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     asid_map.words[0] = 0
-        | (vspace_root & 0xffffffffffffull) << 16
-        | ((uint64_t)asid_map_asid_map_vspace & 0x3ull) << 0;
+        | (vspace_root & ULL_CONST(0xffffffffffff)) << 16
+        | ((uint64_t)asid_map_asid_map_vspace & ULL_CONST(0x3)) << 0;
 
     return asid_map;
 }
@@ -1197,9 +1197,9 @@ asid_map_asid_map_vspace_get_vspace_root(asid_map_t asid_map) {
     /* fail if union does not have the expected tag */
     assert(((asid_map.words[0] >> 0) & 0x3) == asid_map_asid_map_vspace);
 
-    ret = (asid_map.words[0] & 0xffffffffffff0000ull) >> 16;
+    ret = (asid_map.words[0] & ULL_CONST(0xffffffffffff0000)) >> 16;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(1 && (ret & (1ull << (47)))), 1)) {
+    if (__builtin_expect(!!(1 && (ret & (ULL_CONST(1) << (47)))), 1)) {
         ret |= 0xffff000000000000;
     }
     return ret;
@@ -1236,12 +1236,12 @@ typedef enum cap_tag cap_tag_t;
 
 static inline uint64_t CONST
 cap_get_capType(cap_t cap) {
-    return (cap.words[0] >> 59) & 0x1full;
+    return (cap.words[0] >> 59) & ULL_CONST(0x1f);
 }
 
 static inline int CONST
 cap_capType_equals(cap_t cap, uint64_t cap_type_tag) {
-    return ((cap.words[0] >> 59) & 0x1full) == cap_type_tag;
+    return ((cap.words[0] >> 59) & ULL_CONST(0x1f)) == cap_type_tag;
 }
 
 static inline cap_t CONST
@@ -1249,10 +1249,10 @@ cap_null_cap_new(void) {
     cap_t cap;
 
     /* fail if user has passed bits that we will override */  
-    assert(((uint64_t)cap_null_cap & ~0x1full) == ((1 && ((uint64_t)cap_null_cap & (1ull << 47))) ? 0x0 : 0));
+    assert(((uint64_t)cap_null_cap & ~ULL_CONST(0x1f)) == ((1 && ((uint64_t)cap_null_cap & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     cap.words[0] = 0
-        | ((uint64_t)cap_null_cap & 0x1full) << 59;
+        | ((uint64_t)cap_null_cap & ULL_CONST(0x1f)) << 59;
     cap.words[1] = 0;
 
     return cap;
@@ -1263,19 +1263,19 @@ cap_untyped_cap_new(uint64_t capFreeIndex, uint64_t capIsDevice, uint64_t capBlo
     cap_t cap;
 
     /* fail if user has passed bits that we will override */  
-    assert((capFreeIndex & ~0xffffffffffffull) == ((1 && (capFreeIndex & (1ull << 47))) ? 0x0 : 0));  
-    assert((capIsDevice & ~0x1ull) == ((1 && (capIsDevice & (1ull << 47))) ? 0x0 : 0));  
-    assert((capBlockSize & ~0x3full) == ((1 && (capBlockSize & (1ull << 47))) ? 0x0 : 0));  
-    assert(((uint64_t)cap_untyped_cap & ~0x1full) == ((1 && ((uint64_t)cap_untyped_cap & (1ull << 47))) ? 0x0 : 0));  
-    assert((capPtr & ~0xffffffffffffull) == ((1 && (capPtr & (1ull << 47))) ? 0xffff000000000000 : 0));
+    assert((capFreeIndex & ~ULL_CONST(0xffffffffffff)) == ((1 && (capFreeIndex & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capIsDevice & ~ULL_CONST(0x1)) == ((1 && (capIsDevice & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capBlockSize & ~ULL_CONST(0x3f)) == ((1 && (capBlockSize & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert(((uint64_t)cap_untyped_cap & ~ULL_CONST(0x1f)) == ((1 && ((uint64_t)cap_untyped_cap & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capPtr & ~ULL_CONST(0xffffffffffff)) == ((1 && (capPtr & (ULL_CONST(1) << 47))) ? 0xffff000000000000 : 0));
 
     cap.words[0] = 0
-        | ((uint64_t)cap_untyped_cap & 0x1full) << 59
-        | (capPtr & 0xffffffffffffull) >> 0;
+        | ((uint64_t)cap_untyped_cap & ULL_CONST(0x1f)) << 59
+        | (capPtr & ULL_CONST(0xffffffffffff)) >> 0;
     cap.words[1] = 0
-        | (capFreeIndex & 0xffffffffffffull) << 16
-        | (capIsDevice & 0x1ull) << 6
-        | (capBlockSize & 0x3full) << 0;
+        | (capFreeIndex & ULL_CONST(0xffffffffffff)) << 16
+        | (capIsDevice & ULL_CONST(0x1)) << 6
+        | (capBlockSize & ULL_CONST(0x3f)) << 0;
 
     return cap;
 }
@@ -1286,9 +1286,9 @@ cap_untyped_cap_get_capFreeIndex(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_untyped_cap);
 
-    ret = (cap.words[1] & 0xffffffffffff0000ull) >> 16;
+    ret = (cap.words[1] & ULL_CONST(0xffffffffffff0000)) >> 16;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1299,10 +1299,10 @@ cap_untyped_cap_set_capFreeIndex(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_untyped_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0xffffffffffff0000ull >> 16 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0xffffffffffff0000) >> 16 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap.words[1] &= ~0xffffffffffff0000ull;
-    cap.words[1] |= (v64 << 16) & 0xffffffffffff0000ull;
+    cap.words[1] &= ~ULL_CONST(0xffffffffffff0000);
+    cap.words[1] |= (v64 << 16) & ULL_CONST(0xffffffffffff0000);
     return cap;
 }
 
@@ -1312,10 +1312,10 @@ cap_untyped_cap_ptr_set_capFreeIndex(cap_t *cap_ptr, uint64_t v64) {
     assert(((cap_ptr->words[0] >> 59) & 0x1f) == cap_untyped_cap);
 
     /* fail if user has passed bits that we will override */
-    assert((((~0xffffffffffff0000ull >> 16) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0xffffffffffff0000) >> 16) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap_ptr->words[1] &= ~0xffffffffffff0000ull;
-    cap_ptr->words[1] |= (v64 << 16) & 0xffffffffffff0000ull;
+    cap_ptr->words[1] &= ~ULL_CONST(0xffffffffffff0000);
+    cap_ptr->words[1] |= (v64 << 16) & ULL_CONST(0xffffffffffff0000);
 }
 
 static inline uint64_t CONST
@@ -1324,9 +1324,9 @@ cap_untyped_cap_get_capIsDevice(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_untyped_cap);
 
-    ret = (cap.words[1] & 0x40ull) >> 6;
+    ret = (cap.words[1] & ULL_CONST(0x40)) >> 6;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1338,9 +1338,9 @@ cap_untyped_cap_get_capBlockSize(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_untyped_cap);
 
-    ret = (cap.words[1] & 0x3full) >> 0;
+    ret = (cap.words[1] & ULL_CONST(0x3f)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1352,9 +1352,9 @@ cap_untyped_cap_get_capPtr(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_untyped_cap);
 
-    ret = (cap.words[0] & 0xffffffffffffull) << 0;
+    ret = (cap.words[0] & ULL_CONST(0xffffffffffff)) << 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(1 && (ret & (1ull << (47)))), 1)) {
+    if (__builtin_expect(!!(1 && (ret & (ULL_CONST(1) << (47)))), 1)) {
         ret |= 0xffff000000000000;
     }
     return ret;
@@ -1365,20 +1365,20 @@ cap_endpoint_cap_new(uint64_t capEPBadge, uint64_t capCanGrantReply, uint64_t ca
     cap_t cap;
 
     /* fail if user has passed bits that we will override */  
-    assert((capCanGrantReply & ~0x1ull) == ((1 && (capCanGrantReply & (1ull << 47))) ? 0x0 : 0));  
-    assert((capCanGrant & ~0x1ull) == ((1 && (capCanGrant & (1ull << 47))) ? 0x0 : 0));  
-    assert((capCanSend & ~0x1ull) == ((1 && (capCanSend & (1ull << 47))) ? 0x0 : 0));  
-    assert((capCanReceive & ~0x1ull) == ((1 && (capCanReceive & (1ull << 47))) ? 0x0 : 0));  
-    assert((capEPPtr & ~0xffffffffffffull) == ((1 && (capEPPtr & (1ull << 47))) ? 0xffff000000000000 : 0));  
-    assert(((uint64_t)cap_endpoint_cap & ~0x1full) == ((1 && ((uint64_t)cap_endpoint_cap & (1ull << 47))) ? 0x0 : 0));
+    assert((capCanGrantReply & ~ULL_CONST(0x1)) == ((1 && (capCanGrantReply & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capCanGrant & ~ULL_CONST(0x1)) == ((1 && (capCanGrant & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capCanSend & ~ULL_CONST(0x1)) == ((1 && (capCanSend & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capCanReceive & ~ULL_CONST(0x1)) == ((1 && (capCanReceive & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capEPPtr & ~ULL_CONST(0xffffffffffff)) == ((1 && (capEPPtr & (ULL_CONST(1) << 47))) ? 0xffff000000000000 : 0));  
+    assert(((uint64_t)cap_endpoint_cap & ~ULL_CONST(0x1f)) == ((1 && ((uint64_t)cap_endpoint_cap & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     cap.words[0] = 0
-        | (capCanGrantReply & 0x1ull) << 58
-        | (capCanGrant & 0x1ull) << 57
-        | (capCanSend & 0x1ull) << 55
-        | (capCanReceive & 0x1ull) << 56
-        | (capEPPtr & 0xffffffffffffull) >> 0
-        | ((uint64_t)cap_endpoint_cap & 0x1full) << 59;
+        | (capCanGrantReply & ULL_CONST(0x1)) << 58
+        | (capCanGrant & ULL_CONST(0x1)) << 57
+        | (capCanSend & ULL_CONST(0x1)) << 55
+        | (capCanReceive & ULL_CONST(0x1)) << 56
+        | (capEPPtr & ULL_CONST(0xffffffffffff)) >> 0
+        | ((uint64_t)cap_endpoint_cap & ULL_CONST(0x1f)) << 59;
     cap.words[1] = 0
         | capEPBadge << 0;
 
@@ -1391,9 +1391,9 @@ cap_endpoint_cap_get_capEPBadge(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_endpoint_cap);
 
-    ret = (cap.words[1] & 0xffffffffffffffffull) >> 0;
+    ret = (cap.words[1] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1404,10 +1404,10 @@ cap_endpoint_cap_set_capEPBadge(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_endpoint_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap.words[1] &= ~0xffffffffffffffffull;
-    cap.words[1] |= (v64 << 0) & 0xffffffffffffffffull;
+    cap.words[1] &= ~ULL_CONST(0xffffffffffffffff);
+    cap.words[1] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return cap;
 }
 
@@ -1417,9 +1417,9 @@ cap_endpoint_cap_get_capCanGrantReply(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_endpoint_cap);
 
-    ret = (cap.words[0] & 0x400000000000000ull) >> 58;
+    ret = (cap.words[0] & ULL_CONST(0x400000000000000)) >> 58;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1430,10 +1430,10 @@ cap_endpoint_cap_set_capCanGrantReply(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_endpoint_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0x400000000000000ull >> 58 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0x400000000000000) >> 58 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap.words[0] &= ~0x400000000000000ull;
-    cap.words[0] |= (v64 << 58) & 0x400000000000000ull;
+    cap.words[0] &= ~ULL_CONST(0x400000000000000);
+    cap.words[0] |= (v64 << 58) & ULL_CONST(0x400000000000000);
     return cap;
 }
 
@@ -1443,9 +1443,9 @@ cap_endpoint_cap_get_capCanGrant(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_endpoint_cap);
 
-    ret = (cap.words[0] & 0x200000000000000ull) >> 57;
+    ret = (cap.words[0] & ULL_CONST(0x200000000000000)) >> 57;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1456,10 +1456,10 @@ cap_endpoint_cap_set_capCanGrant(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_endpoint_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0x200000000000000ull >> 57 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0x200000000000000) >> 57 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap.words[0] &= ~0x200000000000000ull;
-    cap.words[0] |= (v64 << 57) & 0x200000000000000ull;
+    cap.words[0] &= ~ULL_CONST(0x200000000000000);
+    cap.words[0] |= (v64 << 57) & ULL_CONST(0x200000000000000);
     return cap;
 }
 
@@ -1469,9 +1469,9 @@ cap_endpoint_cap_get_capCanReceive(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_endpoint_cap);
 
-    ret = (cap.words[0] & 0x100000000000000ull) >> 56;
+    ret = (cap.words[0] & ULL_CONST(0x100000000000000)) >> 56;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1482,10 +1482,10 @@ cap_endpoint_cap_set_capCanReceive(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_endpoint_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0x100000000000000ull >> 56 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0x100000000000000) >> 56 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap.words[0] &= ~0x100000000000000ull;
-    cap.words[0] |= (v64 << 56) & 0x100000000000000ull;
+    cap.words[0] &= ~ULL_CONST(0x100000000000000);
+    cap.words[0] |= (v64 << 56) & ULL_CONST(0x100000000000000);
     return cap;
 }
 
@@ -1495,9 +1495,9 @@ cap_endpoint_cap_get_capCanSend(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_endpoint_cap);
 
-    ret = (cap.words[0] & 0x80000000000000ull) >> 55;
+    ret = (cap.words[0] & ULL_CONST(0x80000000000000)) >> 55;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1508,10 +1508,10 @@ cap_endpoint_cap_set_capCanSend(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_endpoint_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0x80000000000000ull >> 55 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0x80000000000000) >> 55 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap.words[0] &= ~0x80000000000000ull;
-    cap.words[0] |= (v64 << 55) & 0x80000000000000ull;
+    cap.words[0] &= ~ULL_CONST(0x80000000000000);
+    cap.words[0] |= (v64 << 55) & ULL_CONST(0x80000000000000);
     return cap;
 }
 
@@ -1521,9 +1521,9 @@ cap_endpoint_cap_get_capEPPtr(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_endpoint_cap);
 
-    ret = (cap.words[0] & 0xffffffffffffull) << 0;
+    ret = (cap.words[0] & ULL_CONST(0xffffffffffff)) << 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(1 && (ret & (1ull << (47)))), 1)) {
+    if (__builtin_expect(!!(1 && (ret & (ULL_CONST(1) << (47)))), 1)) {
         ret |= 0xffff000000000000;
     }
     return ret;
@@ -1534,16 +1534,16 @@ cap_notification_cap_new(uint64_t capNtfnBadge, uint64_t capNtfnCanReceive, uint
     cap_t cap;
 
     /* fail if user has passed bits that we will override */  
-    assert(((uint64_t)cap_notification_cap & ~0x1full) == ((1 && ((uint64_t)cap_notification_cap & (1ull << 47))) ? 0x0 : 0));  
-    assert((capNtfnCanReceive & ~0x1ull) == ((1 && (capNtfnCanReceive & (1ull << 47))) ? 0x0 : 0));  
-    assert((capNtfnCanSend & ~0x1ull) == ((1 && (capNtfnCanSend & (1ull << 47))) ? 0x0 : 0));  
-    assert((capNtfnPtr & ~0xffffffffffffull) == ((1 && (capNtfnPtr & (1ull << 47))) ? 0xffff000000000000 : 0));
+    assert(((uint64_t)cap_notification_cap & ~ULL_CONST(0x1f)) == ((1 && ((uint64_t)cap_notification_cap & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capNtfnCanReceive & ~ULL_CONST(0x1)) == ((1 && (capNtfnCanReceive & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capNtfnCanSend & ~ULL_CONST(0x1)) == ((1 && (capNtfnCanSend & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capNtfnPtr & ~ULL_CONST(0xffffffffffff)) == ((1 && (capNtfnPtr & (ULL_CONST(1) << 47))) ? 0xffff000000000000 : 0));
 
     cap.words[0] = 0
-        | ((uint64_t)cap_notification_cap & 0x1full) << 59
-        | (capNtfnCanReceive & 0x1ull) << 58
-        | (capNtfnCanSend & 0x1ull) << 57
-        | (capNtfnPtr & 0xffffffffffffull) >> 0;
+        | ((uint64_t)cap_notification_cap & ULL_CONST(0x1f)) << 59
+        | (capNtfnCanReceive & ULL_CONST(0x1)) << 58
+        | (capNtfnCanSend & ULL_CONST(0x1)) << 57
+        | (capNtfnPtr & ULL_CONST(0xffffffffffff)) >> 0;
     cap.words[1] = 0
         | capNtfnBadge << 0;
 
@@ -1556,9 +1556,9 @@ cap_notification_cap_get_capNtfnBadge(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_notification_cap);
 
-    ret = (cap.words[1] & 0xffffffffffffffffull) >> 0;
+    ret = (cap.words[1] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1569,10 +1569,10 @@ cap_notification_cap_set_capNtfnBadge(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_notification_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap.words[1] &= ~0xffffffffffffffffull;
-    cap.words[1] |= (v64 << 0) & 0xffffffffffffffffull;
+    cap.words[1] &= ~ULL_CONST(0xffffffffffffffff);
+    cap.words[1] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return cap;
 }
 
@@ -1582,9 +1582,9 @@ cap_notification_cap_get_capNtfnCanReceive(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_notification_cap);
 
-    ret = (cap.words[0] & 0x400000000000000ull) >> 58;
+    ret = (cap.words[0] & ULL_CONST(0x400000000000000)) >> 58;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1595,10 +1595,10 @@ cap_notification_cap_set_capNtfnCanReceive(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_notification_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0x400000000000000ull >> 58 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0x400000000000000) >> 58 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap.words[0] &= ~0x400000000000000ull;
-    cap.words[0] |= (v64 << 58) & 0x400000000000000ull;
+    cap.words[0] &= ~ULL_CONST(0x400000000000000);
+    cap.words[0] |= (v64 << 58) & ULL_CONST(0x400000000000000);
     return cap;
 }
 
@@ -1608,9 +1608,9 @@ cap_notification_cap_get_capNtfnCanSend(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_notification_cap);
 
-    ret = (cap.words[0] & 0x200000000000000ull) >> 57;
+    ret = (cap.words[0] & ULL_CONST(0x200000000000000)) >> 57;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1621,10 +1621,10 @@ cap_notification_cap_set_capNtfnCanSend(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_notification_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0x200000000000000ull >> 57 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0x200000000000000) >> 57 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap.words[0] &= ~0x200000000000000ull;
-    cap.words[0] |= (v64 << 57) & 0x200000000000000ull;
+    cap.words[0] &= ~ULL_CONST(0x200000000000000);
+    cap.words[0] |= (v64 << 57) & ULL_CONST(0x200000000000000);
     return cap;
 }
 
@@ -1634,9 +1634,9 @@ cap_notification_cap_get_capNtfnPtr(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_notification_cap);
 
-    ret = (cap.words[0] & 0xffffffffffffull) << 0;
+    ret = (cap.words[0] & ULL_CONST(0xffffffffffff)) << 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(1 && (ret & (1ull << (47)))), 1)) {
+    if (__builtin_expect(!!(1 && (ret & (ULL_CONST(1) << (47)))), 1)) {
         ret |= 0xffff000000000000;
     }
     return ret;
@@ -1647,14 +1647,14 @@ cap_reply_cap_new(uint64_t capReplyCanGrant, uint64_t capReplyMaster, uint64_t c
     cap_t cap;
 
     /* fail if user has passed bits that we will override */  
-    assert((capReplyCanGrant & ~0x1ull) == ((1 && (capReplyCanGrant & (1ull << 47))) ? 0x0 : 0));  
-    assert((capReplyMaster & ~0x1ull) == ((1 && (capReplyMaster & (1ull << 47))) ? 0x0 : 0));  
-    assert(((uint64_t)cap_reply_cap & ~0x1full) == ((1 && ((uint64_t)cap_reply_cap & (1ull << 47))) ? 0x0 : 0));
+    assert((capReplyCanGrant & ~ULL_CONST(0x1)) == ((1 && (capReplyCanGrant & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capReplyMaster & ~ULL_CONST(0x1)) == ((1 && (capReplyMaster & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert(((uint64_t)cap_reply_cap & ~ULL_CONST(0x1f)) == ((1 && ((uint64_t)cap_reply_cap & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     cap.words[0] = 0
-        | (capReplyCanGrant & 0x1ull) << 1
-        | (capReplyMaster & 0x1ull) << 0
-        | ((uint64_t)cap_reply_cap & 0x1full) << 59;
+        | (capReplyCanGrant & ULL_CONST(0x1)) << 1
+        | (capReplyMaster & ULL_CONST(0x1)) << 0
+        | ((uint64_t)cap_reply_cap & ULL_CONST(0x1f)) << 59;
     cap.words[1] = 0
         | capTCBPtr << 0;
 
@@ -1667,9 +1667,9 @@ cap_reply_cap_get_capTCBPtr(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_reply_cap);
 
-    ret = (cap.words[1] & 0xffffffffffffffffull) >> 0;
+    ret = (cap.words[1] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1681,9 +1681,9 @@ cap_reply_cap_get_capReplyCanGrant(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_reply_cap);
 
-    ret = (cap.words[0] & 0x2ull) >> 1;
+    ret = (cap.words[0] & ULL_CONST(0x2)) >> 1;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1694,10 +1694,10 @@ cap_reply_cap_set_capReplyCanGrant(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_reply_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0x2ull >> 1 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0x2) >> 1 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap.words[0] &= ~0x2ull;
-    cap.words[0] |= (v64 << 1) & 0x2ull;
+    cap.words[0] &= ~ULL_CONST(0x2);
+    cap.words[0] |= (v64 << 1) & ULL_CONST(0x2);
     return cap;
 }
 
@@ -1707,9 +1707,9 @@ cap_reply_cap_get_capReplyMaster(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_reply_cap);
 
-    ret = (cap.words[0] & 0x1ull) >> 0;
+    ret = (cap.words[0] & ULL_CONST(0x1)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1720,16 +1720,16 @@ cap_cnode_cap_new(uint64_t capCNodeRadix, uint64_t capCNodeGuardSize, uint64_t c
     cap_t cap;
 
     /* fail if user has passed bits that we will override */  
-    assert((capCNodeRadix & ~0x3full) == ((1 && (capCNodeRadix & (1ull << 47))) ? 0x0 : 0));  
-    assert((capCNodeGuardSize & ~0x3full) == ((1 && (capCNodeGuardSize & (1ull << 47))) ? 0x0 : 0));  
-    assert((capCNodePtr & ~0xfffffffffffeull) == ((1 && (capCNodePtr & (1ull << 47))) ? 0xffff000000000000 : 0));  
-    assert(((uint64_t)cap_cnode_cap & ~0x1full) == ((1 && ((uint64_t)cap_cnode_cap & (1ull << 47))) ? 0x0 : 0));
+    assert((capCNodeRadix & ~ULL_CONST(0x3f)) == ((1 && (capCNodeRadix & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capCNodeGuardSize & ~ULL_CONST(0x3f)) == ((1 && (capCNodeGuardSize & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capCNodePtr & ~ULL_CONST(0xfffffffffffe)) == ((1 && (capCNodePtr & (ULL_CONST(1) << 47))) ? 0xffff000000000000 : 0));  
+    assert(((uint64_t)cap_cnode_cap & ~ULL_CONST(0x1f)) == ((1 && ((uint64_t)cap_cnode_cap & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     cap.words[0] = 0
-        | (capCNodeRadix & 0x3full) << 47
-        | (capCNodeGuardSize & 0x3full) << 53
-        | (capCNodePtr & 0xfffffffffffeull) >> 1
-        | ((uint64_t)cap_cnode_cap & 0x1full) << 59;
+        | (capCNodeRadix & ULL_CONST(0x3f)) << 47
+        | (capCNodeGuardSize & ULL_CONST(0x3f)) << 53
+        | (capCNodePtr & ULL_CONST(0xfffffffffffe)) >> 1
+        | ((uint64_t)cap_cnode_cap & ULL_CONST(0x1f)) << 59;
     cap.words[1] = 0
         | capCNodeGuard << 0;
 
@@ -1742,9 +1742,9 @@ cap_cnode_cap_get_capCNodeGuard(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_cnode_cap);
 
-    ret = (cap.words[1] & 0xffffffffffffffffull) >> 0;
+    ret = (cap.words[1] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1755,10 +1755,10 @@ cap_cnode_cap_set_capCNodeGuard(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_cnode_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap.words[1] &= ~0xffffffffffffffffull;
-    cap.words[1] |= (v64 << 0) & 0xffffffffffffffffull;
+    cap.words[1] &= ~ULL_CONST(0xffffffffffffffff);
+    cap.words[1] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return cap;
 }
 
@@ -1768,9 +1768,9 @@ cap_cnode_cap_get_capCNodeGuardSize(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_cnode_cap);
 
-    ret = (cap.words[0] & 0x7e0000000000000ull) >> 53;
+    ret = (cap.words[0] & ULL_CONST(0x7e0000000000000)) >> 53;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1781,10 +1781,10 @@ cap_cnode_cap_set_capCNodeGuardSize(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_cnode_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0x7e0000000000000ull >> 53 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0x7e0000000000000) >> 53 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap.words[0] &= ~0x7e0000000000000ull;
-    cap.words[0] |= (v64 << 53) & 0x7e0000000000000ull;
+    cap.words[0] &= ~ULL_CONST(0x7e0000000000000);
+    cap.words[0] |= (v64 << 53) & ULL_CONST(0x7e0000000000000);
     return cap;
 }
 
@@ -1794,9 +1794,9 @@ cap_cnode_cap_get_capCNodeRadix(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_cnode_cap);
 
-    ret = (cap.words[0] & 0x1f800000000000ull) >> 47;
+    ret = (cap.words[0] & ULL_CONST(0x1f800000000000)) >> 47;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1808,9 +1808,9 @@ cap_cnode_cap_get_capCNodePtr(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_cnode_cap);
 
-    ret = (cap.words[0] & 0x7fffffffffffull) << 1;
+    ret = (cap.words[0] & ULL_CONST(0x7fffffffffff)) << 1;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(1 && (ret & (1ull << (47)))), 1)) {
+    if (__builtin_expect(!!(1 && (ret & (ULL_CONST(1) << (47)))), 1)) {
         ret |= 0xffff000000000000;
     }
     return ret;
@@ -1821,12 +1821,12 @@ cap_thread_cap_new(uint64_t capTCBPtr) {
     cap_t cap;
 
     /* fail if user has passed bits that we will override */  
-    assert(((uint64_t)cap_thread_cap & ~0x1full) == ((1 && ((uint64_t)cap_thread_cap & (1ull << 47))) ? 0x0 : 0));  
-    assert((capTCBPtr & ~0xffffffffffffull) == ((1 && (capTCBPtr & (1ull << 47))) ? 0xffff000000000000 : 0));
+    assert(((uint64_t)cap_thread_cap & ~ULL_CONST(0x1f)) == ((1 && ((uint64_t)cap_thread_cap & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capTCBPtr & ~ULL_CONST(0xffffffffffff)) == ((1 && (capTCBPtr & (ULL_CONST(1) << 47))) ? 0xffff000000000000 : 0));
 
     cap.words[0] = 0
-        | ((uint64_t)cap_thread_cap & 0x1full) << 59
-        | (capTCBPtr & 0xffffffffffffull) >> 0;
+        | ((uint64_t)cap_thread_cap & ULL_CONST(0x1f)) << 59
+        | (capTCBPtr & ULL_CONST(0xffffffffffff)) >> 0;
     cap.words[1] = 0;
 
     return cap;
@@ -1838,9 +1838,9 @@ cap_thread_cap_get_capTCBPtr(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_thread_cap);
 
-    ret = (cap.words[0] & 0xffffffffffffull) << 0;
+    ret = (cap.words[0] & ULL_CONST(0xffffffffffff)) << 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(1 && (ret & (1ull << (47)))), 1)) {
+    if (__builtin_expect(!!(1 && (ret & (ULL_CONST(1) << (47)))), 1)) {
         ret |= 0xffff000000000000;
     }
     return ret;
@@ -1851,10 +1851,10 @@ cap_irq_control_cap_new(void) {
     cap_t cap;
 
     /* fail if user has passed bits that we will override */  
-    assert(((uint64_t)cap_irq_control_cap & ~0x1full) == ((1 && ((uint64_t)cap_irq_control_cap & (1ull << 47))) ? 0x0 : 0));
+    assert(((uint64_t)cap_irq_control_cap & ~ULL_CONST(0x1f)) == ((1 && ((uint64_t)cap_irq_control_cap & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     cap.words[0] = 0
-        | ((uint64_t)cap_irq_control_cap & 0x1full) << 59;
+        | ((uint64_t)cap_irq_control_cap & ULL_CONST(0x1f)) << 59;
     cap.words[1] = 0;
 
     return cap;
@@ -1865,13 +1865,13 @@ cap_irq_handler_cap_new(uint64_t capIRQ) {
     cap_t cap;
 
     /* fail if user has passed bits that we will override */  
-    assert((capIRQ & ~0xfffull) == ((1 && (capIRQ & (1ull << 47))) ? 0x0 : 0));  
-    assert(((uint64_t)cap_irq_handler_cap & ~0x1full) == ((1 && ((uint64_t)cap_irq_handler_cap & (1ull << 47))) ? 0x0 : 0));
+    assert((capIRQ & ~ULL_CONST(0xfff)) == ((1 && (capIRQ & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert(((uint64_t)cap_irq_handler_cap & ~ULL_CONST(0x1f)) == ((1 && ((uint64_t)cap_irq_handler_cap & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     cap.words[0] = 0
-        | ((uint64_t)cap_irq_handler_cap & 0x1full) << 59;
+        | ((uint64_t)cap_irq_handler_cap & ULL_CONST(0x1f)) << 59;
     cap.words[1] = 0
-        | (capIRQ & 0xfffull) << 0;
+        | (capIRQ & ULL_CONST(0xfff)) << 0;
 
     return cap;
 }
@@ -1882,9 +1882,9 @@ cap_irq_handler_cap_get_capIRQ(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_irq_handler_cap);
 
-    ret = (cap.words[1] & 0xfffull) >> 0;
+    ret = (cap.words[1] & ULL_CONST(0xfff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1895,12 +1895,12 @@ cap_zombie_cap_new(uint64_t capZombieID, uint64_t capZombieType) {
     cap_t cap;
 
     /* fail if user has passed bits that we will override */  
-    assert(((uint64_t)cap_zombie_cap & ~0x1full) == ((1 && ((uint64_t)cap_zombie_cap & (1ull << 47))) ? 0x0 : 0));  
-    assert((capZombieType & ~0x7full) == ((1 && (capZombieType & (1ull << 47))) ? 0x0 : 0));
+    assert(((uint64_t)cap_zombie_cap & ~ULL_CONST(0x1f)) == ((1 && ((uint64_t)cap_zombie_cap & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capZombieType & ~ULL_CONST(0x7f)) == ((1 && (capZombieType & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     cap.words[0] = 0
-        | ((uint64_t)cap_zombie_cap & 0x1full) << 59
-        | (capZombieType & 0x7full) << 0;
+        | ((uint64_t)cap_zombie_cap & ULL_CONST(0x1f)) << 59
+        | (capZombieType & ULL_CONST(0x7f)) << 0;
     cap.words[1] = 0
         | capZombieID << 0;
 
@@ -1913,9 +1913,9 @@ cap_zombie_cap_get_capZombieID(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_zombie_cap);
 
-    ret = (cap.words[1] & 0xffffffffffffffffull) >> 0;
+    ret = (cap.words[1] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1926,10 +1926,10 @@ cap_zombie_cap_set_capZombieID(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_zombie_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap.words[1] &= ~0xffffffffffffffffull;
-    cap.words[1] |= (v64 << 0) & 0xffffffffffffffffull;
+    cap.words[1] &= ~ULL_CONST(0xffffffffffffffff);
+    cap.words[1] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return cap;
 }
 
@@ -1939,9 +1939,9 @@ cap_zombie_cap_get_capZombieType(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_zombie_cap);
 
-    ret = (cap.words[0] & 0x7full) >> 0;
+    ret = (cap.words[0] & ULL_CONST(0x7f)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1952,10 +1952,10 @@ cap_domain_cap_new(void) {
     cap_t cap;
 
     /* fail if user has passed bits that we will override */  
-    assert(((uint64_t)cap_domain_cap & ~0x1full) == ((1 && ((uint64_t)cap_domain_cap & (1ull << 47))) ? 0x0 : 0));
+    assert(((uint64_t)cap_domain_cap & ~ULL_CONST(0x1f)) == ((1 && ((uint64_t)cap_domain_cap & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     cap.words[0] = 0
-        | ((uint64_t)cap_domain_cap & 0x1full) << 59;
+        | ((uint64_t)cap_domain_cap & ULL_CONST(0x1f)) << 59;
     cap.words[1] = 0;
 
     return cap;
@@ -1966,25 +1966,25 @@ cap_frame_cap_new(uint64_t capFMappedASID, uint64_t capFBasePtr, uint64_t capFSi
     cap_t cap;
 
     /* fail if user has passed bits that we will override */  
-    assert((capFMappedASID & ~0xffffull) == ((1 && (capFMappedASID & (1ull << 47))) ? 0x0 : 0));  
-    assert((capFBasePtr & ~0xffffffffffffull) == ((1 && (capFBasePtr & (1ull << 47))) ? 0xffff000000000000 : 0));  
-    assert(((uint64_t)cap_frame_cap & ~0x1full) == ((1 && ((uint64_t)cap_frame_cap & (1ull << 47))) ? 0x0 : 0));  
-    assert((capFSize & ~0x3ull) == ((1 && (capFSize & (1ull << 47))) ? 0x0 : 0));  
-    assert((capFMapType & ~0x3ull) == ((1 && (capFMapType & (1ull << 47))) ? 0x0 : 0));  
-    assert((capFMappedAddress & ~0xffffffffffffull) == ((1 && (capFMappedAddress & (1ull << 47))) ? 0xffff000000000000 : 0));  
-    assert((capFVMRights & ~0x3ull) == ((1 && (capFVMRights & (1ull << 47))) ? 0x0 : 0));  
-    assert((capFIsDevice & ~0x1ull) == ((1 && (capFIsDevice & (1ull << 47))) ? 0x0 : 0));
+    assert((capFMappedASID & ~ULL_CONST(0xffff)) == ((1 && (capFMappedASID & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capFBasePtr & ~ULL_CONST(0xffffffffffff)) == ((1 && (capFBasePtr & (ULL_CONST(1) << 47))) ? 0xffff000000000000 : 0));  
+    assert(((uint64_t)cap_frame_cap & ~ULL_CONST(0x1f)) == ((1 && ((uint64_t)cap_frame_cap & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capFSize & ~ULL_CONST(0x3)) == ((1 && (capFSize & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capFMapType & ~ULL_CONST(0x3)) == ((1 && (capFMapType & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capFMappedAddress & ~ULL_CONST(0xffffffffffff)) == ((1 && (capFMappedAddress & (ULL_CONST(1) << 47))) ? 0xffff000000000000 : 0));  
+    assert((capFVMRights & ~ULL_CONST(0x3)) == ((1 && (capFVMRights & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capFIsDevice & ~ULL_CONST(0x1)) == ((1 && (capFIsDevice & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     cap.words[0] = 0
-        | ((uint64_t)cap_frame_cap & 0x1full) << 59
-        | (capFSize & 0x3ull) << 57
-        | (capFMapType & 0x3ull) << 55
-        | (capFMappedAddress & 0xffffffffffffull) << 7
-        | (capFVMRights & 0x3ull) << 5
-        | (capFIsDevice & 0x1ull) << 4;
+        | ((uint64_t)cap_frame_cap & ULL_CONST(0x1f)) << 59
+        | (capFSize & ULL_CONST(0x3)) << 57
+        | (capFMapType & ULL_CONST(0x3)) << 55
+        | (capFMappedAddress & ULL_CONST(0xffffffffffff)) << 7
+        | (capFVMRights & ULL_CONST(0x3)) << 5
+        | (capFIsDevice & ULL_CONST(0x1)) << 4;
     cap.words[1] = 0
-        | (capFMappedASID & 0xffffull) << 48
-        | (capFBasePtr & 0xffffffffffffull) >> 0;
+        | (capFMappedASID & ULL_CONST(0xffff)) << 48
+        | (capFBasePtr & ULL_CONST(0xffffffffffff)) >> 0;
 
     return cap;
 }
@@ -1995,9 +1995,9 @@ cap_frame_cap_get_capFMappedASID(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_frame_cap);
 
-    ret = (cap.words[1] & 0xffff000000000000ull) >> 48;
+    ret = (cap.words[1] & ULL_CONST(0xffff000000000000)) >> 48;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2008,10 +2008,10 @@ cap_frame_cap_set_capFMappedASID(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_frame_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0xffff000000000000ull >> 48 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0xffff000000000000) >> 48 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap.words[1] &= ~0xffff000000000000ull;
-    cap.words[1] |= (v64 << 48) & 0xffff000000000000ull;
+    cap.words[1] &= ~ULL_CONST(0xffff000000000000);
+    cap.words[1] |= (v64 << 48) & ULL_CONST(0xffff000000000000);
     return cap;
 }
 
@@ -2021,10 +2021,10 @@ cap_frame_cap_ptr_set_capFMappedASID(cap_t *cap_ptr, uint64_t v64) {
     assert(((cap_ptr->words[0] >> 59) & 0x1f) == cap_frame_cap);
 
     /* fail if user has passed bits that we will override */
-    assert((((~0xffff000000000000ull >> 48) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0xffff000000000000) >> 48) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap_ptr->words[1] &= ~0xffff000000000000ull;
-    cap_ptr->words[1] |= (v64 << 48) & 0xffff000000000000ull;
+    cap_ptr->words[1] &= ~ULL_CONST(0xffff000000000000);
+    cap_ptr->words[1] |= (v64 << 48) & ULL_CONST(0xffff000000000000);
 }
 
 static inline uint64_t CONST
@@ -2033,9 +2033,9 @@ cap_frame_cap_get_capFBasePtr(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_frame_cap);
 
-    ret = (cap.words[1] & 0xffffffffffffull) << 0;
+    ret = (cap.words[1] & ULL_CONST(0xffffffffffff)) << 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(1 && (ret & (1ull << (47)))), 1)) {
+    if (__builtin_expect(!!(1 && (ret & (ULL_CONST(1) << (47)))), 1)) {
         ret |= 0xffff000000000000;
     }
     return ret;
@@ -2047,9 +2047,9 @@ cap_frame_cap_get_capFSize(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_frame_cap);
 
-    ret = (cap.words[0] & 0x600000000000000ull) >> 57;
+    ret = (cap.words[0] & ULL_CONST(0x600000000000000)) >> 57;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2061,9 +2061,9 @@ cap_frame_cap_get_capFMapType(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_frame_cap);
 
-    ret = (cap.words[0] & 0x180000000000000ull) >> 55;
+    ret = (cap.words[0] & ULL_CONST(0x180000000000000)) >> 55;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2074,10 +2074,10 @@ cap_frame_cap_set_capFMapType(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_frame_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0x180000000000000ull >> 55 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0x180000000000000) >> 55 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap.words[0] &= ~0x180000000000000ull;
-    cap.words[0] |= (v64 << 55) & 0x180000000000000ull;
+    cap.words[0] &= ~ULL_CONST(0x180000000000000);
+    cap.words[0] |= (v64 << 55) & ULL_CONST(0x180000000000000);
     return cap;
 }
 
@@ -2087,10 +2087,10 @@ cap_frame_cap_ptr_set_capFMapType(cap_t *cap_ptr, uint64_t v64) {
     assert(((cap_ptr->words[0] >> 59) & 0x1f) == cap_frame_cap);
 
     /* fail if user has passed bits that we will override */
-    assert((((~0x180000000000000ull >> 55) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0x180000000000000) >> 55) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap_ptr->words[0] &= ~0x180000000000000ull;
-    cap_ptr->words[0] |= (v64 << 55) & 0x180000000000000ull;
+    cap_ptr->words[0] &= ~ULL_CONST(0x180000000000000);
+    cap_ptr->words[0] |= (v64 << 55) & ULL_CONST(0x180000000000000);
 }
 
 static inline uint64_t CONST
@@ -2099,9 +2099,9 @@ cap_frame_cap_get_capFMappedAddress(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_frame_cap);
 
-    ret = (cap.words[0] & 0x7fffffffffff80ull) >> 7;
+    ret = (cap.words[0] & ULL_CONST(0x7fffffffffff80)) >> 7;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(1 && (ret & (1ull << (47)))), 1)) {
+    if (__builtin_expect(!!(1 && (ret & (ULL_CONST(1) << (47)))), 1)) {
         ret |= 0xffff000000000000;
     }
     return ret;
@@ -2112,10 +2112,10 @@ cap_frame_cap_set_capFMappedAddress(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_frame_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0x7fffffffffff80ull >> 7 ) | 0xffff000000000000) & v64) == ((1 && (v64 & (1ull << (47)))) ? 0xffff000000000000 : 0));
+    assert((((~ULL_CONST(0x7fffffffffff80) >> 7 ) | 0xffff000000000000) & v64) == ((1 && (v64 & (ULL_CONST(1) << (47)))) ? 0xffff000000000000 : 0));
 
-    cap.words[0] &= ~0x7fffffffffff80ull;
-    cap.words[0] |= (v64 << 7) & 0x7fffffffffff80ull;
+    cap.words[0] &= ~ULL_CONST(0x7fffffffffff80);
+    cap.words[0] |= (v64 << 7) & ULL_CONST(0x7fffffffffff80);
     return cap;
 }
 
@@ -2125,10 +2125,10 @@ cap_frame_cap_ptr_set_capFMappedAddress(cap_t *cap_ptr, uint64_t v64) {
     assert(((cap_ptr->words[0] >> 59) & 0x1f) == cap_frame_cap);
 
     /* fail if user has passed bits that we will override */
-    assert((((~0x7fffffffffff80ull >> 7) | 0xffff000000000000) & v64) == ((1 && (v64 & (1ull << (47)))) ? 0xffff000000000000 : 0));
+    assert((((~ULL_CONST(0x7fffffffffff80) >> 7) | 0xffff000000000000) & v64) == ((1 && (v64 & (ULL_CONST(1) << (47)))) ? 0xffff000000000000 : 0));
 
-    cap_ptr->words[0] &= ~0x7fffffffffff80ull;
-    cap_ptr->words[0] |= (v64 << 7) & 0x7fffffffffff80ull;
+    cap_ptr->words[0] &= ~ULL_CONST(0x7fffffffffff80);
+    cap_ptr->words[0] |= (v64 << 7) & ULL_CONST(0x7fffffffffff80);
 }
 
 static inline uint64_t CONST
@@ -2137,9 +2137,9 @@ cap_frame_cap_get_capFVMRights(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_frame_cap);
 
-    ret = (cap.words[0] & 0x60ull) >> 5;
+    ret = (cap.words[0] & ULL_CONST(0x60)) >> 5;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2150,10 +2150,10 @@ cap_frame_cap_set_capFVMRights(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_frame_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0x60ull >> 5 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0x60) >> 5 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap.words[0] &= ~0x60ull;
-    cap.words[0] |= (v64 << 5) & 0x60ull;
+    cap.words[0] &= ~ULL_CONST(0x60);
+    cap.words[0] |= (v64 << 5) & ULL_CONST(0x60);
     return cap;
 }
 
@@ -2163,9 +2163,9 @@ cap_frame_cap_get_capFIsDevice(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_frame_cap);
 
-    ret = (cap.words[0] & 0x10ull) >> 4;
+    ret = (cap.words[0] & ULL_CONST(0x10)) >> 4;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2176,19 +2176,19 @@ cap_page_table_cap_new(uint64_t capPTMappedASID, uint64_t capPTBasePtr, uint64_t
     cap_t cap;
 
     /* fail if user has passed bits that we will override */  
-    assert((capPTMappedASID & ~0xfffull) == ((1 && (capPTMappedASID & (1ull << 47))) ? 0x0 : 0));  
-    assert((capPTBasePtr & ~0xffffffffffffull) == ((1 && (capPTBasePtr & (1ull << 47))) ? 0xffff000000000000 : 0));  
-    assert(((uint64_t)cap_page_table_cap & ~0x1full) == ((1 && ((uint64_t)cap_page_table_cap & (1ull << 47))) ? 0x0 : 0));  
-    assert((capPTIsMapped & ~0x1ull) == ((1 && (capPTIsMapped & (1ull << 47))) ? 0x0 : 0));  
-    assert((capPTMappedAddress & ~0xfffffff00000ull) == ((1 && (capPTMappedAddress & (1ull << 47))) ? 0xffff000000000000 : 0));
+    assert((capPTMappedASID & ~ULL_CONST(0xfff)) == ((1 && (capPTMappedASID & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capPTBasePtr & ~ULL_CONST(0xffffffffffff)) == ((1 && (capPTBasePtr & (ULL_CONST(1) << 47))) ? 0xffff000000000000 : 0));  
+    assert(((uint64_t)cap_page_table_cap & ~ULL_CONST(0x1f)) == ((1 && ((uint64_t)cap_page_table_cap & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capPTIsMapped & ~ULL_CONST(0x1)) == ((1 && (capPTIsMapped & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capPTMappedAddress & ~ULL_CONST(0xfffffff00000)) == ((1 && (capPTMappedAddress & (ULL_CONST(1) << 47))) ? 0xffff000000000000 : 0));
 
     cap.words[0] = 0
-        | ((uint64_t)cap_page_table_cap & 0x1full) << 59
-        | (capPTIsMapped & 0x1ull) << 49
-        | (capPTMappedAddress & 0xfffffff00000ull) << 1;
+        | ((uint64_t)cap_page_table_cap & ULL_CONST(0x1f)) << 59
+        | (capPTIsMapped & ULL_CONST(0x1)) << 49
+        | (capPTMappedAddress & ULL_CONST(0xfffffff00000)) << 1;
     cap.words[1] = 0
-        | (capPTMappedASID & 0xfffull) << 48
-        | (capPTBasePtr & 0xffffffffffffull) >> 0;
+        | (capPTMappedASID & ULL_CONST(0xfff)) << 48
+        | (capPTBasePtr & ULL_CONST(0xffffffffffff)) >> 0;
 
     return cap;
 }
@@ -2199,9 +2199,9 @@ cap_page_table_cap_get_capPTMappedASID(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_page_table_cap);
 
-    ret = (cap.words[1] & 0xfff000000000000ull) >> 48;
+    ret = (cap.words[1] & ULL_CONST(0xfff000000000000)) >> 48;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2212,10 +2212,10 @@ cap_page_table_cap_set_capPTMappedASID(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_page_table_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0xfff000000000000ull >> 48 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0xfff000000000000) >> 48 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap.words[1] &= ~0xfff000000000000ull;
-    cap.words[1] |= (v64 << 48) & 0xfff000000000000ull;
+    cap.words[1] &= ~ULL_CONST(0xfff000000000000);
+    cap.words[1] |= (v64 << 48) & ULL_CONST(0xfff000000000000);
     return cap;
 }
 
@@ -2225,9 +2225,9 @@ cap_page_table_cap_get_capPTBasePtr(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_page_table_cap);
 
-    ret = (cap.words[1] & 0xffffffffffffull) << 0;
+    ret = (cap.words[1] & ULL_CONST(0xffffffffffff)) << 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(1 && (ret & (1ull << (47)))), 1)) {
+    if (__builtin_expect(!!(1 && (ret & (ULL_CONST(1) << (47)))), 1)) {
         ret |= 0xffff000000000000;
     }
     return ret;
@@ -2239,9 +2239,9 @@ cap_page_table_cap_get_capPTIsMapped(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_page_table_cap);
 
-    ret = (cap.words[0] & 0x2000000000000ull) >> 49;
+    ret = (cap.words[0] & ULL_CONST(0x2000000000000)) >> 49;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2252,10 +2252,10 @@ cap_page_table_cap_set_capPTIsMapped(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_page_table_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0x2000000000000ull >> 49 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0x2000000000000) >> 49 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap.words[0] &= ~0x2000000000000ull;
-    cap.words[0] |= (v64 << 49) & 0x2000000000000ull;
+    cap.words[0] &= ~ULL_CONST(0x2000000000000);
+    cap.words[0] |= (v64 << 49) & ULL_CONST(0x2000000000000);
     return cap;
 }
 
@@ -2265,10 +2265,10 @@ cap_page_table_cap_ptr_set_capPTIsMapped(cap_t *cap_ptr, uint64_t v64) {
     assert(((cap_ptr->words[0] >> 59) & 0x1f) == cap_page_table_cap);
 
     /* fail if user has passed bits that we will override */
-    assert((((~0x2000000000000ull >> 49) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0x2000000000000) >> 49) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap_ptr->words[0] &= ~0x2000000000000ull;
-    cap_ptr->words[0] |= (v64 << 49) & 0x2000000000000ull;
+    cap_ptr->words[0] &= ~ULL_CONST(0x2000000000000);
+    cap_ptr->words[0] |= (v64 << 49) & ULL_CONST(0x2000000000000);
 }
 
 static inline uint64_t CONST
@@ -2277,9 +2277,9 @@ cap_page_table_cap_get_capPTMappedAddress(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_page_table_cap);
 
-    ret = (cap.words[0] & 0x1ffffffe00000ull) >> 1;
+    ret = (cap.words[0] & ULL_CONST(0x1ffffffe00000)) >> 1;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(1 && (ret & (1ull << (47)))), 1)) {
+    if (__builtin_expect(!!(1 && (ret & (ULL_CONST(1) << (47)))), 1)) {
         ret |= 0xffff000000000000;
     }
     return ret;
@@ -2290,10 +2290,10 @@ cap_page_table_cap_set_capPTMappedAddress(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_page_table_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0x1ffffffe00000ull >> 1 ) | 0xffff000000000000) & v64) == ((1 && (v64 & (1ull << (47)))) ? 0xffff000000000000 : 0));
+    assert((((~ULL_CONST(0x1ffffffe00000) >> 1 ) | 0xffff000000000000) & v64) == ((1 && (v64 & (ULL_CONST(1) << (47)))) ? 0xffff000000000000 : 0));
 
-    cap.words[0] &= ~0x1ffffffe00000ull;
-    cap.words[0] |= (v64 << 1) & 0x1ffffffe00000ull;
+    cap.words[0] &= ~ULL_CONST(0x1ffffffe00000);
+    cap.words[0] |= (v64 << 1) & ULL_CONST(0x1ffffffe00000);
     return cap;
 }
 
@@ -2302,19 +2302,19 @@ cap_page_directory_cap_new(uint64_t capPDMappedASID, uint64_t capPDBasePtr, uint
     cap_t cap;
 
     /* fail if user has passed bits that we will override */  
-    assert((capPDMappedASID & ~0xfffull) == ((1 && (capPDMappedASID & (1ull << 47))) ? 0x0 : 0));  
-    assert((capPDBasePtr & ~0xffffffffffffull) == ((1 && (capPDBasePtr & (1ull << 47))) ? 0xffff000000000000 : 0));  
-    assert(((uint64_t)cap_page_directory_cap & ~0x1full) == ((1 && ((uint64_t)cap_page_directory_cap & (1ull << 47))) ? 0x0 : 0));  
-    assert((capPDIsMapped & ~0x1ull) == ((1 && (capPDIsMapped & (1ull << 47))) ? 0x0 : 0));  
-    assert((capPDMappedAddress & ~0xffffe0000000ull) == ((1 && (capPDMappedAddress & (1ull << 47))) ? 0xffff000000000000 : 0));
+    assert((capPDMappedASID & ~ULL_CONST(0xfff)) == ((1 && (capPDMappedASID & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capPDBasePtr & ~ULL_CONST(0xffffffffffff)) == ((1 && (capPDBasePtr & (ULL_CONST(1) << 47))) ? 0xffff000000000000 : 0));  
+    assert(((uint64_t)cap_page_directory_cap & ~ULL_CONST(0x1f)) == ((1 && ((uint64_t)cap_page_directory_cap & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capPDIsMapped & ~ULL_CONST(0x1)) == ((1 && (capPDIsMapped & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capPDMappedAddress & ~ULL_CONST(0xffffe0000000)) == ((1 && (capPDMappedAddress & (ULL_CONST(1) << 47))) ? 0xffff000000000000 : 0));
 
     cap.words[0] = 0
-        | ((uint64_t)cap_page_directory_cap & 0x1full) << 59
-        | (capPDIsMapped & 0x1ull) << 49
-        | (capPDMappedAddress & 0xffffe0000000ull) << 1;
+        | ((uint64_t)cap_page_directory_cap & ULL_CONST(0x1f)) << 59
+        | (capPDIsMapped & ULL_CONST(0x1)) << 49
+        | (capPDMappedAddress & ULL_CONST(0xffffe0000000)) << 1;
     cap.words[1] = 0
-        | (capPDMappedASID & 0xfffull) << 48
-        | (capPDBasePtr & 0xffffffffffffull) >> 0;
+        | (capPDMappedASID & ULL_CONST(0xfff)) << 48
+        | (capPDBasePtr & ULL_CONST(0xffffffffffff)) >> 0;
 
     return cap;
 }
@@ -2325,9 +2325,9 @@ cap_page_directory_cap_get_capPDMappedASID(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_page_directory_cap);
 
-    ret = (cap.words[1] & 0xfff000000000000ull) >> 48;
+    ret = (cap.words[1] & ULL_CONST(0xfff000000000000)) >> 48;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2338,10 +2338,10 @@ cap_page_directory_cap_set_capPDMappedASID(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_page_directory_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0xfff000000000000ull >> 48 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0xfff000000000000) >> 48 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap.words[1] &= ~0xfff000000000000ull;
-    cap.words[1] |= (v64 << 48) & 0xfff000000000000ull;
+    cap.words[1] &= ~ULL_CONST(0xfff000000000000);
+    cap.words[1] |= (v64 << 48) & ULL_CONST(0xfff000000000000);
     return cap;
 }
 
@@ -2351,9 +2351,9 @@ cap_page_directory_cap_get_capPDBasePtr(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_page_directory_cap);
 
-    ret = (cap.words[1] & 0xffffffffffffull) << 0;
+    ret = (cap.words[1] & ULL_CONST(0xffffffffffff)) << 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(1 && (ret & (1ull << (47)))), 1)) {
+    if (__builtin_expect(!!(1 && (ret & (ULL_CONST(1) << (47)))), 1)) {
         ret |= 0xffff000000000000;
     }
     return ret;
@@ -2365,9 +2365,9 @@ cap_page_directory_cap_get_capPDIsMapped(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_page_directory_cap);
 
-    ret = (cap.words[0] & 0x2000000000000ull) >> 49;
+    ret = (cap.words[0] & ULL_CONST(0x2000000000000)) >> 49;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2378,10 +2378,10 @@ cap_page_directory_cap_set_capPDIsMapped(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_page_directory_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0x2000000000000ull >> 49 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0x2000000000000) >> 49 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap.words[0] &= ~0x2000000000000ull;
-    cap.words[0] |= (v64 << 49) & 0x2000000000000ull;
+    cap.words[0] &= ~ULL_CONST(0x2000000000000);
+    cap.words[0] |= (v64 << 49) & ULL_CONST(0x2000000000000);
     return cap;
 }
 
@@ -2391,10 +2391,10 @@ cap_page_directory_cap_ptr_set_capPDIsMapped(cap_t *cap_ptr, uint64_t v64) {
     assert(((cap_ptr->words[0] >> 59) & 0x1f) == cap_page_directory_cap);
 
     /* fail if user has passed bits that we will override */
-    assert((((~0x2000000000000ull >> 49) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0x2000000000000) >> 49) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap_ptr->words[0] &= ~0x2000000000000ull;
-    cap_ptr->words[0] |= (v64 << 49) & 0x2000000000000ull;
+    cap_ptr->words[0] &= ~ULL_CONST(0x2000000000000);
+    cap_ptr->words[0] |= (v64 << 49) & ULL_CONST(0x2000000000000);
 }
 
 static inline uint64_t CONST
@@ -2403,9 +2403,9 @@ cap_page_directory_cap_get_capPDMappedAddress(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_page_directory_cap);
 
-    ret = (cap.words[0] & 0x1ffffc0000000ull) >> 1;
+    ret = (cap.words[0] & ULL_CONST(0x1ffffc0000000)) >> 1;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(1 && (ret & (1ull << (47)))), 1)) {
+    if (__builtin_expect(!!(1 && (ret & (ULL_CONST(1) << (47)))), 1)) {
         ret |= 0xffff000000000000;
     }
     return ret;
@@ -2416,10 +2416,10 @@ cap_page_directory_cap_set_capPDMappedAddress(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_page_directory_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0x1ffffc0000000ull >> 1 ) | 0xffff000000000000) & v64) == ((1 && (v64 & (1ull << (47)))) ? 0xffff000000000000 : 0));
+    assert((((~ULL_CONST(0x1ffffc0000000) >> 1 ) | 0xffff000000000000) & v64) == ((1 && (v64 & (ULL_CONST(1) << (47)))) ? 0xffff000000000000 : 0));
 
-    cap.words[0] &= ~0x1ffffc0000000ull;
-    cap.words[0] |= (v64 << 1) & 0x1ffffc0000000ull;
+    cap.words[0] &= ~ULL_CONST(0x1ffffc0000000);
+    cap.words[0] |= (v64 << 1) & ULL_CONST(0x1ffffc0000000);
     return cap;
 }
 
@@ -2428,19 +2428,19 @@ cap_pdpt_cap_new(uint64_t capPDPTMappedASID, uint64_t capPDPTBasePtr, uint64_t c
     cap_t cap;
 
     /* fail if user has passed bits that we will override */  
-    assert((capPDPTMappedASID & ~0xfffull) == ((1 && (capPDPTMappedASID & (1ull << 47))) ? 0x0 : 0));  
-    assert((capPDPTBasePtr & ~0xffffffffffffull) == ((1 && (capPDPTBasePtr & (1ull << 47))) ? 0xffff000000000000 : 0));  
-    assert(((uint64_t)cap_pdpt_cap & ~0x1full) == ((1 && ((uint64_t)cap_pdpt_cap & (1ull << 47))) ? 0x0 : 0));  
-    assert((capPDPTIsMapped & ~0x1ull) == ((1 && (capPDPTIsMapped & (1ull << 47))) ? 0x0 : 0));  
-    assert((capPDPTMappedAddress & ~0xffc000000000ull) == ((1 && (capPDPTMappedAddress & (1ull << 47))) ? 0xffff000000000000 : 0));
+    assert((capPDPTMappedASID & ~ULL_CONST(0xfff)) == ((1 && (capPDPTMappedASID & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capPDPTBasePtr & ~ULL_CONST(0xffffffffffff)) == ((1 && (capPDPTBasePtr & (ULL_CONST(1) << 47))) ? 0xffff000000000000 : 0));  
+    assert(((uint64_t)cap_pdpt_cap & ~ULL_CONST(0x1f)) == ((1 && ((uint64_t)cap_pdpt_cap & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capPDPTIsMapped & ~ULL_CONST(0x1)) == ((1 && (capPDPTIsMapped & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capPDPTMappedAddress & ~ULL_CONST(0xffc000000000)) == ((1 && (capPDPTMappedAddress & (ULL_CONST(1) << 47))) ? 0xffff000000000000 : 0));
 
     cap.words[0] = 0
-        | ((uint64_t)cap_pdpt_cap & 0x1full) << 59
-        | (capPDPTIsMapped & 0x1ull) << 58
-        | (capPDPTMappedAddress & 0xffc000000000ull) << 10;
+        | ((uint64_t)cap_pdpt_cap & ULL_CONST(0x1f)) << 59
+        | (capPDPTIsMapped & ULL_CONST(0x1)) << 58
+        | (capPDPTMappedAddress & ULL_CONST(0xffc000000000)) << 10;
     cap.words[1] = 0
-        | (capPDPTMappedASID & 0xfffull) << 48
-        | (capPDPTBasePtr & 0xffffffffffffull) >> 0;
+        | (capPDPTMappedASID & ULL_CONST(0xfff)) << 48
+        | (capPDPTBasePtr & ULL_CONST(0xffffffffffff)) >> 0;
 
     return cap;
 }
@@ -2451,9 +2451,9 @@ cap_pdpt_cap_get_capPDPTMappedASID(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_pdpt_cap);
 
-    ret = (cap.words[1] & 0xfff000000000000ull) >> 48;
+    ret = (cap.words[1] & ULL_CONST(0xfff000000000000)) >> 48;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2464,10 +2464,10 @@ cap_pdpt_cap_set_capPDPTMappedASID(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_pdpt_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0xfff000000000000ull >> 48 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0xfff000000000000) >> 48 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap.words[1] &= ~0xfff000000000000ull;
-    cap.words[1] |= (v64 << 48) & 0xfff000000000000ull;
+    cap.words[1] &= ~ULL_CONST(0xfff000000000000);
+    cap.words[1] |= (v64 << 48) & ULL_CONST(0xfff000000000000);
     return cap;
 }
 
@@ -2477,9 +2477,9 @@ cap_pdpt_cap_get_capPDPTBasePtr(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_pdpt_cap);
 
-    ret = (cap.words[1] & 0xffffffffffffull) << 0;
+    ret = (cap.words[1] & ULL_CONST(0xffffffffffff)) << 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(1 && (ret & (1ull << (47)))), 1)) {
+    if (__builtin_expect(!!(1 && (ret & (ULL_CONST(1) << (47)))), 1)) {
         ret |= 0xffff000000000000;
     }
     return ret;
@@ -2491,9 +2491,9 @@ cap_pdpt_cap_get_capPDPTIsMapped(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_pdpt_cap);
 
-    ret = (cap.words[0] & 0x400000000000000ull) >> 58;
+    ret = (cap.words[0] & ULL_CONST(0x400000000000000)) >> 58;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2504,10 +2504,10 @@ cap_pdpt_cap_set_capPDPTIsMapped(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_pdpt_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0x400000000000000ull >> 58 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0x400000000000000) >> 58 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap.words[0] &= ~0x400000000000000ull;
-    cap.words[0] |= (v64 << 58) & 0x400000000000000ull;
+    cap.words[0] &= ~ULL_CONST(0x400000000000000);
+    cap.words[0] |= (v64 << 58) & ULL_CONST(0x400000000000000);
     return cap;
 }
 
@@ -2517,10 +2517,10 @@ cap_pdpt_cap_ptr_set_capPDPTIsMapped(cap_t *cap_ptr, uint64_t v64) {
     assert(((cap_ptr->words[0] >> 59) & 0x1f) == cap_pdpt_cap);
 
     /* fail if user has passed bits that we will override */
-    assert((((~0x400000000000000ull >> 58) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0x400000000000000) >> 58) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap_ptr->words[0] &= ~0x400000000000000ull;
-    cap_ptr->words[0] |= (v64 << 58) & 0x400000000000000ull;
+    cap_ptr->words[0] &= ~ULL_CONST(0x400000000000000);
+    cap_ptr->words[0] |= (v64 << 58) & ULL_CONST(0x400000000000000);
 }
 
 static inline uint64_t CONST
@@ -2529,9 +2529,9 @@ cap_pdpt_cap_get_capPDPTMappedAddress(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_pdpt_cap);
 
-    ret = (cap.words[0] & 0x3ff000000000000ull) >> 10;
+    ret = (cap.words[0] & ULL_CONST(0x3ff000000000000)) >> 10;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(1 && (ret & (1ull << (47)))), 1)) {
+    if (__builtin_expect(!!(1 && (ret & (ULL_CONST(1) << (47)))), 1)) {
         ret |= 0xffff000000000000;
     }
     return ret;
@@ -2542,10 +2542,10 @@ cap_pdpt_cap_set_capPDPTMappedAddress(cap_t cap, uint64_t v64) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_pdpt_cap);
     /* fail if user has passed bits that we will override */
-    assert((((~0x3ff000000000000ull >> 10 ) | 0xffff000000000000) & v64) == ((1 && (v64 & (1ull << (47)))) ? 0xffff000000000000 : 0));
+    assert((((~ULL_CONST(0x3ff000000000000) >> 10 ) | 0xffff000000000000) & v64) == ((1 && (v64 & (ULL_CONST(1) << (47)))) ? 0xffff000000000000 : 0));
 
-    cap.words[0] &= ~0x3ff000000000000ull;
-    cap.words[0] |= (v64 << 10) & 0x3ff000000000000ull;
+    cap.words[0] &= ~ULL_CONST(0x3ff000000000000);
+    cap.words[0] |= (v64 << 10) & ULL_CONST(0x3ff000000000000);
     return cap;
 }
 
@@ -2554,14 +2554,14 @@ cap_pml4_cap_new(uint64_t capPML4MappedASID, uint64_t capPML4BasePtr, uint64_t c
     cap_t cap;
 
     /* fail if user has passed bits that we will override */  
-    assert((capPML4MappedASID & ~0xfffull) == ((1 && (capPML4MappedASID & (1ull << 47))) ? 0x0 : 0));  
-    assert(((uint64_t)cap_pml4_cap & ~0x1full) == ((1 && ((uint64_t)cap_pml4_cap & (1ull << 47))) ? 0x0 : 0));  
-    assert((capPML4IsMapped & ~0x1ull) == ((1 && (capPML4IsMapped & (1ull << 47))) ? 0x0 : 0));
+    assert((capPML4MappedASID & ~ULL_CONST(0xfff)) == ((1 && (capPML4MappedASID & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert(((uint64_t)cap_pml4_cap & ~ULL_CONST(0x1f)) == ((1 && ((uint64_t)cap_pml4_cap & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capPML4IsMapped & ~ULL_CONST(0x1)) == ((1 && (capPML4IsMapped & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     cap.words[0] = 0
-        | (capPML4MappedASID & 0xfffull) << 0
-        | ((uint64_t)cap_pml4_cap & 0x1full) << 59
-        | (capPML4IsMapped & 0x1ull) << 58;
+        | (capPML4MappedASID & ULL_CONST(0xfff)) << 0
+        | ((uint64_t)cap_pml4_cap & ULL_CONST(0x1f)) << 59
+        | (capPML4IsMapped & ULL_CONST(0x1)) << 58;
     cap.words[1] = 0
         | capPML4BasePtr << 0;
 
@@ -2574,9 +2574,9 @@ cap_pml4_cap_get_capPML4BasePtr(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_pml4_cap);
 
-    ret = (cap.words[1] & 0xffffffffffffffffull) >> 0;
+    ret = (cap.words[1] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2588,9 +2588,9 @@ cap_pml4_cap_get_capPML4IsMapped(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_pml4_cap);
 
-    ret = (cap.words[0] & 0x400000000000000ull) >> 58;
+    ret = (cap.words[0] & ULL_CONST(0x400000000000000)) >> 58;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2602,10 +2602,10 @@ cap_pml4_cap_ptr_set_capPML4IsMapped(cap_t *cap_ptr, uint64_t v64) {
     assert(((cap_ptr->words[0] >> 59) & 0x1f) == cap_pml4_cap);
 
     /* fail if user has passed bits that we will override */
-    assert((((~0x400000000000000ull >> 58) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0x400000000000000) >> 58) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap_ptr->words[0] &= ~0x400000000000000ull;
-    cap_ptr->words[0] |= (v64 << 58) & 0x400000000000000ull;
+    cap_ptr->words[0] &= ~ULL_CONST(0x400000000000000);
+    cap_ptr->words[0] |= (v64 << 58) & ULL_CONST(0x400000000000000);
 }
 
 static inline uint64_t CONST
@@ -2614,9 +2614,9 @@ cap_pml4_cap_get_capPML4MappedASID(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_pml4_cap);
 
-    ret = (cap.words[0] & 0xfffull) >> 0;
+    ret = (cap.words[0] & ULL_CONST(0xfff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2628,10 +2628,10 @@ cap_pml4_cap_ptr_set_capPML4MappedASID(cap_t *cap_ptr, uint64_t v64) {
     assert(((cap_ptr->words[0] >> 59) & 0x1f) == cap_pml4_cap);
 
     /* fail if user has passed bits that we will override */
-    assert((((~0xfffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (47)))) ? 0x0 : 0));
+    assert((((~ULL_CONST(0xfff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (47)))) ? 0x0 : 0));
 
-    cap_ptr->words[0] &= ~0xfffull;
-    cap_ptr->words[0] |= (v64 << 0) & 0xfffull;
+    cap_ptr->words[0] &= ~ULL_CONST(0xfff);
+    cap_ptr->words[0] |= (v64 << 0) & ULL_CONST(0xfff);
 }
 
 static inline cap_t CONST
@@ -2639,10 +2639,10 @@ cap_asid_control_cap_new(void) {
     cap_t cap;
 
     /* fail if user has passed bits that we will override */  
-    assert(((uint64_t)cap_asid_control_cap & ~0x1full) == ((1 && ((uint64_t)cap_asid_control_cap & (1ull << 47))) ? 0x0 : 0));
+    assert(((uint64_t)cap_asid_control_cap & ~ULL_CONST(0x1f)) == ((1 && ((uint64_t)cap_asid_control_cap & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     cap.words[0] = 0
-        | ((uint64_t)cap_asid_control_cap & 0x1full) << 59;
+        | ((uint64_t)cap_asid_control_cap & ULL_CONST(0x1f)) << 59;
     cap.words[1] = 0;
 
     return cap;
@@ -2653,14 +2653,14 @@ cap_asid_pool_cap_new(uint64_t capASIDBase, uint64_t capASIDPool) {
     cap_t cap;
 
     /* fail if user has passed bits that we will override */  
-    assert(((uint64_t)cap_asid_pool_cap & ~0x1full) == ((1 && ((uint64_t)cap_asid_pool_cap & (1ull << 47))) ? 0x0 : 0));  
-    assert((capASIDBase & ~0xfffull) == ((1 && (capASIDBase & (1ull << 47))) ? 0x0 : 0));  
-    assert((capASIDPool & ~0xfffffffff800ull) == ((1 && (capASIDPool & (1ull << 47))) ? 0xffff000000000000 : 0));
+    assert(((uint64_t)cap_asid_pool_cap & ~ULL_CONST(0x1f)) == ((1 && ((uint64_t)cap_asid_pool_cap & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capASIDBase & ~ULL_CONST(0xfff)) == ((1 && (capASIDBase & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capASIDPool & ~ULL_CONST(0xfffffffff800)) == ((1 && (capASIDPool & (ULL_CONST(1) << 47))) ? 0xffff000000000000 : 0));
 
     cap.words[0] = 0
-        | ((uint64_t)cap_asid_pool_cap & 0x1full) << 59
-        | (capASIDBase & 0xfffull) << 47
-        | (capASIDPool & 0xfffffffff800ull) >> 11;
+        | ((uint64_t)cap_asid_pool_cap & ULL_CONST(0x1f)) << 59
+        | (capASIDBase & ULL_CONST(0xfff)) << 47
+        | (capASIDPool & ULL_CONST(0xfffffffff800)) >> 11;
     cap.words[1] = 0;
 
     return cap;
@@ -2672,9 +2672,9 @@ cap_asid_pool_cap_get_capASIDBase(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_asid_pool_cap);
 
-    ret = (cap.words[0] & 0x7ff800000000000ull) >> 47;
+    ret = (cap.words[0] & ULL_CONST(0x7ff800000000000)) >> 47;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2686,9 +2686,9 @@ cap_asid_pool_cap_get_capASIDPool(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_asid_pool_cap);
 
-    ret = (cap.words[0] & 0x1fffffffffull) << 11;
+    ret = (cap.words[0] & ULL_CONST(0x1fffffffff)) << 11;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(1 && (ret & (1ull << (47)))), 1)) {
+    if (__builtin_expect(!!(1 && (ret & (ULL_CONST(1) << (47)))), 1)) {
         ret |= 0xffff000000000000;
     }
     return ret;
@@ -2699,14 +2699,14 @@ cap_io_port_cap_new(uint64_t capIOPortFirstPort, uint64_t capIOPortLastPort) {
     cap_t cap;
 
     /* fail if user has passed bits that we will override */  
-    assert(((uint64_t)cap_io_port_cap & ~0x1full) == ((1 && ((uint64_t)cap_io_port_cap & (1ull << 47))) ? 0x0 : 0));  
-    assert((capIOPortFirstPort & ~0xffffull) == ((1 && (capIOPortFirstPort & (1ull << 47))) ? 0x0 : 0));  
-    assert((capIOPortLastPort & ~0xffffull) == ((1 && (capIOPortLastPort & (1ull << 47))) ? 0x0 : 0));
+    assert(((uint64_t)cap_io_port_cap & ~ULL_CONST(0x1f)) == ((1 && ((uint64_t)cap_io_port_cap & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capIOPortFirstPort & ~ULL_CONST(0xffff)) == ((1 && (capIOPortFirstPort & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((capIOPortLastPort & ~ULL_CONST(0xffff)) == ((1 && (capIOPortLastPort & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     cap.words[0] = 0
-        | ((uint64_t)cap_io_port_cap & 0x1full) << 59
-        | (capIOPortFirstPort & 0xffffull) << 40
-        | (capIOPortLastPort & 0xffffull) << 24;
+        | ((uint64_t)cap_io_port_cap & ULL_CONST(0x1f)) << 59
+        | (capIOPortFirstPort & ULL_CONST(0xffff)) << 40
+        | (capIOPortLastPort & ULL_CONST(0xffff)) << 24;
     cap.words[1] = 0;
 
     return cap;
@@ -2718,9 +2718,9 @@ cap_io_port_cap_get_capIOPortFirstPort(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_io_port_cap);
 
-    ret = (cap.words[0] & 0xffff0000000000ull) >> 40;
+    ret = (cap.words[0] & ULL_CONST(0xffff0000000000)) >> 40;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2732,9 +2732,9 @@ cap_io_port_cap_get_capIOPortLastPort(cap_t cap) {
     /* fail if union does not have the expected tag */
     assert(((cap.words[0] >> 59) & 0x1f) == cap_io_port_cap);
 
-    ret = (cap.words[0] & 0xffff000000ull) >> 24;
+    ret = (cap.words[0] & ULL_CONST(0xffff000000)) >> 24;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2745,10 +2745,10 @@ cap_io_port_control_cap_new(void) {
     cap_t cap;
 
     /* fail if user has passed bits that we will override */  
-    assert(((uint64_t)cap_io_port_control_cap & ~0x1full) == ((1 && ((uint64_t)cap_io_port_control_cap & (1ull << 47))) ? 0x0 : 0));
+    assert(((uint64_t)cap_io_port_control_cap & ~ULL_CONST(0x1f)) == ((1 && ((uint64_t)cap_io_port_control_cap & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     cap.words[0] = 0
-        | ((uint64_t)cap_io_port_control_cap & 0x1full) << 59;
+        | ((uint64_t)cap_io_port_control_cap & ULL_CONST(0x1f)) << 59;
     cap.words[1] = 0;
 
     return cap;
@@ -2771,10 +2771,10 @@ gdt_entry_gdt_null_new(void) {
     gdt_entry_t gdt_entry;
 
     /* fail if user has passed bits that we will override */  
-    assert(((uint64_t)gdt_entry_gdt_null & ~0xfull) == ((1 && ((uint64_t)gdt_entry_gdt_null & (1ull << 47))) ? 0x0 : 0));
+    assert(((uint64_t)gdt_entry_gdt_null & ~ULL_CONST(0xf)) == ((1 && ((uint64_t)gdt_entry_gdt_null & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     gdt_entry.words[0] = 0
-        | ((uint64_t)gdt_entry_gdt_null & 0xfull) << 40;
+        | ((uint64_t)gdt_entry_gdt_null & ULL_CONST(0xf)) << 40;
 
     return gdt_entry;
 }
@@ -2784,32 +2784,32 @@ gdt_entry_gdt_data_new(uint64_t base_high, uint64_t granularity, uint64_t operat
     gdt_entry_t gdt_entry;
 
     /* fail if user has passed bits that we will override */  
-    assert((base_high & ~0xffull) == ((1 && (base_high & (1ull << 47))) ? 0x0 : 0));  
-    assert((granularity & ~0x1ull) == ((1 && (granularity & (1ull << 47))) ? 0x0 : 0));  
-    assert((operation_size & ~0x1ull) == ((1 && (operation_size & (1ull << 47))) ? 0x0 : 0));  
-    assert((avl & ~0x1ull) == ((1 && (avl & (1ull << 47))) ? 0x0 : 0));  
-    assert((seg_limit_high & ~0xfull) == ((1 && (seg_limit_high & (1ull << 47))) ? 0x0 : 0));  
-    assert((present & ~0x1ull) == ((1 && (present & (1ull << 47))) ? 0x0 : 0));  
-    assert((dpl & ~0x3ull) == ((1 && (dpl & (1ull << 47))) ? 0x0 : 0));  
-    assert((always_1 & ~0x1ull) == ((1 && (always_1 & (1ull << 47))) ? 0x0 : 0));  
-    assert(((uint64_t)gdt_entry_gdt_data & ~0xfull) == ((1 && ((uint64_t)gdt_entry_gdt_data & (1ull << 47))) ? 0x0 : 0));  
-    assert((base_mid & ~0xffull) == ((1 && (base_mid & (1ull << 47))) ? 0x0 : 0));  
-    assert((base_low & ~0xffffull) == ((1 && (base_low & (1ull << 47))) ? 0x0 : 0));  
-    assert((seg_limit_low & ~0xffffull) == ((1 && (seg_limit_low & (1ull << 47))) ? 0x0 : 0));
+    assert((base_high & ~ULL_CONST(0xff)) == ((1 && (base_high & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((granularity & ~ULL_CONST(0x1)) == ((1 && (granularity & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((operation_size & ~ULL_CONST(0x1)) == ((1 && (operation_size & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((avl & ~ULL_CONST(0x1)) == ((1 && (avl & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((seg_limit_high & ~ULL_CONST(0xf)) == ((1 && (seg_limit_high & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((present & ~ULL_CONST(0x1)) == ((1 && (present & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((dpl & ~ULL_CONST(0x3)) == ((1 && (dpl & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((always_1 & ~ULL_CONST(0x1)) == ((1 && (always_1 & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert(((uint64_t)gdt_entry_gdt_data & ~ULL_CONST(0xf)) == ((1 && ((uint64_t)gdt_entry_gdt_data & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((base_mid & ~ULL_CONST(0xff)) == ((1 && (base_mid & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((base_low & ~ULL_CONST(0xffff)) == ((1 && (base_low & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((seg_limit_low & ~ULL_CONST(0xffff)) == ((1 && (seg_limit_low & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     gdt_entry.words[0] = 0
-        | (base_high & 0xffull) << 56
-        | (granularity & 0x1ull) << 55
-        | (operation_size & 0x1ull) << 54
-        | (avl & 0x1ull) << 52
-        | (seg_limit_high & 0xfull) << 48
-        | (present & 0x1ull) << 47
-        | (dpl & 0x3ull) << 45
-        | (always_1 & 0x1ull) << 44
-        | ((uint64_t)gdt_entry_gdt_data & 0xfull) << 40
-        | (base_mid & 0xffull) << 32
-        | (base_low & 0xffffull) << 16
-        | (seg_limit_low & 0xffffull) << 0;
+        | (base_high & ULL_CONST(0xff)) << 56
+        | (granularity & ULL_CONST(0x1)) << 55
+        | (operation_size & ULL_CONST(0x1)) << 54
+        | (avl & ULL_CONST(0x1)) << 52
+        | (seg_limit_high & ULL_CONST(0xf)) << 48
+        | (present & ULL_CONST(0x1)) << 47
+        | (dpl & ULL_CONST(0x3)) << 45
+        | (always_1 & ULL_CONST(0x1)) << 44
+        | ((uint64_t)gdt_entry_gdt_data & ULL_CONST(0xf)) << 40
+        | (base_mid & ULL_CONST(0xff)) << 32
+        | (base_low & ULL_CONST(0xffff)) << 16
+        | (seg_limit_low & ULL_CONST(0xffff)) << 0;
 
     return gdt_entry;
 }
@@ -2819,34 +2819,34 @@ gdt_entry_gdt_code_new(uint64_t base_high, uint64_t granularity, uint64_t operat
     gdt_entry_t gdt_entry;
 
     /* fail if user has passed bits that we will override */  
-    assert((base_high & ~0xffull) == ((1 && (base_high & (1ull << 47))) ? 0x0 : 0));  
-    assert((granularity & ~0x1ull) == ((1 && (granularity & (1ull << 47))) ? 0x0 : 0));  
-    assert((operation_size & ~0x1ull) == ((1 && (operation_size & (1ull << 47))) ? 0x0 : 0));  
-    assert((long_mode & ~0x1ull) == ((1 && (long_mode & (1ull << 47))) ? 0x0 : 0));  
-    assert((avl & ~0x1ull) == ((1 && (avl & (1ull << 47))) ? 0x0 : 0));  
-    assert((seg_limit_high & ~0xfull) == ((1 && (seg_limit_high & (1ull << 47))) ? 0x0 : 0));  
-    assert((present & ~0x1ull) == ((1 && (present & (1ull << 47))) ? 0x0 : 0));  
-    assert((dpl & ~0x3ull) == ((1 && (dpl & (1ull << 47))) ? 0x0 : 0));  
-    assert((always_1 & ~0x1ull) == ((1 && (always_1 & (1ull << 47))) ? 0x0 : 0));  
-    assert(((uint64_t)gdt_entry_gdt_code & ~0xfull) == ((1 && ((uint64_t)gdt_entry_gdt_code & (1ull << 47))) ? 0x0 : 0));  
-    assert((base_mid & ~0xffull) == ((1 && (base_mid & (1ull << 47))) ? 0x0 : 0));  
-    assert((base_low & ~0xffffull) == ((1 && (base_low & (1ull << 47))) ? 0x0 : 0));  
-    assert((seg_limit_low & ~0xffffull) == ((1 && (seg_limit_low & (1ull << 47))) ? 0x0 : 0));
+    assert((base_high & ~ULL_CONST(0xff)) == ((1 && (base_high & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((granularity & ~ULL_CONST(0x1)) == ((1 && (granularity & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((operation_size & ~ULL_CONST(0x1)) == ((1 && (operation_size & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((long_mode & ~ULL_CONST(0x1)) == ((1 && (long_mode & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((avl & ~ULL_CONST(0x1)) == ((1 && (avl & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((seg_limit_high & ~ULL_CONST(0xf)) == ((1 && (seg_limit_high & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((present & ~ULL_CONST(0x1)) == ((1 && (present & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((dpl & ~ULL_CONST(0x3)) == ((1 && (dpl & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((always_1 & ~ULL_CONST(0x1)) == ((1 && (always_1 & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert(((uint64_t)gdt_entry_gdt_code & ~ULL_CONST(0xf)) == ((1 && ((uint64_t)gdt_entry_gdt_code & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((base_mid & ~ULL_CONST(0xff)) == ((1 && (base_mid & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((base_low & ~ULL_CONST(0xffff)) == ((1 && (base_low & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((seg_limit_low & ~ULL_CONST(0xffff)) == ((1 && (seg_limit_low & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     gdt_entry.words[0] = 0
-        | (base_high & 0xffull) << 56
-        | (granularity & 0x1ull) << 55
-        | (operation_size & 0x1ull) << 54
-        | (long_mode & 0x1ull) << 53
-        | (avl & 0x1ull) << 52
-        | (seg_limit_high & 0xfull) << 48
-        | (present & 0x1ull) << 47
-        | (dpl & 0x3ull) << 45
-        | (always_1 & 0x1ull) << 44
-        | ((uint64_t)gdt_entry_gdt_code & 0xfull) << 40
-        | (base_mid & 0xffull) << 32
-        | (base_low & 0xffffull) << 16
-        | (seg_limit_low & 0xffffull) << 0;
+        | (base_high & ULL_CONST(0xff)) << 56
+        | (granularity & ULL_CONST(0x1)) << 55
+        | (operation_size & ULL_CONST(0x1)) << 54
+        | (long_mode & ULL_CONST(0x1)) << 53
+        | (avl & ULL_CONST(0x1)) << 52
+        | (seg_limit_high & ULL_CONST(0xf)) << 48
+        | (present & ULL_CONST(0x1)) << 47
+        | (dpl & ULL_CONST(0x3)) << 45
+        | (always_1 & ULL_CONST(0x1)) << 44
+        | ((uint64_t)gdt_entry_gdt_code & ULL_CONST(0xf)) << 40
+        | (base_mid & ULL_CONST(0xff)) << 32
+        | (base_low & ULL_CONST(0xffff)) << 16
+        | (seg_limit_low & ULL_CONST(0xffff)) << 0;
 
     return gdt_entry;
 }
@@ -2867,25 +2867,25 @@ idt_entry_interrupt_gate_new(uint64_t offset_63_32, uint64_t offset_31_16, uint6
     idt_entry_t idt_entry;
 
     /* fail if user has passed bits that we will override */  
-    assert((offset_63_32 & ~0xffffffffull) == ((1 && (offset_63_32 & (1ull << 47))) ? 0x0 : 0));  
-    assert((offset_31_16 & ~0xffffull) == ((1 && (offset_31_16 & (1ull << 47))) ? 0x0 : 0));  
-    assert((present & ~0x1ull) == ((1 && (present & (1ull << 47))) ? 0x0 : 0));  
-    assert((dpl & ~0x3ull) == ((1 && (dpl & (1ull << 47))) ? 0x0 : 0));  
-    assert(((uint64_t)idt_entry_interrupt_gate & ~0xfull) == ((1 && ((uint64_t)idt_entry_interrupt_gate & (1ull << 47))) ? 0x0 : 0));  
-    assert((ist & ~0x7ull) == ((1 && (ist & (1ull << 47))) ? 0x0 : 0));  
-    assert((seg_selector & ~0xffffull) == ((1 && (seg_selector & (1ull << 47))) ? 0x0 : 0));  
-    assert((offset_15_0 & ~0xffffull) == ((1 && (offset_15_0 & (1ull << 47))) ? 0x0 : 0));
+    assert((offset_63_32 & ~ULL_CONST(0xffffffff)) == ((1 && (offset_63_32 & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((offset_31_16 & ~ULL_CONST(0xffff)) == ((1 && (offset_31_16 & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((present & ~ULL_CONST(0x1)) == ((1 && (present & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((dpl & ~ULL_CONST(0x3)) == ((1 && (dpl & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert(((uint64_t)idt_entry_interrupt_gate & ~ULL_CONST(0xf)) == ((1 && ((uint64_t)idt_entry_interrupt_gate & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((ist & ~ULL_CONST(0x7)) == ((1 && (ist & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((seg_selector & ~ULL_CONST(0xffff)) == ((1 && (seg_selector & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((offset_15_0 & ~ULL_CONST(0xffff)) == ((1 && (offset_15_0 & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     idt_entry.words[0] = 0
-        | (offset_31_16 & 0xffffull) << 48
-        | (present & 0x1ull) << 47
-        | (dpl & 0x3ull) << 45
-        | ((uint64_t)idt_entry_interrupt_gate & 0xfull) << 40
-        | (ist & 0x7ull) << 32
-        | (seg_selector & 0xffffull) << 16
-        | (offset_15_0 & 0xffffull) << 0;
+        | (offset_31_16 & ULL_CONST(0xffff)) << 48
+        | (present & ULL_CONST(0x1)) << 47
+        | (dpl & ULL_CONST(0x3)) << 45
+        | ((uint64_t)idt_entry_interrupt_gate & ULL_CONST(0xf)) << 40
+        | (ist & ULL_CONST(0x7)) << 32
+        | (seg_selector & ULL_CONST(0xffff)) << 16
+        | (offset_15_0 & ULL_CONST(0xffff)) << 0;
     idt_entry.words[1] = 0
-        | (offset_63_32 & 0xffffffffull) << 0;
+        | (offset_63_32 & ULL_CONST(0xffffffff)) << 0;
 
     return idt_entry;
 }
@@ -2905,7 +2905,7 @@ typedef enum lookup_fault_tag lookup_fault_tag_t;
 
 static inline uint64_t CONST
 lookup_fault_get_lufType(lookup_fault_t lookup_fault) {
-    return (lookup_fault.words[0] >> 0) & 0x3ull;
+    return (lookup_fault.words[0] >> 0) & ULL_CONST(0x3);
 }
 
 static inline lookup_fault_t CONST
@@ -2913,10 +2913,10 @@ lookup_fault_invalid_root_new(void) {
     lookup_fault_t lookup_fault;
 
     /* fail if user has passed bits that we will override */  
-    assert(((uint64_t)lookup_fault_invalid_root & ~0x3ull) == ((1 && ((uint64_t)lookup_fault_invalid_root & (1ull << 47))) ? 0x0 : 0));
+    assert(((uint64_t)lookup_fault_invalid_root & ~ULL_CONST(0x3)) == ((1 && ((uint64_t)lookup_fault_invalid_root & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     lookup_fault.words[0] = 0
-        | ((uint64_t)lookup_fault_invalid_root & 0x3ull) << 0;
+        | ((uint64_t)lookup_fault_invalid_root & ULL_CONST(0x3)) << 0;
     lookup_fault.words[1] = 0;
 
     return lookup_fault;
@@ -2927,12 +2927,12 @@ lookup_fault_missing_capability_new(uint64_t bitsLeft) {
     lookup_fault_t lookup_fault;
 
     /* fail if user has passed bits that we will override */  
-    assert((bitsLeft & ~0x7full) == ((1 && (bitsLeft & (1ull << 47))) ? 0x0 : 0));  
-    assert(((uint64_t)lookup_fault_missing_capability & ~0x3ull) == ((1 && ((uint64_t)lookup_fault_missing_capability & (1ull << 47))) ? 0x0 : 0));
+    assert((bitsLeft & ~ULL_CONST(0x7f)) == ((1 && (bitsLeft & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert(((uint64_t)lookup_fault_missing_capability & ~ULL_CONST(0x3)) == ((1 && ((uint64_t)lookup_fault_missing_capability & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     lookup_fault.words[0] = 0
-        | (bitsLeft & 0x7full) << 2
-        | ((uint64_t)lookup_fault_missing_capability & 0x3ull) << 0;
+        | (bitsLeft & ULL_CONST(0x7f)) << 2
+        | ((uint64_t)lookup_fault_missing_capability & ULL_CONST(0x3)) << 0;
     lookup_fault.words[1] = 0;
 
     return lookup_fault;
@@ -2944,9 +2944,9 @@ lookup_fault_missing_capability_get_bitsLeft(lookup_fault_t lookup_fault) {
     /* fail if union does not have the expected tag */
     assert(((lookup_fault.words[0] >> 0) & 0x3) == lookup_fault_missing_capability);
 
-    ret = (lookup_fault.words[0] & 0x1fcull) >> 2;
+    ret = (lookup_fault.words[0] & ULL_CONST(0x1fc)) >> 2;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2957,14 +2957,14 @@ lookup_fault_depth_mismatch_new(uint64_t bitsFound, uint64_t bitsLeft) {
     lookup_fault_t lookup_fault;
 
     /* fail if user has passed bits that we will override */  
-    assert((bitsFound & ~0x7full) == ((1 && (bitsFound & (1ull << 47))) ? 0x0 : 0));  
-    assert((bitsLeft & ~0x7full) == ((1 && (bitsLeft & (1ull << 47))) ? 0x0 : 0));  
-    assert(((uint64_t)lookup_fault_depth_mismatch & ~0x3ull) == ((1 && ((uint64_t)lookup_fault_depth_mismatch & (1ull << 47))) ? 0x0 : 0));
+    assert((bitsFound & ~ULL_CONST(0x7f)) == ((1 && (bitsFound & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((bitsLeft & ~ULL_CONST(0x7f)) == ((1 && (bitsLeft & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert(((uint64_t)lookup_fault_depth_mismatch & ~ULL_CONST(0x3)) == ((1 && ((uint64_t)lookup_fault_depth_mismatch & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     lookup_fault.words[0] = 0
-        | (bitsFound & 0x7full) << 9
-        | (bitsLeft & 0x7full) << 2
-        | ((uint64_t)lookup_fault_depth_mismatch & 0x3ull) << 0;
+        | (bitsFound & ULL_CONST(0x7f)) << 9
+        | (bitsLeft & ULL_CONST(0x7f)) << 2
+        | ((uint64_t)lookup_fault_depth_mismatch & ULL_CONST(0x3)) << 0;
     lookup_fault.words[1] = 0;
 
     return lookup_fault;
@@ -2976,9 +2976,9 @@ lookup_fault_depth_mismatch_get_bitsFound(lookup_fault_t lookup_fault) {
     /* fail if union does not have the expected tag */
     assert(((lookup_fault.words[0] >> 0) & 0x3) == lookup_fault_depth_mismatch);
 
-    ret = (lookup_fault.words[0] & 0xfe00ull) >> 9;
+    ret = (lookup_fault.words[0] & ULL_CONST(0xfe00)) >> 9;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2990,9 +2990,9 @@ lookup_fault_depth_mismatch_get_bitsLeft(lookup_fault_t lookup_fault) {
     /* fail if union does not have the expected tag */
     assert(((lookup_fault.words[0] >> 0) & 0x3) == lookup_fault_depth_mismatch);
 
-    ret = (lookup_fault.words[0] & 0x1fcull) >> 2;
+    ret = (lookup_fault.words[0] & ULL_CONST(0x1fc)) >> 2;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -3003,14 +3003,14 @@ lookup_fault_guard_mismatch_new(uint64_t guardFound, uint64_t bitsLeft, uint64_t
     lookup_fault_t lookup_fault;
 
     /* fail if user has passed bits that we will override */  
-    assert((bitsLeft & ~0x7full) == ((1 && (bitsLeft & (1ull << 47))) ? 0x0 : 0));  
-    assert((bitsFound & ~0x7full) == ((1 && (bitsFound & (1ull << 47))) ? 0x0 : 0));  
-    assert(((uint64_t)lookup_fault_guard_mismatch & ~0x3ull) == ((1 && ((uint64_t)lookup_fault_guard_mismatch & (1ull << 47))) ? 0x0 : 0));
+    assert((bitsLeft & ~ULL_CONST(0x7f)) == ((1 && (bitsLeft & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert((bitsFound & ~ULL_CONST(0x7f)) == ((1 && (bitsFound & (ULL_CONST(1) << 47))) ? 0x0 : 0));  
+    assert(((uint64_t)lookup_fault_guard_mismatch & ~ULL_CONST(0x3)) == ((1 && ((uint64_t)lookup_fault_guard_mismatch & (ULL_CONST(1) << 47))) ? 0x0 : 0));
 
     lookup_fault.words[0] = 0
-        | (bitsLeft & 0x7full) << 9
-        | (bitsFound & 0x7full) << 2
-        | ((uint64_t)lookup_fault_guard_mismatch & 0x3ull) << 0;
+        | (bitsLeft & ULL_CONST(0x7f)) << 9
+        | (bitsFound & ULL_CONST(0x7f)) << 2
+        | ((uint64_t)lookup_fault_guard_mismatch & ULL_CONST(0x3)) << 0;
     lookup_fault.words[1] = 0
         | guardFound << 0;
 
@@ -3023,9 +3023,9 @@ lookup_fault_guard_mismatch_get_guardFound(lookup_fault_t lookup_fault) {
     /* fail if union does not have the expected tag */
     assert(((lookup_fault.words[0] >> 0) & 0x3) == lookup_fault_guard_mismatch);
 
-    ret = (lookup_fault.words[1] & 0xffffffffffffffffull) >> 0;
+    ret = (lookup_fault.words[1] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -3037,9 +3037,9 @@ lookup_fault_guard_mismatch_get_bitsLeft(lookup_fault_t lookup_fault) {
     /* fail if union does not have the expected tag */
     assert(((lookup_fault.words[0] >> 0) & 0x3) == lookup_fault_guard_mismatch);
 
-    ret = (lookup_fault.words[0] & 0xfe00ull) >> 9;
+    ret = (lookup_fault.words[0] & ULL_CONST(0xfe00)) >> 9;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -3051,9 +3051,9 @@ lookup_fault_guard_mismatch_get_bitsFound(lookup_fault_t lookup_fault) {
     /* fail if union does not have the expected tag */
     assert(((lookup_fault.words[0] >> 0) & 0x3) == lookup_fault_guard_mismatch);
 
-    ret = (lookup_fault.words[0] & 0x1fcull) >> 2;
+    ret = (lookup_fault.words[0] & ULL_CONST(0x1fc)) >> 2;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (47)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (47)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -3072,7 +3072,7 @@ typedef enum pde_tag pde_tag_t;
 
 static inline uint64_t PURE
 pde_ptr_get_page_size(pde_t *pde_ptr) {
-    return (pde_ptr->words[0] >> 7) & 0x1ull;
+    return (pde_ptr->words[0] >> 7) & ULL_CONST(0x1);
 }
 
 static inline pde_t CONST
@@ -3080,26 +3080,26 @@ pde_pde_pt_new(uint64_t xd, uint64_t pt_base_address, uint64_t accessed, uint64_
     pde_t pde;
 
     /* fail if user has passed bits that we will override */  
-    assert((xd & ~0x1ull) == ((0 && (xd & (1ull << 50))) ? 0x0 : 0));  
-    assert((pt_base_address & ~0x7fffffffff000ull) == ((0 && (pt_base_address & (1ull << 50))) ? 0x0 : 0));  
-    assert(((uint64_t)pde_pde_pt & ~0x1ull) == ((0 && ((uint64_t)pde_pde_pt & (1ull << 50))) ? 0x0 : 0));  
-    assert((accessed & ~0x1ull) == ((0 && (accessed & (1ull << 50))) ? 0x0 : 0));  
-    assert((cache_disabled & ~0x1ull) == ((0 && (cache_disabled & (1ull << 50))) ? 0x0 : 0));  
-    assert((write_through & ~0x1ull) == ((0 && (write_through & (1ull << 50))) ? 0x0 : 0));  
-    assert((super_user & ~0x1ull) == ((0 && (super_user & (1ull << 50))) ? 0x0 : 0));  
-    assert((read_write & ~0x1ull) == ((0 && (read_write & (1ull << 50))) ? 0x0 : 0));  
-    assert((present & ~0x1ull) == ((0 && (present & (1ull << 50))) ? 0x0 : 0));
+    assert((xd & ~ULL_CONST(0x1)) == ((0 && (xd & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((pt_base_address & ~ULL_CONST(0x7fffffffff000)) == ((0 && (pt_base_address & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert(((uint64_t)pde_pde_pt & ~ULL_CONST(0x1)) == ((0 && ((uint64_t)pde_pde_pt & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((accessed & ~ULL_CONST(0x1)) == ((0 && (accessed & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((cache_disabled & ~ULL_CONST(0x1)) == ((0 && (cache_disabled & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((write_through & ~ULL_CONST(0x1)) == ((0 && (write_through & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((super_user & ~ULL_CONST(0x1)) == ((0 && (super_user & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((read_write & ~ULL_CONST(0x1)) == ((0 && (read_write & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((present & ~ULL_CONST(0x1)) == ((0 && (present & (ULL_CONST(1) << 50))) ? 0x0 : 0));
 
     pde.words[0] = 0
-        | (xd & 0x1ull) << 63
-        | (pt_base_address & 0x7fffffffff000ull) >> 0
-        | ((uint64_t)pde_pde_pt & 0x1ull) << 7
-        | (accessed & 0x1ull) << 5
-        | (cache_disabled & 0x1ull) << 4
-        | (write_through & 0x1ull) << 3
-        | (super_user & 0x1ull) << 2
-        | (read_write & 0x1ull) << 1
-        | (present & 0x1ull) << 0;
+        | (xd & ULL_CONST(0x1)) << 63
+        | (pt_base_address & ULL_CONST(0x7fffffffff000)) >> 0
+        | ((uint64_t)pde_pde_pt & ULL_CONST(0x1)) << 7
+        | (accessed & ULL_CONST(0x1)) << 5
+        | (cache_disabled & ULL_CONST(0x1)) << 4
+        | (write_through & ULL_CONST(0x1)) << 3
+        | (super_user & ULL_CONST(0x1)) << 2
+        | (read_write & ULL_CONST(0x1)) << 1
+        | (present & ULL_CONST(0x1)) << 0;
 
     return pde;
 }
@@ -3110,9 +3110,9 @@ pde_pde_pt_ptr_get_pt_base_address(pde_t *pde_ptr) {
     /* fail if union does not have the expected tag */
     assert(((pde_ptr->words[0] >> 7) & 0x1) == pde_pde_pt);
 
-    ret = (pde_ptr->words[0] & 0x7fffffffff000ull) << 0;
+    ret = (pde_ptr->words[0] & ULL_CONST(0x7fffffffff000)) << 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (50)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (50)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -3124,9 +3124,9 @@ pde_pde_pt_ptr_get_present(pde_t *pde_ptr) {
     /* fail if union does not have the expected tag */
     assert(((pde_ptr->words[0] >> 7) & 0x1) == pde_pde_pt);
 
-    ret = (pde_ptr->words[0] & 0x1ull) >> 0;
+    ret = (pde_ptr->words[0] & ULL_CONST(0x1)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (50)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (50)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -3137,32 +3137,32 @@ pde_pde_large_new(uint64_t xd, uint64_t page_base_address, uint64_t pat, uint64_
     pde_t pde;
 
     /* fail if user has passed bits that we will override */  
-    assert((xd & ~0x1ull) == ((0 && (xd & (1ull << 50))) ? 0x0 : 0));  
-    assert((page_base_address & ~0x7ffffffe00000ull) == ((0 && (page_base_address & (1ull << 50))) ? 0x0 : 0));  
-    assert((pat & ~0x1ull) == ((0 && (pat & (1ull << 50))) ? 0x0 : 0));  
-    assert((global & ~0x1ull) == ((0 && (global & (1ull << 50))) ? 0x0 : 0));  
-    assert(((uint64_t)pde_pde_large & ~0x1ull) == ((0 && ((uint64_t)pde_pde_large & (1ull << 50))) ? 0x0 : 0));  
-    assert((dirty & ~0x1ull) == ((0 && (dirty & (1ull << 50))) ? 0x0 : 0));  
-    assert((accessed & ~0x1ull) == ((0 && (accessed & (1ull << 50))) ? 0x0 : 0));  
-    assert((cache_disabled & ~0x1ull) == ((0 && (cache_disabled & (1ull << 50))) ? 0x0 : 0));  
-    assert((write_through & ~0x1ull) == ((0 && (write_through & (1ull << 50))) ? 0x0 : 0));  
-    assert((super_user & ~0x1ull) == ((0 && (super_user & (1ull << 50))) ? 0x0 : 0));  
-    assert((read_write & ~0x1ull) == ((0 && (read_write & (1ull << 50))) ? 0x0 : 0));  
-    assert((present & ~0x1ull) == ((0 && (present & (1ull << 50))) ? 0x0 : 0));
+    assert((xd & ~ULL_CONST(0x1)) == ((0 && (xd & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((page_base_address & ~ULL_CONST(0x7ffffffe00000)) == ((0 && (page_base_address & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((pat & ~ULL_CONST(0x1)) == ((0 && (pat & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((global & ~ULL_CONST(0x1)) == ((0 && (global & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert(((uint64_t)pde_pde_large & ~ULL_CONST(0x1)) == ((0 && ((uint64_t)pde_pde_large & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((dirty & ~ULL_CONST(0x1)) == ((0 && (dirty & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((accessed & ~ULL_CONST(0x1)) == ((0 && (accessed & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((cache_disabled & ~ULL_CONST(0x1)) == ((0 && (cache_disabled & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((write_through & ~ULL_CONST(0x1)) == ((0 && (write_through & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((super_user & ~ULL_CONST(0x1)) == ((0 && (super_user & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((read_write & ~ULL_CONST(0x1)) == ((0 && (read_write & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((present & ~ULL_CONST(0x1)) == ((0 && (present & (ULL_CONST(1) << 50))) ? 0x0 : 0));
 
     pde.words[0] = 0
-        | (xd & 0x1ull) << 63
-        | (page_base_address & 0x7ffffffe00000ull) >> 0
-        | (pat & 0x1ull) << 12
-        | (global & 0x1ull) << 8
-        | ((uint64_t)pde_pde_large & 0x1ull) << 7
-        | (dirty & 0x1ull) << 6
-        | (accessed & 0x1ull) << 5
-        | (cache_disabled & 0x1ull) << 4
-        | (write_through & 0x1ull) << 3
-        | (super_user & 0x1ull) << 2
-        | (read_write & 0x1ull) << 1
-        | (present & 0x1ull) << 0;
+        | (xd & ULL_CONST(0x1)) << 63
+        | (page_base_address & ULL_CONST(0x7ffffffe00000)) >> 0
+        | (pat & ULL_CONST(0x1)) << 12
+        | (global & ULL_CONST(0x1)) << 8
+        | ((uint64_t)pde_pde_large & ULL_CONST(0x1)) << 7
+        | (dirty & ULL_CONST(0x1)) << 6
+        | (accessed & ULL_CONST(0x1)) << 5
+        | (cache_disabled & ULL_CONST(0x1)) << 4
+        | (write_through & ULL_CONST(0x1)) << 3
+        | (super_user & ULL_CONST(0x1)) << 2
+        | (read_write & ULL_CONST(0x1)) << 1
+        | (present & ULL_CONST(0x1)) << 0;
 
     return pde;
 }
@@ -3173,9 +3173,9 @@ pde_pde_large_ptr_get_page_base_address(pde_t *pde_ptr) {
     /* fail if union does not have the expected tag */
     assert(((pde_ptr->words[0] >> 7) & 0x1) == pde_pde_large);
 
-    ret = (pde_ptr->words[0] & 0x7ffffffe00000ull) << 0;
+    ret = (pde_ptr->words[0] & ULL_CONST(0x7ffffffe00000)) << 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (50)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (50)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -3187,9 +3187,9 @@ pde_pde_large_ptr_get_present(pde_t *pde_ptr) {
     /* fail if union does not have the expected tag */
     assert(((pde_ptr->words[0] >> 7) & 0x1) == pde_pde_large);
 
-    ret = (pde_ptr->words[0] & 0x1ull) >> 0;
+    ret = (pde_ptr->words[0] & ULL_CONST(0x1)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (50)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (50)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -3208,7 +3208,7 @@ typedef enum pdpte_tag pdpte_tag_t;
 
 static inline uint64_t PURE
 pdpte_ptr_get_page_size(pdpte_t *pdpte_ptr) {
-    return (pdpte_ptr->words[0] >> 7) & 0x1ull;
+    return (pdpte_ptr->words[0] >> 7) & ULL_CONST(0x1);
 }
 
 static inline pdpte_t CONST
@@ -3216,32 +3216,32 @@ pdpte_pdpte_1g_new(uint64_t xd, uint64_t page_base_address, uint64_t pat, uint64
     pdpte_t pdpte;
 
     /* fail if user has passed bits that we will override */  
-    assert((xd & ~0x1ull) == ((0 && (xd & (1ull << 50))) ? 0x0 : 0));  
-    assert((page_base_address & ~0x7ffffc0000000ull) == ((0 && (page_base_address & (1ull << 50))) ? 0x0 : 0));  
-    assert((pat & ~0x1ull) == ((0 && (pat & (1ull << 50))) ? 0x0 : 0));  
-    assert((global & ~0x1ull) == ((0 && (global & (1ull << 50))) ? 0x0 : 0));  
-    assert(((uint64_t)pdpte_pdpte_1g & ~0x1ull) == ((0 && ((uint64_t)pdpte_pdpte_1g & (1ull << 50))) ? 0x0 : 0));  
-    assert((dirty & ~0x1ull) == ((0 && (dirty & (1ull << 50))) ? 0x0 : 0));  
-    assert((accessed & ~0x1ull) == ((0 && (accessed & (1ull << 50))) ? 0x0 : 0));  
-    assert((cache_disabled & ~0x1ull) == ((0 && (cache_disabled & (1ull << 50))) ? 0x0 : 0));  
-    assert((write_through & ~0x1ull) == ((0 && (write_through & (1ull << 50))) ? 0x0 : 0));  
-    assert((super_user & ~0x1ull) == ((0 && (super_user & (1ull << 50))) ? 0x0 : 0));  
-    assert((read_write & ~0x1ull) == ((0 && (read_write & (1ull << 50))) ? 0x0 : 0));  
-    assert((present & ~0x1ull) == ((0 && (present & (1ull << 50))) ? 0x0 : 0));
+    assert((xd & ~ULL_CONST(0x1)) == ((0 && (xd & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((page_base_address & ~ULL_CONST(0x7ffffc0000000)) == ((0 && (page_base_address & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((pat & ~ULL_CONST(0x1)) == ((0 && (pat & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((global & ~ULL_CONST(0x1)) == ((0 && (global & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert(((uint64_t)pdpte_pdpte_1g & ~ULL_CONST(0x1)) == ((0 && ((uint64_t)pdpte_pdpte_1g & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((dirty & ~ULL_CONST(0x1)) == ((0 && (dirty & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((accessed & ~ULL_CONST(0x1)) == ((0 && (accessed & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((cache_disabled & ~ULL_CONST(0x1)) == ((0 && (cache_disabled & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((write_through & ~ULL_CONST(0x1)) == ((0 && (write_through & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((super_user & ~ULL_CONST(0x1)) == ((0 && (super_user & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((read_write & ~ULL_CONST(0x1)) == ((0 && (read_write & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((present & ~ULL_CONST(0x1)) == ((0 && (present & (ULL_CONST(1) << 50))) ? 0x0 : 0));
 
     pdpte.words[0] = 0
-        | (xd & 0x1ull) << 63
-        | (page_base_address & 0x7ffffc0000000ull) >> 0
-        | (pat & 0x1ull) << 12
-        | (global & 0x1ull) << 8
-        | ((uint64_t)pdpte_pdpte_1g & 0x1ull) << 7
-        | (dirty & 0x1ull) << 6
-        | (accessed & 0x1ull) << 5
-        | (cache_disabled & 0x1ull) << 4
-        | (write_through & 0x1ull) << 3
-        | (super_user & 0x1ull) << 2
-        | (read_write & 0x1ull) << 1
-        | (present & 0x1ull) << 0;
+        | (xd & ULL_CONST(0x1)) << 63
+        | (page_base_address & ULL_CONST(0x7ffffc0000000)) >> 0
+        | (pat & ULL_CONST(0x1)) << 12
+        | (global & ULL_CONST(0x1)) << 8
+        | ((uint64_t)pdpte_pdpte_1g & ULL_CONST(0x1)) << 7
+        | (dirty & ULL_CONST(0x1)) << 6
+        | (accessed & ULL_CONST(0x1)) << 5
+        | (cache_disabled & ULL_CONST(0x1)) << 4
+        | (write_through & ULL_CONST(0x1)) << 3
+        | (super_user & ULL_CONST(0x1)) << 2
+        | (read_write & ULL_CONST(0x1)) << 1
+        | (present & ULL_CONST(0x1)) << 0;
 
     return pdpte;
 }
@@ -3252,9 +3252,9 @@ pdpte_pdpte_1g_ptr_get_page_base_address(pdpte_t *pdpte_ptr) {
     /* fail if union does not have the expected tag */
     assert(((pdpte_ptr->words[0] >> 7) & 0x1) == pdpte_pdpte_1g);
 
-    ret = (pdpte_ptr->words[0] & 0x7ffffc0000000ull) << 0;
+    ret = (pdpte_ptr->words[0] & ULL_CONST(0x7ffffc0000000)) << 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (50)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (50)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -3266,9 +3266,9 @@ pdpte_pdpte_1g_ptr_get_present(pdpte_t *pdpte_ptr) {
     /* fail if union does not have the expected tag */
     assert(((pdpte_ptr->words[0] >> 7) & 0x1) == pdpte_pdpte_1g);
 
-    ret = (pdpte_ptr->words[0] & 0x1ull) >> 0;
+    ret = (pdpte_ptr->words[0] & ULL_CONST(0x1)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (50)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (50)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -3279,26 +3279,26 @@ pdpte_pdpte_pd_new(uint64_t xd, uint64_t pd_base_address, uint64_t accessed, uin
     pdpte_t pdpte;
 
     /* fail if user has passed bits that we will override */  
-    assert((xd & ~0x1ull) == ((0 && (xd & (1ull << 50))) ? 0x0 : 0));  
-    assert((pd_base_address & ~0x7fffffffff000ull) == ((0 && (pd_base_address & (1ull << 50))) ? 0x0 : 0));  
-    assert(((uint64_t)pdpte_pdpte_pd & ~0x1ull) == ((0 && ((uint64_t)pdpte_pdpte_pd & (1ull << 50))) ? 0x0 : 0));  
-    assert((accessed & ~0x1ull) == ((0 && (accessed & (1ull << 50))) ? 0x0 : 0));  
-    assert((cache_disabled & ~0x1ull) == ((0 && (cache_disabled & (1ull << 50))) ? 0x0 : 0));  
-    assert((write_through & ~0x1ull) == ((0 && (write_through & (1ull << 50))) ? 0x0 : 0));  
-    assert((super_user & ~0x1ull) == ((0 && (super_user & (1ull << 50))) ? 0x0 : 0));  
-    assert((read_write & ~0x1ull) == ((0 && (read_write & (1ull << 50))) ? 0x0 : 0));  
-    assert((present & ~0x1ull) == ((0 && (present & (1ull << 50))) ? 0x0 : 0));
+    assert((xd & ~ULL_CONST(0x1)) == ((0 && (xd & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((pd_base_address & ~ULL_CONST(0x7fffffffff000)) == ((0 && (pd_base_address & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert(((uint64_t)pdpte_pdpte_pd & ~ULL_CONST(0x1)) == ((0 && ((uint64_t)pdpte_pdpte_pd & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((accessed & ~ULL_CONST(0x1)) == ((0 && (accessed & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((cache_disabled & ~ULL_CONST(0x1)) == ((0 && (cache_disabled & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((write_through & ~ULL_CONST(0x1)) == ((0 && (write_through & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((super_user & ~ULL_CONST(0x1)) == ((0 && (super_user & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((read_write & ~ULL_CONST(0x1)) == ((0 && (read_write & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((present & ~ULL_CONST(0x1)) == ((0 && (present & (ULL_CONST(1) << 50))) ? 0x0 : 0));
 
     pdpte.words[0] = 0
-        | (xd & 0x1ull) << 63
-        | (pd_base_address & 0x7fffffffff000ull) >> 0
-        | ((uint64_t)pdpte_pdpte_pd & 0x1ull) << 7
-        | (accessed & 0x1ull) << 5
-        | (cache_disabled & 0x1ull) << 4
-        | (write_through & 0x1ull) << 3
-        | (super_user & 0x1ull) << 2
-        | (read_write & 0x1ull) << 1
-        | (present & 0x1ull) << 0;
+        | (xd & ULL_CONST(0x1)) << 63
+        | (pd_base_address & ULL_CONST(0x7fffffffff000)) >> 0
+        | ((uint64_t)pdpte_pdpte_pd & ULL_CONST(0x1)) << 7
+        | (accessed & ULL_CONST(0x1)) << 5
+        | (cache_disabled & ULL_CONST(0x1)) << 4
+        | (write_through & ULL_CONST(0x1)) << 3
+        | (super_user & ULL_CONST(0x1)) << 2
+        | (read_write & ULL_CONST(0x1)) << 1
+        | (present & ULL_CONST(0x1)) << 0;
 
     return pdpte;
 }
@@ -3309,9 +3309,9 @@ pdpte_pdpte_pd_ptr_get_pd_base_address(pdpte_t *pdpte_ptr) {
     /* fail if union does not have the expected tag */
     assert(((pdpte_ptr->words[0] >> 7) & 0x1) == pdpte_pdpte_pd);
 
-    ret = (pdpte_ptr->words[0] & 0x7fffffffff000ull) << 0;
+    ret = (pdpte_ptr->words[0] & ULL_CONST(0x7fffffffff000)) << 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (50)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (50)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -3323,9 +3323,9 @@ pdpte_pdpte_pd_ptr_get_present(pdpte_t *pdpte_ptr) {
     /* fail if union does not have the expected tag */
     assert(((pdpte_ptr->words[0] >> 7) & 0x1) == pdpte_pdpte_pd);
 
-    ret = (pdpte_ptr->words[0] & 0x1ull) >> 0;
+    ret = (pdpte_ptr->words[0] & ULL_CONST(0x1)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (50)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (50)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -3347,7 +3347,7 @@ typedef enum seL4_Fault_tag seL4_Fault_tag_t;
 
 static inline uint64_t CONST
 seL4_Fault_get_seL4_FaultType(seL4_Fault_t seL4_Fault) {
-    return (seL4_Fault.words[0] >> 0) & 0xfull;
+    return (seL4_Fault.words[0] >> 0) & ULL_CONST(0xf);
 }
 
 static inline seL4_Fault_t CONST
@@ -3355,10 +3355,10 @@ seL4_Fault_NullFault_new(void) {
     seL4_Fault_t seL4_Fault;
 
     /* fail if user has passed bits that we will override */  
-    assert(((uint64_t)seL4_Fault_NullFault & ~0xfull) == ((0 && ((uint64_t)seL4_Fault_NullFault & (1ull << 50))) ? 0x0 : 0));
+    assert(((uint64_t)seL4_Fault_NullFault & ~ULL_CONST(0xf)) == ((0 && ((uint64_t)seL4_Fault_NullFault & (ULL_CONST(1) << 50))) ? 0x0 : 0));
 
     seL4_Fault.words[0] = 0
-        | ((uint64_t)seL4_Fault_NullFault & 0xfull) << 0;
+        | ((uint64_t)seL4_Fault_NullFault & ULL_CONST(0xf)) << 0;
     seL4_Fault.words[1] = 0;
 
     return seL4_Fault;
@@ -3369,12 +3369,12 @@ seL4_Fault_CapFault_new(uint64_t address, uint64_t inReceivePhase) {
     seL4_Fault_t seL4_Fault;
 
     /* fail if user has passed bits that we will override */  
-    assert((inReceivePhase & ~0x1ull) == ((0 && (inReceivePhase & (1ull << 50))) ? 0x0 : 0));  
-    assert(((uint64_t)seL4_Fault_CapFault & ~0xfull) == ((0 && ((uint64_t)seL4_Fault_CapFault & (1ull << 50))) ? 0x0 : 0));
+    assert((inReceivePhase & ~ULL_CONST(0x1)) == ((0 && (inReceivePhase & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert(((uint64_t)seL4_Fault_CapFault & ~ULL_CONST(0xf)) == ((0 && ((uint64_t)seL4_Fault_CapFault & (ULL_CONST(1) << 50))) ? 0x0 : 0));
 
     seL4_Fault.words[0] = 0
-        | (inReceivePhase & 0x1ull) << 63
-        | ((uint64_t)seL4_Fault_CapFault & 0xfull) << 0;
+        | (inReceivePhase & ULL_CONST(0x1)) << 63
+        | ((uint64_t)seL4_Fault_CapFault & ULL_CONST(0xf)) << 0;
     seL4_Fault.words[1] = 0
         | address << 0;
 
@@ -3387,9 +3387,9 @@ seL4_Fault_CapFault_get_address(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     assert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
 
-    ret = (seL4_Fault.words[1] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[1] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (50)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (50)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -3401,9 +3401,9 @@ seL4_Fault_CapFault_get_inReceivePhase(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     assert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
 
-    ret = (seL4_Fault.words[0] & 0x8000000000000000ull) >> 63;
+    ret = (seL4_Fault.words[0] & ULL_CONST(0x8000000000000000)) >> 63;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (50)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (50)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -3414,10 +3414,10 @@ seL4_Fault_UnknownSyscall_new(uint64_t syscallNumber) {
     seL4_Fault_t seL4_Fault;
 
     /* fail if user has passed bits that we will override */  
-    assert(((uint64_t)seL4_Fault_UnknownSyscall & ~0xfull) == ((0 && ((uint64_t)seL4_Fault_UnknownSyscall & (1ull << 50))) ? 0x0 : 0));
+    assert(((uint64_t)seL4_Fault_UnknownSyscall & ~ULL_CONST(0xf)) == ((0 && ((uint64_t)seL4_Fault_UnknownSyscall & (ULL_CONST(1) << 50))) ? 0x0 : 0));
 
     seL4_Fault.words[0] = 0
-        | ((uint64_t)seL4_Fault_UnknownSyscall & 0xfull) << 0;
+        | ((uint64_t)seL4_Fault_UnknownSyscall & ULL_CONST(0xf)) << 0;
     seL4_Fault.words[1] = 0
         | syscallNumber << 0;
 
@@ -3430,9 +3430,9 @@ seL4_Fault_UnknownSyscall_get_syscallNumber(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     assert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault.words[1] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[1] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (50)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (50)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -3443,14 +3443,14 @@ seL4_Fault_UserException_new(uint64_t number, uint64_t code) {
     seL4_Fault_t seL4_Fault;
 
     /* fail if user has passed bits that we will override */  
-    assert((number & ~0xffffffffull) == ((0 && (number & (1ull << 50))) ? 0x0 : 0));  
-    assert((code & ~0xfffffffull) == ((0 && (code & (1ull << 50))) ? 0x0 : 0));  
-    assert(((uint64_t)seL4_Fault_UserException & ~0xfull) == ((0 && ((uint64_t)seL4_Fault_UserException & (1ull << 50))) ? 0x0 : 0));
+    assert((number & ~ULL_CONST(0xffffffff)) == ((0 && (number & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((code & ~ULL_CONST(0xfffffff)) == ((0 && (code & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert(((uint64_t)seL4_Fault_UserException & ~ULL_CONST(0xf)) == ((0 && ((uint64_t)seL4_Fault_UserException & (ULL_CONST(1) << 50))) ? 0x0 : 0));
 
     seL4_Fault.words[0] = 0
-        | (number & 0xffffffffull) << 32
-        | (code & 0xfffffffull) << 4
-        | ((uint64_t)seL4_Fault_UserException & 0xfull) << 0;
+        | (number & ULL_CONST(0xffffffff)) << 32
+        | (code & ULL_CONST(0xfffffff)) << 4
+        | ((uint64_t)seL4_Fault_UserException & ULL_CONST(0xf)) << 0;
     seL4_Fault.words[1] = 0;
 
     return seL4_Fault;
@@ -3462,9 +3462,9 @@ seL4_Fault_UserException_get_number(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     assert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UserException);
 
-    ret = (seL4_Fault.words[0] & 0xffffffff00000000ull) >> 32;
+    ret = (seL4_Fault.words[0] & ULL_CONST(0xffffffff00000000)) >> 32;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (50)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (50)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -3476,9 +3476,9 @@ seL4_Fault_UserException_get_code(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     assert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UserException);
 
-    ret = (seL4_Fault.words[0] & 0xfffffff0ull) >> 4;
+    ret = (seL4_Fault.words[0] & ULL_CONST(0xfffffff0)) >> 4;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (50)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (50)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -3489,14 +3489,14 @@ seL4_Fault_VMFault_new(uint64_t address, uint64_t FSR, uint64_t instructionFault
     seL4_Fault_t seL4_Fault;
 
     /* fail if user has passed bits that we will override */  
-    assert((FSR & ~0x1full) == ((0 && (FSR & (1ull << 50))) ? 0x0 : 0));  
-    assert((instructionFault & ~0x1ull) == ((0 && (instructionFault & (1ull << 50))) ? 0x0 : 0));  
-    assert(((uint64_t)seL4_Fault_VMFault & ~0xfull) == ((0 && ((uint64_t)seL4_Fault_VMFault & (1ull << 50))) ? 0x0 : 0));
+    assert((FSR & ~ULL_CONST(0x1f)) == ((0 && (FSR & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert((instructionFault & ~ULL_CONST(0x1)) == ((0 && (instructionFault & (ULL_CONST(1) << 50))) ? 0x0 : 0));  
+    assert(((uint64_t)seL4_Fault_VMFault & ~ULL_CONST(0xf)) == ((0 && ((uint64_t)seL4_Fault_VMFault & (ULL_CONST(1) << 50))) ? 0x0 : 0));
 
     seL4_Fault.words[0] = 0
-        | (FSR & 0x1full) << 27
-        | (instructionFault & 0x1ull) << 19
-        | ((uint64_t)seL4_Fault_VMFault & 0xfull) << 0;
+        | (FSR & ULL_CONST(0x1f)) << 27
+        | (instructionFault & ULL_CONST(0x1)) << 19
+        | ((uint64_t)seL4_Fault_VMFault & ULL_CONST(0xf)) << 0;
     seL4_Fault.words[1] = 0
         | address << 0;
 
@@ -3509,9 +3509,9 @@ seL4_Fault_VMFault_get_address(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     assert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_VMFault);
 
-    ret = (seL4_Fault.words[1] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[1] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (50)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (50)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -3523,9 +3523,9 @@ seL4_Fault_VMFault_get_FSR(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     assert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_VMFault);
 
-    ret = (seL4_Fault.words[0] & 0xf8000000ull) >> 27;
+    ret = (seL4_Fault.words[0] & ULL_CONST(0xf8000000)) >> 27;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (50)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (50)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -3537,9 +3537,9 @@ seL4_Fault_VMFault_get_instructionFault(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     assert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_VMFault);
 
-    ret = (seL4_Fault.words[0] & 0x80000ull) >> 19;
+    ret = (seL4_Fault.words[0] & ULL_CONST(0x80000)) >> 19;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (50)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (50)))), 0)) {
         ret |= 0x0;
     }
     return ret;

--- a/preconfigured/X64_verified/generated/sel4/shared_types_gen.h
+++ b/preconfigured/X64_verified/generated/sel4/shared_types_gen.h
@@ -14,9 +14,9 @@ typedef struct seL4_CNode_CapData seL4_CNode_CapData_t;
 static inline uint64_t CONST
 seL4_CNode_CapData_get_guard(seL4_CNode_CapData_t seL4_CNode_CapData) {
     uint64_t ret;
-    ret = (seL4_CNode_CapData.words[0] & 0xffffffffffffffc0ull) >> 6;
+    ret = (seL4_CNode_CapData.words[0] & ULL_CONST(0xffffffffffffffc0)) >> 6;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -25,9 +25,9 @@ seL4_CNode_CapData_get_guard(seL4_CNode_CapData_t seL4_CNode_CapData) {
 static inline uint64_t CONST
 seL4_CNode_CapData_get_guardSize(seL4_CNode_CapData_t seL4_CNode_CapData) {
     uint64_t ret;
-    ret = (seL4_CNode_CapData.words[0] & 0x3full) >> 0;
+    ret = (seL4_CNode_CapData.words[0] & ULL_CONST(0x3f)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -41,9 +41,9 @@ typedef struct seL4_CapRights seL4_CapRights_t;
 static inline uint64_t CONST
 seL4_CapRights_get_capAllowGrantReply(seL4_CapRights_t seL4_CapRights) {
     uint64_t ret;
-    ret = (seL4_CapRights.words[0] & 0x8ull) >> 3;
+    ret = (seL4_CapRights.words[0] & ULL_CONST(0x8)) >> 3;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -52,9 +52,9 @@ seL4_CapRights_get_capAllowGrantReply(seL4_CapRights_t seL4_CapRights) {
 static inline uint64_t CONST
 seL4_CapRights_get_capAllowGrant(seL4_CapRights_t seL4_CapRights) {
     uint64_t ret;
-    ret = (seL4_CapRights.words[0] & 0x4ull) >> 2;
+    ret = (seL4_CapRights.words[0] & ULL_CONST(0x4)) >> 2;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -63,9 +63,9 @@ seL4_CapRights_get_capAllowGrant(seL4_CapRights_t seL4_CapRights) {
 static inline uint64_t CONST
 seL4_CapRights_get_capAllowRead(seL4_CapRights_t seL4_CapRights) {
     uint64_t ret;
-    ret = (seL4_CapRights.words[0] & 0x2ull) >> 1;
+    ret = (seL4_CapRights.words[0] & ULL_CONST(0x2)) >> 1;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -74,9 +74,9 @@ seL4_CapRights_get_capAllowRead(seL4_CapRights_t seL4_CapRights) {
 static inline uint64_t CONST
 seL4_CapRights_get_capAllowWrite(seL4_CapRights_t seL4_CapRights) {
     uint64_t ret;
-    ret = (seL4_CapRights.words[0] & 0x1ull) >> 0;
+    ret = (seL4_CapRights.words[0] & ULL_CONST(0x1)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -92,16 +92,16 @@ seL4_MessageInfo_new(uint64_t label, uint64_t capsUnwrapped, uint64_t extraCaps,
     seL4_MessageInfo_t seL4_MessageInfo;
 
     /* fail if user has passed bits that we will override */  
-    assert((label & ~0xfffffffffffffull) == ((0 && (label & (1ull << 63))) ? 0x0 : 0));  
-    assert((capsUnwrapped & ~0x7ull) == ((0 && (capsUnwrapped & (1ull << 63))) ? 0x0 : 0));  
-    assert((extraCaps & ~0x3ull) == ((0 && (extraCaps & (1ull << 63))) ? 0x0 : 0));  
-    assert((length & ~0x7full) == ((0 && (length & (1ull << 63))) ? 0x0 : 0));
+    assert((label & ~ULL_CONST(0xfffffffffffff)) == ((0 && (label & (ULL_CONST(1) << 63))) ? 0x0 : 0));  
+    assert((capsUnwrapped & ~ULL_CONST(0x7)) == ((0 && (capsUnwrapped & (ULL_CONST(1) << 63))) ? 0x0 : 0));  
+    assert((extraCaps & ~ULL_CONST(0x3)) == ((0 && (extraCaps & (ULL_CONST(1) << 63))) ? 0x0 : 0));  
+    assert((length & ~ULL_CONST(0x7f)) == ((0 && (length & (ULL_CONST(1) << 63))) ? 0x0 : 0));
 
     seL4_MessageInfo.words[0] = 0
-        | (label & 0xfffffffffffffull) << 12
-        | (capsUnwrapped & 0x7ull) << 9
-        | (extraCaps & 0x3ull) << 7
-        | (length & 0x7full) << 0;
+        | (label & ULL_CONST(0xfffffffffffff)) << 12
+        | (capsUnwrapped & ULL_CONST(0x7)) << 9
+        | (extraCaps & ULL_CONST(0x3)) << 7
+        | (length & ULL_CONST(0x7f)) << 0;
 
     return seL4_MessageInfo;
 }
@@ -109,9 +109,9 @@ seL4_MessageInfo_new(uint64_t label, uint64_t capsUnwrapped, uint64_t extraCaps,
 static inline uint64_t CONST
 seL4_MessageInfo_get_label(seL4_MessageInfo_t seL4_MessageInfo) {
     uint64_t ret;
-    ret = (seL4_MessageInfo.words[0] & 0xfffffffffffff000ull) >> 12;
+    ret = (seL4_MessageInfo.words[0] & ULL_CONST(0xfffffffffffff000)) >> 12;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -120,9 +120,9 @@ seL4_MessageInfo_get_label(seL4_MessageInfo_t seL4_MessageInfo) {
 static inline uint64_t CONST
 seL4_MessageInfo_get_capsUnwrapped(seL4_MessageInfo_t seL4_MessageInfo) {
     uint64_t ret;
-    ret = (seL4_MessageInfo.words[0] & 0xe00ull) >> 9;
+    ret = (seL4_MessageInfo.words[0] & ULL_CONST(0xe00)) >> 9;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -131,18 +131,18 @@ seL4_MessageInfo_get_capsUnwrapped(seL4_MessageInfo_t seL4_MessageInfo) {
 static inline seL4_MessageInfo_t CONST
 seL4_MessageInfo_set_capsUnwrapped(seL4_MessageInfo_t seL4_MessageInfo, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0xe00ull >> 9 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
-    seL4_MessageInfo.words[0] &= ~0xe00ull;
-    seL4_MessageInfo.words[0] |= (v64 << 9) & 0xe00ull;
+    assert((((~ULL_CONST(0xe00) >> 9 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
+    seL4_MessageInfo.words[0] &= ~ULL_CONST(0xe00);
+    seL4_MessageInfo.words[0] |= (v64 << 9) & ULL_CONST(0xe00);
     return seL4_MessageInfo;
 }
 
 static inline uint64_t CONST
 seL4_MessageInfo_get_extraCaps(seL4_MessageInfo_t seL4_MessageInfo) {
     uint64_t ret;
-    ret = (seL4_MessageInfo.words[0] & 0x180ull) >> 7;
+    ret = (seL4_MessageInfo.words[0] & ULL_CONST(0x180)) >> 7;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -151,18 +151,18 @@ seL4_MessageInfo_get_extraCaps(seL4_MessageInfo_t seL4_MessageInfo) {
 static inline seL4_MessageInfo_t CONST
 seL4_MessageInfo_set_extraCaps(seL4_MessageInfo_t seL4_MessageInfo, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0x180ull >> 7 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
-    seL4_MessageInfo.words[0] &= ~0x180ull;
-    seL4_MessageInfo.words[0] |= (v64 << 7) & 0x180ull;
+    assert((((~ULL_CONST(0x180) >> 7 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
+    seL4_MessageInfo.words[0] &= ~ULL_CONST(0x180);
+    seL4_MessageInfo.words[0] |= (v64 << 7) & ULL_CONST(0x180);
     return seL4_MessageInfo;
 }
 
 static inline uint64_t CONST
 seL4_MessageInfo_get_length(seL4_MessageInfo_t seL4_MessageInfo) {
     uint64_t ret;
-    ret = (seL4_MessageInfo.words[0] & 0x7full) >> 0;
+    ret = (seL4_MessageInfo.words[0] & ULL_CONST(0x7f)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -171,9 +171,9 @@ seL4_MessageInfo_get_length(seL4_MessageInfo_t seL4_MessageInfo) {
 static inline seL4_MessageInfo_t CONST
 seL4_MessageInfo_set_length(seL4_MessageInfo_t seL4_MessageInfo, uint64_t v64) {
     /* fail if user has passed bits that we will override */
-    assert((((~0x7full >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
-    seL4_MessageInfo.words[0] &= ~0x7full;
-    seL4_MessageInfo.words[0] |= (v64 << 0) & 0x7full;
+    assert((((~ULL_CONST(0x7f) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
+    seL4_MessageInfo.words[0] &= ~ULL_CONST(0x7f);
+    seL4_MessageInfo.words[0] |= (v64 << 0) & ULL_CONST(0x7f);
     return seL4_MessageInfo;
 }
 

--- a/preconfigured/X64_verified/libsel4/include/interfaces/sel4_client.h
+++ b/preconfigured/X64_verified/libsel4/include/interfaces/sel4_client.h
@@ -1169,7 +1169,7 @@ seL4_X86_ASIDControl_MakePool(seL4_X86_ASIDControl _service, seL4_Untyped untype
 
 	/* Marshal and initialise parameters. */
 	mr0 = index;
-	mr1 = (depth & 0xffull);
+	mr1 = (depth & ULL_CONST(0xff));
 	mr2 = 0;
 	mr3 = 0;
 
@@ -1293,7 +1293,7 @@ seL4_X86_IOPortControl_Issue(seL4_X86_IOPortControl _service, seL4_Word first_po
 	mr0 = first_port;
 	mr1 = last_port;
 	mr2 = index;
-	mr3 = (depth & 0xffull);
+	mr3 = (depth & ULL_CONST(0xff));
 
 	/* Perform the call, passing in-register arguments directly. */
 	output_tag = seL4_CallWithMRs(_service, tag,
@@ -1345,7 +1345,7 @@ seL4_X86_IOPort_In8(seL4_X86_IOPort _service, seL4_Uint16 port)
 	seL4_Word mr3;
 
 	/* Marshal and initialise parameters. */
-	mr0 = (port & 0xffffull);
+	mr0 = (port & ULL_CONST(0xffff));
 	mr1 = 0;
 	mr2 = 0;
 	mr3 = 0;
@@ -1403,7 +1403,7 @@ seL4_X86_IOPort_In16(seL4_X86_IOPort _service, seL4_Uint16 port)
 	seL4_Word mr3;
 
 	/* Marshal and initialise parameters. */
-	mr0 = (port & 0xffffull);
+	mr0 = (port & ULL_CONST(0xffff));
 	mr1 = 0;
 	mr2 = 0;
 	mr3 = 0;
@@ -1461,7 +1461,7 @@ seL4_X86_IOPort_In32(seL4_X86_IOPort _service, seL4_Uint16 port)
 	seL4_Word mr3;
 
 	/* Marshal and initialise parameters. */
-	mr0 = (port & 0xffffull);
+	mr0 = (port & ULL_CONST(0xffff));
 	mr1 = 0;
 	mr2 = 0;
 	mr3 = 0;
@@ -1697,7 +1697,7 @@ seL4_IRQControl_GetIOAPIC(seL4_IRQControl _service, seL4_CNode root, seL4_Word i
 
 	/* Marshal and initialise parameters. */
 	mr0 = index;
-	mr1 = (depth & 0xffull);
+	mr1 = (depth & ULL_CONST(0xff));
 	mr2 = ioapic;
 	mr3 = pin;
 	seL4_SetMR(4, level);
@@ -1769,7 +1769,7 @@ seL4_IRQControl_GetMSI(seL4_IRQControl _service, seL4_CNode root, seL4_Word inde
 
 	/* Marshal and initialise parameters. */
 	mr0 = index;
-	mr1 = (depth & 0xffull);
+	mr1 = (depth & ULL_CONST(0xff));
 	mr2 = pci_bus;
 	mr3 = pci_dev;
 	seL4_SetMR(4, pci_func);
@@ -2702,7 +2702,7 @@ seL4_TCB_ReadRegisters(seL4_TCB _service, seL4_Bool suspend_source, seL4_Uint8 a
 	seL4_Word mr3;
 
 	/* Marshal and initialise parameters. */
-	mr0 = (suspend_source & 0x1ull) | ((arch_flags & 0xffull) << 8);
+	mr0 = (suspend_source & ULL_CONST(0x1)) | ((arch_flags & ULL_CONST(0xff)) << 8);
 	mr1 = count;
 	mr2 = 0;
 	mr3 = 0;
@@ -2779,7 +2779,7 @@ seL4_TCB_WriteRegisters(seL4_TCB _service, seL4_Bool resume_target, seL4_Uint8 a
 	seL4_Word mr3;
 
 	/* Marshal and initialise parameters. */
-	mr0 = (resume_target & 0x1ull) | ((arch_flags & 0xffull) << 8);
+	mr0 = (resume_target & ULL_CONST(0x1)) | ((arch_flags & ULL_CONST(0xff)) << 8);
 	mr1 = count;
 	mr2 = regs->rip;
 	mr3 = regs->rsp;
@@ -2859,7 +2859,7 @@ seL4_TCB_CopyRegisters(seL4_TCB _service, seL4_TCB source, seL4_Bool suspend_sou
 	seL4_SetCap(0, source);
 
 	/* Marshal and initialise parameters. */
-	mr0 = (suspend_source & 0x1ull) | ((resume_target & 0x1ull) << 1) | ((transfer_frame & 0x1ull) << 2) | ((transfer_integer & 0x1ull) << 3) | ((arch_flags & 0xffull) << 8);
+	mr0 = (suspend_source & ULL_CONST(0x1)) | ((resume_target & ULL_CONST(0x1)) << 1) | ((transfer_frame & ULL_CONST(0x1)) << 2) | ((transfer_integer & ULL_CONST(0x1)) << 3) | ((arch_flags & ULL_CONST(0xff)) << 8);
 	mr1 = 0;
 	mr2 = 0;
 	mr3 = 0;
@@ -3823,7 +3823,7 @@ seL4_TCB_SetBreakpoint(seL4_TCB _service, seL4_Uint16 bp_num, seL4_Word vaddr, s
 	seL4_Word mr3;
 
 	/* Marshal and initialise parameters. */
-	mr0 = (bp_num & 0xffffull);
+	mr0 = (bp_num & ULL_CONST(0xffff));
 	mr1 = vaddr;
 	mr2 = type;
 	mr3 = size;
@@ -3892,7 +3892,7 @@ seL4_TCB_GetBreakpoint(seL4_TCB _service, seL4_Uint16 bp_num)
 	seL4_Word mr3;
 
 	/* Marshal and initialise parameters. */
-	mr0 = (bp_num & 0xffffull);
+	mr0 = (bp_num & ULL_CONST(0xffff));
 	mr1 = 0;
 	mr2 = 0;
 	mr3 = 0;
@@ -3959,7 +3959,7 @@ seL4_TCB_UnsetBreakpoint(seL4_TCB _service, seL4_Uint16 bp_num)
 	seL4_Word mr3;
 
 	/* Marshal and initialise parameters. */
-	mr0 = (bp_num & 0xffffull);
+	mr0 = (bp_num & ULL_CONST(0xffff));
 	mr1 = 0;
 	mr2 = 0;
 	mr3 = 0;
@@ -4026,7 +4026,7 @@ seL4_TCB_ConfigureSingleStepping(seL4_TCB _service, seL4_Uint16 bp_num, seL4_Wor
 	seL4_Word mr3;
 
 	/* Marshal and initialise parameters. */
-	mr0 = (bp_num & 0xffffull);
+	mr0 = (bp_num & ULL_CONST(0xffff));
 	mr1 = num_instructions;
 	mr2 = 0;
 	mr3 = 0;
@@ -4198,7 +4198,7 @@ seL4_CNode_Revoke(seL4_CNode _service, seL4_Word index, seL4_Uint8 depth)
 
 	/* Marshal and initialise parameters. */
 	mr0 = index;
-	mr1 = (depth & 0xffull);
+	mr1 = (depth & ULL_CONST(0xff));
 	mr2 = 0;
 	mr3 = 0;
 
@@ -4253,7 +4253,7 @@ seL4_CNode_Delete(seL4_CNode _service, seL4_Word index, seL4_Uint8 depth)
 
 	/* Marshal and initialise parameters. */
 	mr0 = index;
-	mr1 = (depth & 0xffull);
+	mr1 = (depth & ULL_CONST(0xff));
 	mr2 = 0;
 	mr3 = 0;
 
@@ -4312,7 +4312,7 @@ seL4_CNode_CancelBadgedSends(seL4_CNode _service, seL4_Word index, seL4_Uint8 de
 
 	/* Marshal and initialise parameters. */
 	mr0 = index;
-	mr1 = (depth & 0xffull);
+	mr1 = (depth & ULL_CONST(0xff));
 	mr2 = 0;
 	mr3 = 0;
 
@@ -4379,9 +4379,9 @@ seL4_CNode_Copy(seL4_CNode _service, seL4_Word dest_index, seL4_Uint8 dest_depth
 
 	/* Marshal and initialise parameters. */
 	mr0 = dest_index;
-	mr1 = (dest_depth & 0xffull);
+	mr1 = (dest_depth & ULL_CONST(0xff));
 	mr2 = src_index;
-	mr3 = (src_depth & 0xffull);
+	mr3 = (src_depth & ULL_CONST(0xff));
 	seL4_SetMR(4, rights.words[0]);
 
 	/* Perform the call, passing in-register arguments directly. */
@@ -4449,9 +4449,9 @@ seL4_CNode_Mint(seL4_CNode _service, seL4_Word dest_index, seL4_Uint8 dest_depth
 
 	/* Marshal and initialise parameters. */
 	mr0 = dest_index;
-	mr1 = (dest_depth & 0xffull);
+	mr1 = (dest_depth & ULL_CONST(0xff));
 	mr2 = src_index;
-	mr3 = (src_depth & 0xffull);
+	mr3 = (src_depth & ULL_CONST(0xff));
 	seL4_SetMR(4, rights.words[0]);
 	seL4_SetMR(5, badge);
 
@@ -4515,9 +4515,9 @@ seL4_CNode_Move(seL4_CNode _service, seL4_Word dest_index, seL4_Uint8 dest_depth
 
 	/* Marshal and initialise parameters. */
 	mr0 = dest_index;
-	mr1 = (dest_depth & 0xffull);
+	mr1 = (dest_depth & ULL_CONST(0xff));
 	mr2 = src_index;
-	mr3 = (src_depth & 0xffull);
+	mr3 = (src_depth & ULL_CONST(0xff));
 
 	/* Perform the call, passing in-register arguments directly. */
 	output_tag = seL4_CallWithMRs(_service, tag,
@@ -4585,9 +4585,9 @@ seL4_CNode_Mutate(seL4_CNode _service, seL4_Word dest_index, seL4_Uint8 dest_dep
 
 	/* Marshal and initialise parameters. */
 	mr0 = dest_index;
-	mr1 = (dest_depth & 0xffull);
+	mr1 = (dest_depth & ULL_CONST(0xff));
 	mr2 = src_index;
-	mr3 = (src_depth & 0xffull);
+	mr3 = (src_depth & ULL_CONST(0xff));
 	seL4_SetMR(4, badge);
 
 	/* Perform the call, passing in-register arguments directly. */
@@ -4659,13 +4659,13 @@ seL4_CNode_Rotate(seL4_CNode _service, seL4_Word dest_index, seL4_Uint8 dest_dep
 
 	/* Marshal and initialise parameters. */
 	mr0 = dest_index;
-	mr1 = (dest_depth & 0xffull);
+	mr1 = (dest_depth & ULL_CONST(0xff));
 	mr2 = dest_badge;
 	mr3 = pivot_index;
-	seL4_SetMR(4, (pivot_depth & 0xffull));
+	seL4_SetMR(4, (pivot_depth & ULL_CONST(0xff)));
 	seL4_SetMR(5, pivot_badge);
 	seL4_SetMR(6, src_index);
-	seL4_SetMR(7, (src_depth & 0xffull));
+	seL4_SetMR(7, (src_depth & ULL_CONST(0xff)));
 
 	/* Perform the call, passing in-register arguments directly. */
 	output_tag = seL4_CallWithMRs(_service, tag,
@@ -4720,7 +4720,7 @@ seL4_CNode_SaveCaller(seL4_CNode _service, seL4_Word index, seL4_Uint8 depth)
 
 	/* Marshal and initialise parameters. */
 	mr0 = index;
-	mr1 = (depth & 0xffull);
+	mr1 = (depth & ULL_CONST(0xff));
 	mr2 = 0;
 	mr3 = 0;
 
@@ -4787,7 +4787,7 @@ seL4_IRQControl_Get(seL4_IRQControl _service, seL4_Word irq, seL4_CNode root, se
 	/* Marshal and initialise parameters. */
 	mr0 = irq;
 	mr1 = index;
-	mr2 = (depth & 0xffull);
+	mr2 = (depth & ULL_CONST(0xff));
 	mr3 = 0;
 
 	/* Perform the call, passing in-register arguments directly. */
@@ -5002,7 +5002,7 @@ seL4_DomainSet_Set(seL4_DomainSet _service, seL4_Uint8 domain, seL4_TCB thread)
 	seL4_SetCap(0, thread);
 
 	/* Marshal and initialise parameters. */
-	mr0 = (domain & 0xffull);
+	mr0 = (domain & ULL_CONST(0xff));
 	mr1 = 0;
 	mr2 = 0;
 	mr3 = 0;

--- a/preconfigured/X64_verified/libsel4/include/sel4/shared_types_gen.h
+++ b/preconfigured/X64_verified/libsel4/include/sel4/shared_types_gen.h
@@ -15,12 +15,12 @@ seL4_CNode_CapData_new(seL4_Uint64 guard, seL4_Uint64 guardSize) {
     seL4_CNode_CapData_t seL4_CNode_CapData;
 
     /* fail if user has passed bits that we will override */  
-    seL4_DebugAssert((guard & ~0x3ffffffffffffffull) == ((0 && (guard & (1ull << 63))) ? 0x0 : 0));  
-    seL4_DebugAssert((guardSize & ~0x3full) == ((0 && (guardSize & (1ull << 63))) ? 0x0 : 0));
+    seL4_DebugAssert((guard & ~ULL_CONST(0x3ffffffffffffff)) == ((0 && (guard & (ULL_CONST(1) << 63))) ? 0x0 : 0));  
+    seL4_DebugAssert((guardSize & ~ULL_CONST(0x3f)) == ((0 && (guardSize & (ULL_CONST(1) << 63))) ? 0x0 : 0));
 
     seL4_CNode_CapData.words[0] = 0
-        | (guard & 0x3ffffffffffffffull) << 6
-        | (guardSize & 0x3full) << 0;
+        | (guard & ULL_CONST(0x3ffffffffffffff)) << 6
+        | (guardSize & ULL_CONST(0x3f)) << 0;
 
     return seL4_CNode_CapData;
 }
@@ -28,20 +28,20 @@ seL4_CNode_CapData_new(seL4_Uint64 guard, seL4_Uint64 guardSize) {
 LIBSEL4_INLINE_FUNC void
 seL4_CNode_CapData_ptr_new(seL4_CNode_CapData_t *seL4_CNode_CapData_ptr, seL4_Uint64 guard, seL4_Uint64 guardSize) {
     /* fail if user has passed bits that we will override */  
-    seL4_DebugAssert((guard & ~0x3ffffffffffffffull) == ((0 && (guard & (1ull << 63))) ? 0x0 : 0));  
-    seL4_DebugAssert((guardSize & ~0x3full) == ((0 && (guardSize & (1ull << 63))) ? 0x0 : 0));
+    seL4_DebugAssert((guard & ~ULL_CONST(0x3ffffffffffffff)) == ((0 && (guard & (ULL_CONST(1) << 63))) ? 0x0 : 0));  
+    seL4_DebugAssert((guardSize & ~ULL_CONST(0x3f)) == ((0 && (guardSize & (ULL_CONST(1) << 63))) ? 0x0 : 0));
 
     seL4_CNode_CapData_ptr->words[0] = 0
-        | (guard & 0x3ffffffffffffffull) << 6
-        | (guardSize & 0x3full) << 0;
+        | (guard & ULL_CONST(0x3ffffffffffffff)) << 6
+        | (guardSize & ULL_CONST(0x3f)) << 0;
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
 seL4_CNode_CapData_get_guard(seL4_CNode_CapData_t seL4_CNode_CapData) {
     seL4_Uint64 ret;
-    ret = (seL4_CNode_CapData.words[0] & 0xffffffffffffffc0ull) >> 6;
+    ret = (seL4_CNode_CapData.words[0] & ULL_CONST(0xffffffffffffffc0)) >> 6;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -50,18 +50,18 @@ seL4_CNode_CapData_get_guard(seL4_CNode_CapData_t seL4_CNode_CapData) {
 LIBSEL4_INLINE_FUNC seL4_CNode_CapData_t CONST
 seL4_CNode_CapData_set_guard(seL4_CNode_CapData_t seL4_CNode_CapData, seL4_Uint64 v64) {
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffc0ull >> 6 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
-    seL4_CNode_CapData.words[0] &= ~0xffffffffffffffc0ull;
-    seL4_CNode_CapData.words[0] |= (v64 << 6) & 0xffffffffffffffc0ull;
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffc0) >> 6 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
+    seL4_CNode_CapData.words[0] &= ~ULL_CONST(0xffffffffffffffc0);
+    seL4_CNode_CapData.words[0] |= (v64 << 6) & ULL_CONST(0xffffffffffffffc0);
     return seL4_CNode_CapData;
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 PURE
 seL4_CNode_CapData_ptr_get_guard(seL4_CNode_CapData_t *seL4_CNode_CapData_ptr) {
     seL4_Uint64 ret;
-    ret = (seL4_CNode_CapData_ptr->words[0] & 0xffffffffffffffc0ull) >> 6;
+    ret = (seL4_CNode_CapData_ptr->words[0] & ULL_CONST(0xffffffffffffffc0)) >> 6;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -70,17 +70,17 @@ seL4_CNode_CapData_ptr_get_guard(seL4_CNode_CapData_t *seL4_CNode_CapData_ptr) {
 LIBSEL4_INLINE_FUNC void
 seL4_CNode_CapData_ptr_set_guard(seL4_CNode_CapData_t *seL4_CNode_CapData_ptr, seL4_Uint64 v64) {
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffc0ull >> 6) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
-    seL4_CNode_CapData_ptr->words[0] &= ~0xffffffffffffffc0ull;
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffc0) >> 6) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
+    seL4_CNode_CapData_ptr->words[0] &= ~ULL_CONST(0xffffffffffffffc0);
     seL4_CNode_CapData_ptr->words[0] |= (v64 << 6) & 0xffffffffffffffc0;
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
 seL4_CNode_CapData_get_guardSize(seL4_CNode_CapData_t seL4_CNode_CapData) {
     seL4_Uint64 ret;
-    ret = (seL4_CNode_CapData.words[0] & 0x3full) >> 0;
+    ret = (seL4_CNode_CapData.words[0] & ULL_CONST(0x3f)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -89,18 +89,18 @@ seL4_CNode_CapData_get_guardSize(seL4_CNode_CapData_t seL4_CNode_CapData) {
 LIBSEL4_INLINE_FUNC seL4_CNode_CapData_t CONST
 seL4_CNode_CapData_set_guardSize(seL4_CNode_CapData_t seL4_CNode_CapData, seL4_Uint64 v64) {
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0x3full >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
-    seL4_CNode_CapData.words[0] &= ~0x3full;
-    seL4_CNode_CapData.words[0] |= (v64 << 0) & 0x3full;
+    seL4_DebugAssert((((~ULL_CONST(0x3f) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
+    seL4_CNode_CapData.words[0] &= ~ULL_CONST(0x3f);
+    seL4_CNode_CapData.words[0] |= (v64 << 0) & ULL_CONST(0x3f);
     return seL4_CNode_CapData;
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 PURE
 seL4_CNode_CapData_ptr_get_guardSize(seL4_CNode_CapData_t *seL4_CNode_CapData_ptr) {
     seL4_Uint64 ret;
-    ret = (seL4_CNode_CapData_ptr->words[0] & 0x3full) >> 0;
+    ret = (seL4_CNode_CapData_ptr->words[0] & ULL_CONST(0x3f)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -109,8 +109,8 @@ seL4_CNode_CapData_ptr_get_guardSize(seL4_CNode_CapData_t *seL4_CNode_CapData_pt
 LIBSEL4_INLINE_FUNC void
 seL4_CNode_CapData_ptr_set_guardSize(seL4_CNode_CapData_t *seL4_CNode_CapData_ptr, seL4_Uint64 v64) {
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0x3full >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
-    seL4_CNode_CapData_ptr->words[0] &= ~0x3full;
+    seL4_DebugAssert((((~ULL_CONST(0x3f) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
+    seL4_CNode_CapData_ptr->words[0] &= ~ULL_CONST(0x3f);
     seL4_CNode_CapData_ptr->words[0] |= (v64 << 0) & 0x3f;
 }
 
@@ -124,16 +124,16 @@ seL4_CapRights_new(seL4_Uint64 capAllowGrantReply, seL4_Uint64 capAllowGrant, se
     seL4_CapRights_t seL4_CapRights;
 
     /* fail if user has passed bits that we will override */  
-    seL4_DebugAssert((capAllowGrantReply & ~0x1ull) == ((0 && (capAllowGrantReply & (1ull << 63))) ? 0x0 : 0));  
-    seL4_DebugAssert((capAllowGrant & ~0x1ull) == ((0 && (capAllowGrant & (1ull << 63))) ? 0x0 : 0));  
-    seL4_DebugAssert((capAllowRead & ~0x1ull) == ((0 && (capAllowRead & (1ull << 63))) ? 0x0 : 0));  
-    seL4_DebugAssert((capAllowWrite & ~0x1ull) == ((0 && (capAllowWrite & (1ull << 63))) ? 0x0 : 0));
+    seL4_DebugAssert((capAllowGrantReply & ~ULL_CONST(0x1)) == ((0 && (capAllowGrantReply & (ULL_CONST(1) << 63))) ? 0x0 : 0));  
+    seL4_DebugAssert((capAllowGrant & ~ULL_CONST(0x1)) == ((0 && (capAllowGrant & (ULL_CONST(1) << 63))) ? 0x0 : 0));  
+    seL4_DebugAssert((capAllowRead & ~ULL_CONST(0x1)) == ((0 && (capAllowRead & (ULL_CONST(1) << 63))) ? 0x0 : 0));  
+    seL4_DebugAssert((capAllowWrite & ~ULL_CONST(0x1)) == ((0 && (capAllowWrite & (ULL_CONST(1) << 63))) ? 0x0 : 0));
 
     seL4_CapRights.words[0] = 0
-        | (capAllowGrantReply & 0x1ull) << 3
-        | (capAllowGrant & 0x1ull) << 2
-        | (capAllowRead & 0x1ull) << 1
-        | (capAllowWrite & 0x1ull) << 0;
+        | (capAllowGrantReply & ULL_CONST(0x1)) << 3
+        | (capAllowGrant & ULL_CONST(0x1)) << 2
+        | (capAllowRead & ULL_CONST(0x1)) << 1
+        | (capAllowWrite & ULL_CONST(0x1)) << 0;
 
     return seL4_CapRights;
 }
@@ -141,24 +141,24 @@ seL4_CapRights_new(seL4_Uint64 capAllowGrantReply, seL4_Uint64 capAllowGrant, se
 LIBSEL4_INLINE_FUNC void
 seL4_CapRights_ptr_new(seL4_CapRights_t *seL4_CapRights_ptr, seL4_Uint64 capAllowGrantReply, seL4_Uint64 capAllowGrant, seL4_Uint64 capAllowRead, seL4_Uint64 capAllowWrite) {
     /* fail if user has passed bits that we will override */  
-    seL4_DebugAssert((capAllowGrantReply & ~0x1ull) == ((0 && (capAllowGrantReply & (1ull << 63))) ? 0x0 : 0));  
-    seL4_DebugAssert((capAllowGrant & ~0x1ull) == ((0 && (capAllowGrant & (1ull << 63))) ? 0x0 : 0));  
-    seL4_DebugAssert((capAllowRead & ~0x1ull) == ((0 && (capAllowRead & (1ull << 63))) ? 0x0 : 0));  
-    seL4_DebugAssert((capAllowWrite & ~0x1ull) == ((0 && (capAllowWrite & (1ull << 63))) ? 0x0 : 0));
+    seL4_DebugAssert((capAllowGrantReply & ~ULL_CONST(0x1)) == ((0 && (capAllowGrantReply & (ULL_CONST(1) << 63))) ? 0x0 : 0));  
+    seL4_DebugAssert((capAllowGrant & ~ULL_CONST(0x1)) == ((0 && (capAllowGrant & (ULL_CONST(1) << 63))) ? 0x0 : 0));  
+    seL4_DebugAssert((capAllowRead & ~ULL_CONST(0x1)) == ((0 && (capAllowRead & (ULL_CONST(1) << 63))) ? 0x0 : 0));  
+    seL4_DebugAssert((capAllowWrite & ~ULL_CONST(0x1)) == ((0 && (capAllowWrite & (ULL_CONST(1) << 63))) ? 0x0 : 0));
 
     seL4_CapRights_ptr->words[0] = 0
-        | (capAllowGrantReply & 0x1ull) << 3
-        | (capAllowGrant & 0x1ull) << 2
-        | (capAllowRead & 0x1ull) << 1
-        | (capAllowWrite & 0x1ull) << 0;
+        | (capAllowGrantReply & ULL_CONST(0x1)) << 3
+        | (capAllowGrant & ULL_CONST(0x1)) << 2
+        | (capAllowRead & ULL_CONST(0x1)) << 1
+        | (capAllowWrite & ULL_CONST(0x1)) << 0;
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
 seL4_CapRights_get_capAllowGrantReply(seL4_CapRights_t seL4_CapRights) {
     seL4_Uint64 ret;
-    ret = (seL4_CapRights.words[0] & 0x8ull) >> 3;
+    ret = (seL4_CapRights.words[0] & ULL_CONST(0x8)) >> 3;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -167,18 +167,18 @@ seL4_CapRights_get_capAllowGrantReply(seL4_CapRights_t seL4_CapRights) {
 LIBSEL4_INLINE_FUNC seL4_CapRights_t CONST
 seL4_CapRights_set_capAllowGrantReply(seL4_CapRights_t seL4_CapRights, seL4_Uint64 v64) {
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0x8ull >> 3 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
-    seL4_CapRights.words[0] &= ~0x8ull;
-    seL4_CapRights.words[0] |= (v64 << 3) & 0x8ull;
+    seL4_DebugAssert((((~ULL_CONST(0x8) >> 3 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
+    seL4_CapRights.words[0] &= ~ULL_CONST(0x8);
+    seL4_CapRights.words[0] |= (v64 << 3) & ULL_CONST(0x8);
     return seL4_CapRights;
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 PURE
 seL4_CapRights_ptr_get_capAllowGrantReply(seL4_CapRights_t *seL4_CapRights_ptr) {
     seL4_Uint64 ret;
-    ret = (seL4_CapRights_ptr->words[0] & 0x8ull) >> 3;
+    ret = (seL4_CapRights_ptr->words[0] & ULL_CONST(0x8)) >> 3;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -187,17 +187,17 @@ seL4_CapRights_ptr_get_capAllowGrantReply(seL4_CapRights_t *seL4_CapRights_ptr) 
 LIBSEL4_INLINE_FUNC void
 seL4_CapRights_ptr_set_capAllowGrantReply(seL4_CapRights_t *seL4_CapRights_ptr, seL4_Uint64 v64) {
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0x8ull >> 3) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
-    seL4_CapRights_ptr->words[0] &= ~0x8ull;
+    seL4_DebugAssert((((~ULL_CONST(0x8) >> 3) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
+    seL4_CapRights_ptr->words[0] &= ~ULL_CONST(0x8);
     seL4_CapRights_ptr->words[0] |= (v64 << 3) & 0x8;
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
 seL4_CapRights_get_capAllowGrant(seL4_CapRights_t seL4_CapRights) {
     seL4_Uint64 ret;
-    ret = (seL4_CapRights.words[0] & 0x4ull) >> 2;
+    ret = (seL4_CapRights.words[0] & ULL_CONST(0x4)) >> 2;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -206,18 +206,18 @@ seL4_CapRights_get_capAllowGrant(seL4_CapRights_t seL4_CapRights) {
 LIBSEL4_INLINE_FUNC seL4_CapRights_t CONST
 seL4_CapRights_set_capAllowGrant(seL4_CapRights_t seL4_CapRights, seL4_Uint64 v64) {
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0x4ull >> 2 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
-    seL4_CapRights.words[0] &= ~0x4ull;
-    seL4_CapRights.words[0] |= (v64 << 2) & 0x4ull;
+    seL4_DebugAssert((((~ULL_CONST(0x4) >> 2 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
+    seL4_CapRights.words[0] &= ~ULL_CONST(0x4);
+    seL4_CapRights.words[0] |= (v64 << 2) & ULL_CONST(0x4);
     return seL4_CapRights;
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 PURE
 seL4_CapRights_ptr_get_capAllowGrant(seL4_CapRights_t *seL4_CapRights_ptr) {
     seL4_Uint64 ret;
-    ret = (seL4_CapRights_ptr->words[0] & 0x4ull) >> 2;
+    ret = (seL4_CapRights_ptr->words[0] & ULL_CONST(0x4)) >> 2;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -226,17 +226,17 @@ seL4_CapRights_ptr_get_capAllowGrant(seL4_CapRights_t *seL4_CapRights_ptr) {
 LIBSEL4_INLINE_FUNC void
 seL4_CapRights_ptr_set_capAllowGrant(seL4_CapRights_t *seL4_CapRights_ptr, seL4_Uint64 v64) {
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0x4ull >> 2) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
-    seL4_CapRights_ptr->words[0] &= ~0x4ull;
+    seL4_DebugAssert((((~ULL_CONST(0x4) >> 2) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
+    seL4_CapRights_ptr->words[0] &= ~ULL_CONST(0x4);
     seL4_CapRights_ptr->words[0] |= (v64 << 2) & 0x4;
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
 seL4_CapRights_get_capAllowRead(seL4_CapRights_t seL4_CapRights) {
     seL4_Uint64 ret;
-    ret = (seL4_CapRights.words[0] & 0x2ull) >> 1;
+    ret = (seL4_CapRights.words[0] & ULL_CONST(0x2)) >> 1;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -245,18 +245,18 @@ seL4_CapRights_get_capAllowRead(seL4_CapRights_t seL4_CapRights) {
 LIBSEL4_INLINE_FUNC seL4_CapRights_t CONST
 seL4_CapRights_set_capAllowRead(seL4_CapRights_t seL4_CapRights, seL4_Uint64 v64) {
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0x2ull >> 1 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
-    seL4_CapRights.words[0] &= ~0x2ull;
-    seL4_CapRights.words[0] |= (v64 << 1) & 0x2ull;
+    seL4_DebugAssert((((~ULL_CONST(0x2) >> 1 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
+    seL4_CapRights.words[0] &= ~ULL_CONST(0x2);
+    seL4_CapRights.words[0] |= (v64 << 1) & ULL_CONST(0x2);
     return seL4_CapRights;
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 PURE
 seL4_CapRights_ptr_get_capAllowRead(seL4_CapRights_t *seL4_CapRights_ptr) {
     seL4_Uint64 ret;
-    ret = (seL4_CapRights_ptr->words[0] & 0x2ull) >> 1;
+    ret = (seL4_CapRights_ptr->words[0] & ULL_CONST(0x2)) >> 1;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -265,17 +265,17 @@ seL4_CapRights_ptr_get_capAllowRead(seL4_CapRights_t *seL4_CapRights_ptr) {
 LIBSEL4_INLINE_FUNC void
 seL4_CapRights_ptr_set_capAllowRead(seL4_CapRights_t *seL4_CapRights_ptr, seL4_Uint64 v64) {
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0x2ull >> 1) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
-    seL4_CapRights_ptr->words[0] &= ~0x2ull;
+    seL4_DebugAssert((((~ULL_CONST(0x2) >> 1) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
+    seL4_CapRights_ptr->words[0] &= ~ULL_CONST(0x2);
     seL4_CapRights_ptr->words[0] |= (v64 << 1) & 0x2;
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
 seL4_CapRights_get_capAllowWrite(seL4_CapRights_t seL4_CapRights) {
     seL4_Uint64 ret;
-    ret = (seL4_CapRights.words[0] & 0x1ull) >> 0;
+    ret = (seL4_CapRights.words[0] & ULL_CONST(0x1)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -284,18 +284,18 @@ seL4_CapRights_get_capAllowWrite(seL4_CapRights_t seL4_CapRights) {
 LIBSEL4_INLINE_FUNC seL4_CapRights_t CONST
 seL4_CapRights_set_capAllowWrite(seL4_CapRights_t seL4_CapRights, seL4_Uint64 v64) {
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0x1ull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
-    seL4_CapRights.words[0] &= ~0x1ull;
-    seL4_CapRights.words[0] |= (v64 << 0) & 0x1ull;
+    seL4_DebugAssert((((~ULL_CONST(0x1) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
+    seL4_CapRights.words[0] &= ~ULL_CONST(0x1);
+    seL4_CapRights.words[0] |= (v64 << 0) & ULL_CONST(0x1);
     return seL4_CapRights;
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 PURE
 seL4_CapRights_ptr_get_capAllowWrite(seL4_CapRights_t *seL4_CapRights_ptr) {
     seL4_Uint64 ret;
-    ret = (seL4_CapRights_ptr->words[0] & 0x1ull) >> 0;
+    ret = (seL4_CapRights_ptr->words[0] & ULL_CONST(0x1)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -304,8 +304,8 @@ seL4_CapRights_ptr_get_capAllowWrite(seL4_CapRights_t *seL4_CapRights_ptr) {
 LIBSEL4_INLINE_FUNC void
 seL4_CapRights_ptr_set_capAllowWrite(seL4_CapRights_t *seL4_CapRights_ptr, seL4_Uint64 v64) {
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0x1ull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
-    seL4_CapRights_ptr->words[0] &= ~0x1ull;
+    seL4_DebugAssert((((~ULL_CONST(0x1) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
+    seL4_CapRights_ptr->words[0] &= ~ULL_CONST(0x1);
     seL4_CapRights_ptr->words[0] |= (v64 << 0) & 0x1;
 }
 
@@ -319,16 +319,16 @@ seL4_MessageInfo_new(seL4_Uint64 label, seL4_Uint64 capsUnwrapped, seL4_Uint64 e
     seL4_MessageInfo_t seL4_MessageInfo;
 
     /* fail if user has passed bits that we will override */  
-    seL4_DebugAssert((label & ~0xfffffffffffffull) == ((0 && (label & (1ull << 63))) ? 0x0 : 0));  
-    seL4_DebugAssert((capsUnwrapped & ~0x7ull) == ((0 && (capsUnwrapped & (1ull << 63))) ? 0x0 : 0));  
-    seL4_DebugAssert((extraCaps & ~0x3ull) == ((0 && (extraCaps & (1ull << 63))) ? 0x0 : 0));  
-    seL4_DebugAssert((length & ~0x7full) == ((0 && (length & (1ull << 63))) ? 0x0 : 0));
+    seL4_DebugAssert((label & ~ULL_CONST(0xfffffffffffff)) == ((0 && (label & (ULL_CONST(1) << 63))) ? 0x0 : 0));  
+    seL4_DebugAssert((capsUnwrapped & ~ULL_CONST(0x7)) == ((0 && (capsUnwrapped & (ULL_CONST(1) << 63))) ? 0x0 : 0));  
+    seL4_DebugAssert((extraCaps & ~ULL_CONST(0x3)) == ((0 && (extraCaps & (ULL_CONST(1) << 63))) ? 0x0 : 0));  
+    seL4_DebugAssert((length & ~ULL_CONST(0x7f)) == ((0 && (length & (ULL_CONST(1) << 63))) ? 0x0 : 0));
 
     seL4_MessageInfo.words[0] = 0
-        | (label & 0xfffffffffffffull) << 12
-        | (capsUnwrapped & 0x7ull) << 9
-        | (extraCaps & 0x3ull) << 7
-        | (length & 0x7full) << 0;
+        | (label & ULL_CONST(0xfffffffffffff)) << 12
+        | (capsUnwrapped & ULL_CONST(0x7)) << 9
+        | (extraCaps & ULL_CONST(0x3)) << 7
+        | (length & ULL_CONST(0x7f)) << 0;
 
     return seL4_MessageInfo;
 }
@@ -336,24 +336,24 @@ seL4_MessageInfo_new(seL4_Uint64 label, seL4_Uint64 capsUnwrapped, seL4_Uint64 e
 LIBSEL4_INLINE_FUNC void
 seL4_MessageInfo_ptr_new(seL4_MessageInfo_t *seL4_MessageInfo_ptr, seL4_Uint64 label, seL4_Uint64 capsUnwrapped, seL4_Uint64 extraCaps, seL4_Uint64 length) {
     /* fail if user has passed bits that we will override */  
-    seL4_DebugAssert((label & ~0xfffffffffffffull) == ((0 && (label & (1ull << 63))) ? 0x0 : 0));  
-    seL4_DebugAssert((capsUnwrapped & ~0x7ull) == ((0 && (capsUnwrapped & (1ull << 63))) ? 0x0 : 0));  
-    seL4_DebugAssert((extraCaps & ~0x3ull) == ((0 && (extraCaps & (1ull << 63))) ? 0x0 : 0));  
-    seL4_DebugAssert((length & ~0x7full) == ((0 && (length & (1ull << 63))) ? 0x0 : 0));
+    seL4_DebugAssert((label & ~ULL_CONST(0xfffffffffffff)) == ((0 && (label & (ULL_CONST(1) << 63))) ? 0x0 : 0));  
+    seL4_DebugAssert((capsUnwrapped & ~ULL_CONST(0x7)) == ((0 && (capsUnwrapped & (ULL_CONST(1) << 63))) ? 0x0 : 0));  
+    seL4_DebugAssert((extraCaps & ~ULL_CONST(0x3)) == ((0 && (extraCaps & (ULL_CONST(1) << 63))) ? 0x0 : 0));  
+    seL4_DebugAssert((length & ~ULL_CONST(0x7f)) == ((0 && (length & (ULL_CONST(1) << 63))) ? 0x0 : 0));
 
     seL4_MessageInfo_ptr->words[0] = 0
-        | (label & 0xfffffffffffffull) << 12
-        | (capsUnwrapped & 0x7ull) << 9
-        | (extraCaps & 0x3ull) << 7
-        | (length & 0x7full) << 0;
+        | (label & ULL_CONST(0xfffffffffffff)) << 12
+        | (capsUnwrapped & ULL_CONST(0x7)) << 9
+        | (extraCaps & ULL_CONST(0x3)) << 7
+        | (length & ULL_CONST(0x7f)) << 0;
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
 seL4_MessageInfo_get_label(seL4_MessageInfo_t seL4_MessageInfo) {
     seL4_Uint64 ret;
-    ret = (seL4_MessageInfo.words[0] & 0xfffffffffffff000ull) >> 12;
+    ret = (seL4_MessageInfo.words[0] & ULL_CONST(0xfffffffffffff000)) >> 12;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -362,18 +362,18 @@ seL4_MessageInfo_get_label(seL4_MessageInfo_t seL4_MessageInfo) {
 LIBSEL4_INLINE_FUNC seL4_MessageInfo_t CONST
 seL4_MessageInfo_set_label(seL4_MessageInfo_t seL4_MessageInfo, seL4_Uint64 v64) {
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xfffffffffffff000ull >> 12 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
-    seL4_MessageInfo.words[0] &= ~0xfffffffffffff000ull;
-    seL4_MessageInfo.words[0] |= (v64 << 12) & 0xfffffffffffff000ull;
+    seL4_DebugAssert((((~ULL_CONST(0xfffffffffffff000) >> 12 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
+    seL4_MessageInfo.words[0] &= ~ULL_CONST(0xfffffffffffff000);
+    seL4_MessageInfo.words[0] |= (v64 << 12) & ULL_CONST(0xfffffffffffff000);
     return seL4_MessageInfo;
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 PURE
 seL4_MessageInfo_ptr_get_label(seL4_MessageInfo_t *seL4_MessageInfo_ptr) {
     seL4_Uint64 ret;
-    ret = (seL4_MessageInfo_ptr->words[0] & 0xfffffffffffff000ull) >> 12;
+    ret = (seL4_MessageInfo_ptr->words[0] & ULL_CONST(0xfffffffffffff000)) >> 12;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -382,17 +382,17 @@ seL4_MessageInfo_ptr_get_label(seL4_MessageInfo_t *seL4_MessageInfo_ptr) {
 LIBSEL4_INLINE_FUNC void
 seL4_MessageInfo_ptr_set_label(seL4_MessageInfo_t *seL4_MessageInfo_ptr, seL4_Uint64 v64) {
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xfffffffffffff000ull >> 12) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
-    seL4_MessageInfo_ptr->words[0] &= ~0xfffffffffffff000ull;
+    seL4_DebugAssert((((~ULL_CONST(0xfffffffffffff000) >> 12) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
+    seL4_MessageInfo_ptr->words[0] &= ~ULL_CONST(0xfffffffffffff000);
     seL4_MessageInfo_ptr->words[0] |= (v64 << 12) & 0xfffffffffffff000;
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
 seL4_MessageInfo_get_capsUnwrapped(seL4_MessageInfo_t seL4_MessageInfo) {
     seL4_Uint64 ret;
-    ret = (seL4_MessageInfo.words[0] & 0xe00ull) >> 9;
+    ret = (seL4_MessageInfo.words[0] & ULL_CONST(0xe00)) >> 9;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -401,18 +401,18 @@ seL4_MessageInfo_get_capsUnwrapped(seL4_MessageInfo_t seL4_MessageInfo) {
 LIBSEL4_INLINE_FUNC seL4_MessageInfo_t CONST
 seL4_MessageInfo_set_capsUnwrapped(seL4_MessageInfo_t seL4_MessageInfo, seL4_Uint64 v64) {
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xe00ull >> 9 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
-    seL4_MessageInfo.words[0] &= ~0xe00ull;
-    seL4_MessageInfo.words[0] |= (v64 << 9) & 0xe00ull;
+    seL4_DebugAssert((((~ULL_CONST(0xe00) >> 9 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
+    seL4_MessageInfo.words[0] &= ~ULL_CONST(0xe00);
+    seL4_MessageInfo.words[0] |= (v64 << 9) & ULL_CONST(0xe00);
     return seL4_MessageInfo;
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 PURE
 seL4_MessageInfo_ptr_get_capsUnwrapped(seL4_MessageInfo_t *seL4_MessageInfo_ptr) {
     seL4_Uint64 ret;
-    ret = (seL4_MessageInfo_ptr->words[0] & 0xe00ull) >> 9;
+    ret = (seL4_MessageInfo_ptr->words[0] & ULL_CONST(0xe00)) >> 9;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -421,17 +421,17 @@ seL4_MessageInfo_ptr_get_capsUnwrapped(seL4_MessageInfo_t *seL4_MessageInfo_ptr)
 LIBSEL4_INLINE_FUNC void
 seL4_MessageInfo_ptr_set_capsUnwrapped(seL4_MessageInfo_t *seL4_MessageInfo_ptr, seL4_Uint64 v64) {
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xe00ull >> 9) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
-    seL4_MessageInfo_ptr->words[0] &= ~0xe00ull;
+    seL4_DebugAssert((((~ULL_CONST(0xe00) >> 9) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
+    seL4_MessageInfo_ptr->words[0] &= ~ULL_CONST(0xe00);
     seL4_MessageInfo_ptr->words[0] |= (v64 << 9) & 0xe00;
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
 seL4_MessageInfo_get_extraCaps(seL4_MessageInfo_t seL4_MessageInfo) {
     seL4_Uint64 ret;
-    ret = (seL4_MessageInfo.words[0] & 0x180ull) >> 7;
+    ret = (seL4_MessageInfo.words[0] & ULL_CONST(0x180)) >> 7;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -440,18 +440,18 @@ seL4_MessageInfo_get_extraCaps(seL4_MessageInfo_t seL4_MessageInfo) {
 LIBSEL4_INLINE_FUNC seL4_MessageInfo_t CONST
 seL4_MessageInfo_set_extraCaps(seL4_MessageInfo_t seL4_MessageInfo, seL4_Uint64 v64) {
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0x180ull >> 7 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
-    seL4_MessageInfo.words[0] &= ~0x180ull;
-    seL4_MessageInfo.words[0] |= (v64 << 7) & 0x180ull;
+    seL4_DebugAssert((((~ULL_CONST(0x180) >> 7 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
+    seL4_MessageInfo.words[0] &= ~ULL_CONST(0x180);
+    seL4_MessageInfo.words[0] |= (v64 << 7) & ULL_CONST(0x180);
     return seL4_MessageInfo;
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 PURE
 seL4_MessageInfo_ptr_get_extraCaps(seL4_MessageInfo_t *seL4_MessageInfo_ptr) {
     seL4_Uint64 ret;
-    ret = (seL4_MessageInfo_ptr->words[0] & 0x180ull) >> 7;
+    ret = (seL4_MessageInfo_ptr->words[0] & ULL_CONST(0x180)) >> 7;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -460,17 +460,17 @@ seL4_MessageInfo_ptr_get_extraCaps(seL4_MessageInfo_t *seL4_MessageInfo_ptr) {
 LIBSEL4_INLINE_FUNC void
 seL4_MessageInfo_ptr_set_extraCaps(seL4_MessageInfo_t *seL4_MessageInfo_ptr, seL4_Uint64 v64) {
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0x180ull >> 7) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
-    seL4_MessageInfo_ptr->words[0] &= ~0x180ull;
+    seL4_DebugAssert((((~ULL_CONST(0x180) >> 7) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
+    seL4_MessageInfo_ptr->words[0] &= ~ULL_CONST(0x180);
     seL4_MessageInfo_ptr->words[0] |= (v64 << 7) & 0x180;
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
 seL4_MessageInfo_get_length(seL4_MessageInfo_t seL4_MessageInfo) {
     seL4_Uint64 ret;
-    ret = (seL4_MessageInfo.words[0] & 0x7full) >> 0;
+    ret = (seL4_MessageInfo.words[0] & ULL_CONST(0x7f)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -479,18 +479,18 @@ seL4_MessageInfo_get_length(seL4_MessageInfo_t seL4_MessageInfo) {
 LIBSEL4_INLINE_FUNC seL4_MessageInfo_t CONST
 seL4_MessageInfo_set_length(seL4_MessageInfo_t seL4_MessageInfo, seL4_Uint64 v64) {
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0x7full >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
-    seL4_MessageInfo.words[0] &= ~0x7full;
-    seL4_MessageInfo.words[0] |= (v64 << 0) & 0x7full;
+    seL4_DebugAssert((((~ULL_CONST(0x7f) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
+    seL4_MessageInfo.words[0] &= ~ULL_CONST(0x7f);
+    seL4_MessageInfo.words[0] |= (v64 << 0) & ULL_CONST(0x7f);
     return seL4_MessageInfo;
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 PURE
 seL4_MessageInfo_ptr_get_length(seL4_MessageInfo_t *seL4_MessageInfo_ptr) {
     seL4_Uint64 ret;
-    ret = (seL4_MessageInfo_ptr->words[0] & 0x7full) >> 0;
+    ret = (seL4_MessageInfo_ptr->words[0] & ULL_CONST(0x7f)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -499,8 +499,8 @@ seL4_MessageInfo_ptr_get_length(seL4_MessageInfo_t *seL4_MessageInfo_ptr) {
 LIBSEL4_INLINE_FUNC void
 seL4_MessageInfo_ptr_set_length(seL4_MessageInfo_t *seL4_MessageInfo_ptr, seL4_Uint64 v64) {
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0x7full >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
-    seL4_MessageInfo_ptr->words[0] &= ~0x7full;
+    seL4_DebugAssert((((~ULL_CONST(0x7f) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
+    seL4_MessageInfo_ptr->words[0] &= ~ULL_CONST(0x7f);
     seL4_MessageInfo_ptr->words[0] |= (v64 << 0) & 0x7f;
 }
 

--- a/preconfigured/X64_verified/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/types_gen.h
+++ b/preconfigured/X64_verified/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/types_gen.h
@@ -21,17 +21,17 @@ typedef enum seL4_Fault_tag seL4_Fault_tag_t;
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
 seL4_Fault_get_seL4_FaultType(seL4_Fault_t seL4_Fault) {
-    return (seL4_Fault.words[0] >> 0) & 0xfull;
+    return (seL4_Fault.words[0] >> 0) & ULL_CONST(0xf);
 }
 
 LIBSEL4_INLINE_FUNC int CONST
 seL4_Fault_seL4_FaultType_equals(seL4_Fault_t seL4_Fault, seL4_Uint64 seL4_Fault_type_tag) {
-    return ((seL4_Fault.words[0] >> 0) & 0xfull) == seL4_Fault_type_tag;
+    return ((seL4_Fault.words[0] >> 0) & ULL_CONST(0xf)) == seL4_Fault_type_tag;
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 PURE
 seL4_Fault_ptr_get_seL4_FaultType(seL4_Fault_t *seL4_Fault_ptr) {
-    return (seL4_Fault_ptr->words[0] >> 0) & 0xfull;
+    return (seL4_Fault_ptr->words[0] >> 0) & ULL_CONST(0xf);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Fault_t CONST
@@ -39,10 +39,10 @@ seL4_Fault_NullFault_new(void) {
     seL4_Fault_t seL4_Fault;
 
     /* fail if user has passed bits that we will override */  
-    seL4_DebugAssert(((seL4_Uint64)seL4_Fault_NullFault & ~0xfull) == ((0 && ((seL4_Uint64)seL4_Fault_NullFault & (1ull << 63))) ? 0x0 : 0));
+    seL4_DebugAssert(((seL4_Uint64)seL4_Fault_NullFault & ~ULL_CONST(0xf)) == ((0 && ((seL4_Uint64)seL4_Fault_NullFault & (ULL_CONST(1) << 63))) ? 0x0 : 0));
 
     seL4_Fault.words[0] = 0
-        | ((seL4_Uint64)seL4_Fault_NullFault & 0xfull) << 0;
+        | ((seL4_Uint64)seL4_Fault_NullFault & ULL_CONST(0xf)) << 0;
     seL4_Fault.words[1] = 0;
     seL4_Fault.words[2] = 0;
     seL4_Fault.words[3] = 0;
@@ -69,10 +69,10 @@ seL4_Fault_NullFault_new(void) {
 LIBSEL4_INLINE_FUNC void
 seL4_Fault_NullFault_ptr_new(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if user has passed bits that we will override */  
-    seL4_DebugAssert(((seL4_Uint64)seL4_Fault_NullFault & ~0xfull) == ((0 && ((seL4_Uint64)seL4_Fault_NullFault & (1ull << 63))) ? 0x0 : 0));
+    seL4_DebugAssert(((seL4_Uint64)seL4_Fault_NullFault & ~ULL_CONST(0xf)) == ((0 && ((seL4_Uint64)seL4_Fault_NullFault & (ULL_CONST(1) << 63))) ? 0x0 : 0));
 
     seL4_Fault_ptr->words[0] = 0
-        | ((seL4_Uint64)seL4_Fault_NullFault & 0xfull) << 0;
+        | ((seL4_Uint64)seL4_Fault_NullFault & ULL_CONST(0xf)) << 0;
     seL4_Fault_ptr->words[1] = 0;
     seL4_Fault_ptr->words[2] = 0;
     seL4_Fault_ptr->words[3] = 0;
@@ -99,10 +99,10 @@ seL4_Fault_CapFault_new(seL4_Uint64 IP, seL4_Uint64 Addr, seL4_Uint64 InRecvPhas
     seL4_Fault_t seL4_Fault;
 
     /* fail if user has passed bits that we will override */  
-    seL4_DebugAssert(((seL4_Uint64)seL4_Fault_CapFault & ~0xfull) == ((0 && ((seL4_Uint64)seL4_Fault_CapFault & (1ull << 63))) ? 0x0 : 0));
+    seL4_DebugAssert(((seL4_Uint64)seL4_Fault_CapFault & ~ULL_CONST(0xf)) == ((0 && ((seL4_Uint64)seL4_Fault_CapFault & (ULL_CONST(1) << 63))) ? 0x0 : 0));
 
     seL4_Fault.words[0] = 0
-        | ((seL4_Uint64)seL4_Fault_CapFault & 0xfull) << 0;
+        | ((seL4_Uint64)seL4_Fault_CapFault & ULL_CONST(0xf)) << 0;
     seL4_Fault.words[1] = 0
         | MR6 << 0;
     seL4_Fault.words[2] = 0
@@ -136,10 +136,10 @@ seL4_Fault_CapFault_new(seL4_Uint64 IP, seL4_Uint64 Addr, seL4_Uint64 InRecvPhas
 LIBSEL4_INLINE_FUNC void
 seL4_Fault_CapFault_ptr_new(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 IP, seL4_Uint64 Addr, seL4_Uint64 InRecvPhase, seL4_Uint64 LookupFailureType, seL4_Uint64 MR4, seL4_Uint64 MR5, seL4_Uint64 MR6) {
     /* fail if user has passed bits that we will override */  
-    seL4_DebugAssert(((seL4_Uint64)seL4_Fault_CapFault & ~0xfull) == ((0 && ((seL4_Uint64)seL4_Fault_CapFault & (1ull << 63))) ? 0x0 : 0));
+    seL4_DebugAssert(((seL4_Uint64)seL4_Fault_CapFault & ~ULL_CONST(0xf)) == ((0 && ((seL4_Uint64)seL4_Fault_CapFault & (ULL_CONST(1) << 63))) ? 0x0 : 0));
 
     seL4_Fault_ptr->words[0] = 0
-        | ((seL4_Uint64)seL4_Fault_CapFault & 0xfull) << 0;
+        | ((seL4_Uint64)seL4_Fault_CapFault & ULL_CONST(0xf)) << 0;
     seL4_Fault_ptr->words[1] = 0
         | MR6 << 0;
     seL4_Fault_ptr->words[2] = 0
@@ -174,9 +174,9 @@ seL4_Fault_CapFault_get_IP(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
 
-    ret = (seL4_Fault.words[7] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[7] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -187,10 +187,10 @@ seL4_Fault_CapFault_set_IP(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[7] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[7] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[7] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[7] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -200,9 +200,9 @@ seL4_Fault_CapFault_ptr_get_IP(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
 
-    ret = (seL4_Fault_ptr->words[7] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[7] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -214,10 +214,10 @@ seL4_Fault_CapFault_ptr_set_IP(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 v64) {
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[7] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[7] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[7] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[7] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -226,9 +226,9 @@ seL4_Fault_CapFault_get_Addr(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
 
-    ret = (seL4_Fault.words[6] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[6] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -239,10 +239,10 @@ seL4_Fault_CapFault_set_Addr(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[6] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[6] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[6] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[6] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -252,9 +252,9 @@ seL4_Fault_CapFault_ptr_get_Addr(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
 
-    ret = (seL4_Fault_ptr->words[6] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[6] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -266,10 +266,10 @@ seL4_Fault_CapFault_ptr_set_Addr(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 v64) 
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[6] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[6] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[6] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[6] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -278,9 +278,9 @@ seL4_Fault_CapFault_get_InRecvPhase(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
 
-    ret = (seL4_Fault.words[5] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[5] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -291,10 +291,10 @@ seL4_Fault_CapFault_set_InRecvPhase(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[5] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[5] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[5] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[5] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -304,9 +304,9 @@ seL4_Fault_CapFault_ptr_get_InRecvPhase(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
 
-    ret = (seL4_Fault_ptr->words[5] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[5] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -318,10 +318,10 @@ seL4_Fault_CapFault_ptr_set_InRecvPhase(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint6
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[5] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[5] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[5] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[5] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -330,9 +330,9 @@ seL4_Fault_CapFault_get_LookupFailureType(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
 
-    ret = (seL4_Fault.words[4] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[4] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -343,10 +343,10 @@ seL4_Fault_CapFault_set_LookupFailureType(seL4_Fault_t seL4_Fault, seL4_Uint64 v
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[4] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[4] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[4] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[4] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -356,9 +356,9 @@ seL4_Fault_CapFault_ptr_get_LookupFailureType(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
 
-    ret = (seL4_Fault_ptr->words[4] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[4] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -370,10 +370,10 @@ seL4_Fault_CapFault_ptr_set_LookupFailureType(seL4_Fault_t *seL4_Fault_ptr, seL4
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[4] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[4] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[4] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[4] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -382,9 +382,9 @@ seL4_Fault_CapFault_get_MR4(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
 
-    ret = (seL4_Fault.words[3] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[3] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -395,10 +395,10 @@ seL4_Fault_CapFault_set_MR4(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[3] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[3] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[3] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[3] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -408,9 +408,9 @@ seL4_Fault_CapFault_ptr_get_MR4(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
 
-    ret = (seL4_Fault_ptr->words[3] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[3] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -422,10 +422,10 @@ seL4_Fault_CapFault_ptr_set_MR4(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 v64) {
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[3] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[3] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[3] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[3] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -434,9 +434,9 @@ seL4_Fault_CapFault_get_MR5(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
 
-    ret = (seL4_Fault.words[2] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[2] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -447,10 +447,10 @@ seL4_Fault_CapFault_set_MR5(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[2] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[2] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[2] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[2] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -460,9 +460,9 @@ seL4_Fault_CapFault_ptr_get_MR5(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
 
-    ret = (seL4_Fault_ptr->words[2] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[2] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -474,10 +474,10 @@ seL4_Fault_CapFault_ptr_set_MR5(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 v64) {
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[2] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[2] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[2] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[2] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -486,9 +486,9 @@ seL4_Fault_CapFault_get_MR6(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
 
-    ret = (seL4_Fault.words[1] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[1] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -499,10 +499,10 @@ seL4_Fault_CapFault_set_MR6(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[1] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[1] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[1] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[1] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -512,9 +512,9 @@ seL4_Fault_CapFault_ptr_get_MR6(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
 
-    ret = (seL4_Fault_ptr->words[1] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[1] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -526,10 +526,10 @@ seL4_Fault_CapFault_ptr_set_MR6(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 v64) {
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_CapFault);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[1] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[1] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[1] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[1] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Fault_t CONST
@@ -537,10 +537,10 @@ seL4_Fault_UnknownSyscall_new(seL4_Uint64 RAX, seL4_Uint64 RBX, seL4_Uint64 RCX,
     seL4_Fault_t seL4_Fault;
 
     /* fail if user has passed bits that we will override */  
-    seL4_DebugAssert(((seL4_Uint64)seL4_Fault_UnknownSyscall & ~0xfull) == ((0 && ((seL4_Uint64)seL4_Fault_UnknownSyscall & (1ull << 63))) ? 0x0 : 0));
+    seL4_DebugAssert(((seL4_Uint64)seL4_Fault_UnknownSyscall & ~ULL_CONST(0xf)) == ((0 && ((seL4_Uint64)seL4_Fault_UnknownSyscall & (ULL_CONST(1) << 63))) ? 0x0 : 0));
 
     seL4_Fault.words[0] = 0
-        | ((seL4_Uint64)seL4_Fault_UnknownSyscall & 0xfull) << 0;
+        | ((seL4_Uint64)seL4_Fault_UnknownSyscall & ULL_CONST(0xf)) << 0;
     seL4_Fault.words[1] = 0
         | Syscall << 0;
     seL4_Fault.words[2] = 0
@@ -586,10 +586,10 @@ seL4_Fault_UnknownSyscall_new(seL4_Uint64 RAX, seL4_Uint64 RBX, seL4_Uint64 RCX,
 LIBSEL4_INLINE_FUNC void
 seL4_Fault_UnknownSyscall_ptr_new(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 RAX, seL4_Uint64 RBX, seL4_Uint64 RCX, seL4_Uint64 RDX, seL4_Uint64 RSI, seL4_Uint64 RDI, seL4_Uint64 RBP, seL4_Uint64 R8, seL4_Uint64 R9, seL4_Uint64 R10, seL4_Uint64 R11, seL4_Uint64 R12, seL4_Uint64 R13, seL4_Uint64 R14, seL4_Uint64 R15, seL4_Uint64 FaultIP, seL4_Uint64 RSP, seL4_Uint64 FLAGS, seL4_Uint64 Syscall) {
     /* fail if user has passed bits that we will override */  
-    seL4_DebugAssert(((seL4_Uint64)seL4_Fault_UnknownSyscall & ~0xfull) == ((0 && ((seL4_Uint64)seL4_Fault_UnknownSyscall & (1ull << 63))) ? 0x0 : 0));
+    seL4_DebugAssert(((seL4_Uint64)seL4_Fault_UnknownSyscall & ~ULL_CONST(0xf)) == ((0 && ((seL4_Uint64)seL4_Fault_UnknownSyscall & (ULL_CONST(1) << 63))) ? 0x0 : 0));
 
     seL4_Fault_ptr->words[0] = 0
-        | ((seL4_Uint64)seL4_Fault_UnknownSyscall & 0xfull) << 0;
+        | ((seL4_Uint64)seL4_Fault_UnknownSyscall & ULL_CONST(0xf)) << 0;
     seL4_Fault_ptr->words[1] = 0
         | Syscall << 0;
     seL4_Fault_ptr->words[2] = 0
@@ -636,9 +636,9 @@ seL4_Fault_UnknownSyscall_get_RAX(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault.words[19] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[19] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -649,10 +649,10 @@ seL4_Fault_UnknownSyscall_set_RAX(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[19] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[19] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[19] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[19] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -662,9 +662,9 @@ seL4_Fault_UnknownSyscall_ptr_get_RAX(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault_ptr->words[19] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[19] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -676,10 +676,10 @@ seL4_Fault_UnknownSyscall_ptr_set_RAX(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[19] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[19] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[19] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[19] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -688,9 +688,9 @@ seL4_Fault_UnknownSyscall_get_RBX(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault.words[18] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[18] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -701,10 +701,10 @@ seL4_Fault_UnknownSyscall_set_RBX(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[18] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[18] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[18] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[18] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -714,9 +714,9 @@ seL4_Fault_UnknownSyscall_ptr_get_RBX(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault_ptr->words[18] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[18] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -728,10 +728,10 @@ seL4_Fault_UnknownSyscall_ptr_set_RBX(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[18] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[18] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[18] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[18] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -740,9 +740,9 @@ seL4_Fault_UnknownSyscall_get_RCX(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault.words[17] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[17] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -753,10 +753,10 @@ seL4_Fault_UnknownSyscall_set_RCX(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[17] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[17] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[17] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[17] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -766,9 +766,9 @@ seL4_Fault_UnknownSyscall_ptr_get_RCX(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault_ptr->words[17] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[17] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -780,10 +780,10 @@ seL4_Fault_UnknownSyscall_ptr_set_RCX(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[17] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[17] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[17] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[17] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -792,9 +792,9 @@ seL4_Fault_UnknownSyscall_get_RDX(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault.words[16] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[16] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -805,10 +805,10 @@ seL4_Fault_UnknownSyscall_set_RDX(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[16] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[16] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[16] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[16] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -818,9 +818,9 @@ seL4_Fault_UnknownSyscall_ptr_get_RDX(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault_ptr->words[16] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[16] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -832,10 +832,10 @@ seL4_Fault_UnknownSyscall_ptr_set_RDX(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[16] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[16] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[16] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[16] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -844,9 +844,9 @@ seL4_Fault_UnknownSyscall_get_RSI(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault.words[15] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[15] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -857,10 +857,10 @@ seL4_Fault_UnknownSyscall_set_RSI(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[15] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[15] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[15] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[15] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -870,9 +870,9 @@ seL4_Fault_UnknownSyscall_ptr_get_RSI(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault_ptr->words[15] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[15] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -884,10 +884,10 @@ seL4_Fault_UnknownSyscall_ptr_set_RSI(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[15] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[15] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[15] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[15] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -896,9 +896,9 @@ seL4_Fault_UnknownSyscall_get_RDI(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault.words[14] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[14] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -909,10 +909,10 @@ seL4_Fault_UnknownSyscall_set_RDI(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[14] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[14] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[14] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[14] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -922,9 +922,9 @@ seL4_Fault_UnknownSyscall_ptr_get_RDI(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault_ptr->words[14] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[14] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -936,10 +936,10 @@ seL4_Fault_UnknownSyscall_ptr_set_RDI(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[14] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[14] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[14] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[14] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -948,9 +948,9 @@ seL4_Fault_UnknownSyscall_get_RBP(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault.words[13] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[13] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -961,10 +961,10 @@ seL4_Fault_UnknownSyscall_set_RBP(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[13] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[13] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[13] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[13] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -974,9 +974,9 @@ seL4_Fault_UnknownSyscall_ptr_get_RBP(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault_ptr->words[13] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[13] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -988,10 +988,10 @@ seL4_Fault_UnknownSyscall_ptr_set_RBP(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[13] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[13] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[13] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[13] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -1000,9 +1000,9 @@ seL4_Fault_UnknownSyscall_get_R8(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault.words[12] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[12] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1013,10 +1013,10 @@ seL4_Fault_UnknownSyscall_set_R8(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[12] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[12] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[12] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[12] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -1026,9 +1026,9 @@ seL4_Fault_UnknownSyscall_ptr_get_R8(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault_ptr->words[12] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[12] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1040,10 +1040,10 @@ seL4_Fault_UnknownSyscall_ptr_set_R8(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 v
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[12] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[12] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[12] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[12] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -1052,9 +1052,9 @@ seL4_Fault_UnknownSyscall_get_R9(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault.words[11] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[11] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1065,10 +1065,10 @@ seL4_Fault_UnknownSyscall_set_R9(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[11] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[11] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[11] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[11] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -1078,9 +1078,9 @@ seL4_Fault_UnknownSyscall_ptr_get_R9(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault_ptr->words[11] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[11] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1092,10 +1092,10 @@ seL4_Fault_UnknownSyscall_ptr_set_R9(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 v
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[11] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[11] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[11] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[11] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -1104,9 +1104,9 @@ seL4_Fault_UnknownSyscall_get_R10(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault.words[10] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[10] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1117,10 +1117,10 @@ seL4_Fault_UnknownSyscall_set_R10(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[10] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[10] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[10] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[10] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -1130,9 +1130,9 @@ seL4_Fault_UnknownSyscall_ptr_get_R10(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault_ptr->words[10] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[10] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1144,10 +1144,10 @@ seL4_Fault_UnknownSyscall_ptr_set_R10(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[10] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[10] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[10] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[10] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -1156,9 +1156,9 @@ seL4_Fault_UnknownSyscall_get_R11(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault.words[9] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[9] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1169,10 +1169,10 @@ seL4_Fault_UnknownSyscall_set_R11(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[9] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[9] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[9] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[9] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -1182,9 +1182,9 @@ seL4_Fault_UnknownSyscall_ptr_get_R11(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault_ptr->words[9] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[9] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1196,10 +1196,10 @@ seL4_Fault_UnknownSyscall_ptr_set_R11(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[9] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[9] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[9] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[9] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -1208,9 +1208,9 @@ seL4_Fault_UnknownSyscall_get_R12(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault.words[8] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[8] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1221,10 +1221,10 @@ seL4_Fault_UnknownSyscall_set_R12(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[8] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[8] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[8] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[8] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -1234,9 +1234,9 @@ seL4_Fault_UnknownSyscall_ptr_get_R12(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault_ptr->words[8] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[8] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1248,10 +1248,10 @@ seL4_Fault_UnknownSyscall_ptr_set_R12(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[8] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[8] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[8] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[8] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -1260,9 +1260,9 @@ seL4_Fault_UnknownSyscall_get_R13(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault.words[7] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[7] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1273,10 +1273,10 @@ seL4_Fault_UnknownSyscall_set_R13(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[7] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[7] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[7] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[7] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -1286,9 +1286,9 @@ seL4_Fault_UnknownSyscall_ptr_get_R13(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault_ptr->words[7] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[7] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1300,10 +1300,10 @@ seL4_Fault_UnknownSyscall_ptr_set_R13(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[7] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[7] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[7] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[7] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -1312,9 +1312,9 @@ seL4_Fault_UnknownSyscall_get_R14(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault.words[6] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[6] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1325,10 +1325,10 @@ seL4_Fault_UnknownSyscall_set_R14(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[6] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[6] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[6] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[6] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -1338,9 +1338,9 @@ seL4_Fault_UnknownSyscall_ptr_get_R14(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault_ptr->words[6] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[6] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1352,10 +1352,10 @@ seL4_Fault_UnknownSyscall_ptr_set_R14(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[6] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[6] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[6] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[6] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -1364,9 +1364,9 @@ seL4_Fault_UnknownSyscall_get_R15(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault.words[5] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[5] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1377,10 +1377,10 @@ seL4_Fault_UnknownSyscall_set_R15(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[5] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[5] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[5] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[5] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -1390,9 +1390,9 @@ seL4_Fault_UnknownSyscall_ptr_get_R15(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault_ptr->words[5] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[5] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1404,10 +1404,10 @@ seL4_Fault_UnknownSyscall_ptr_set_R15(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[5] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[5] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[5] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[5] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -1416,9 +1416,9 @@ seL4_Fault_UnknownSyscall_get_FaultIP(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault.words[4] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[4] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1429,10 +1429,10 @@ seL4_Fault_UnknownSyscall_set_FaultIP(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) 
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[4] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[4] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[4] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[4] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -1442,9 +1442,9 @@ seL4_Fault_UnknownSyscall_ptr_get_FaultIP(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault_ptr->words[4] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[4] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1456,10 +1456,10 @@ seL4_Fault_UnknownSyscall_ptr_set_FaultIP(seL4_Fault_t *seL4_Fault_ptr, seL4_Uin
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[4] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[4] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[4] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[4] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -1468,9 +1468,9 @@ seL4_Fault_UnknownSyscall_get_RSP(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault.words[3] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[3] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1481,10 +1481,10 @@ seL4_Fault_UnknownSyscall_set_RSP(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[3] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[3] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[3] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[3] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -1494,9 +1494,9 @@ seL4_Fault_UnknownSyscall_ptr_get_RSP(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault_ptr->words[3] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[3] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1508,10 +1508,10 @@ seL4_Fault_UnknownSyscall_ptr_set_RSP(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[3] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[3] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[3] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[3] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -1520,9 +1520,9 @@ seL4_Fault_UnknownSyscall_get_FLAGS(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault.words[2] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[2] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1533,10 +1533,10 @@ seL4_Fault_UnknownSyscall_set_FLAGS(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[2] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[2] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[2] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[2] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -1546,9 +1546,9 @@ seL4_Fault_UnknownSyscall_ptr_get_FLAGS(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault_ptr->words[2] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[2] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1560,10 +1560,10 @@ seL4_Fault_UnknownSyscall_ptr_set_FLAGS(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint6
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[2] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[2] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[2] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[2] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -1572,9 +1572,9 @@ seL4_Fault_UnknownSyscall_get_Syscall(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault.words[1] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[1] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1585,10 +1585,10 @@ seL4_Fault_UnknownSyscall_set_Syscall(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) 
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[1] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[1] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[1] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[1] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -1598,9 +1598,9 @@ seL4_Fault_UnknownSyscall_ptr_get_Syscall(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
-    ret = (seL4_Fault_ptr->words[1] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[1] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1612,10 +1612,10 @@ seL4_Fault_UnknownSyscall_ptr_set_Syscall(seL4_Fault_t *seL4_Fault_ptr, seL4_Uin
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UnknownSyscall);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[1] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[1] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[1] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[1] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Fault_t CONST
@@ -1623,10 +1623,10 @@ seL4_Fault_UserException_new(seL4_Uint64 FaultIP, seL4_Uint64 Stack, seL4_Uint64
     seL4_Fault_t seL4_Fault;
 
     /* fail if user has passed bits that we will override */  
-    seL4_DebugAssert(((seL4_Uint64)seL4_Fault_UserException & ~0xfull) == ((0 && ((seL4_Uint64)seL4_Fault_UserException & (1ull << 63))) ? 0x0 : 0));
+    seL4_DebugAssert(((seL4_Uint64)seL4_Fault_UserException & ~ULL_CONST(0xf)) == ((0 && ((seL4_Uint64)seL4_Fault_UserException & (ULL_CONST(1) << 63))) ? 0x0 : 0));
 
     seL4_Fault.words[0] = 0
-        | ((seL4_Uint64)seL4_Fault_UserException & 0xfull) << 0;
+        | ((seL4_Uint64)seL4_Fault_UserException & ULL_CONST(0xf)) << 0;
     seL4_Fault.words[1] = 0
         | Code << 0;
     seL4_Fault.words[2] = 0
@@ -1658,10 +1658,10 @@ seL4_Fault_UserException_new(seL4_Uint64 FaultIP, seL4_Uint64 Stack, seL4_Uint64
 LIBSEL4_INLINE_FUNC void
 seL4_Fault_UserException_ptr_new(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 FaultIP, seL4_Uint64 Stack, seL4_Uint64 FLAGS, seL4_Uint64 Number, seL4_Uint64 Code) {
     /* fail if user has passed bits that we will override */  
-    seL4_DebugAssert(((seL4_Uint64)seL4_Fault_UserException & ~0xfull) == ((0 && ((seL4_Uint64)seL4_Fault_UserException & (1ull << 63))) ? 0x0 : 0));
+    seL4_DebugAssert(((seL4_Uint64)seL4_Fault_UserException & ~ULL_CONST(0xf)) == ((0 && ((seL4_Uint64)seL4_Fault_UserException & (ULL_CONST(1) << 63))) ? 0x0 : 0));
 
     seL4_Fault_ptr->words[0] = 0
-        | ((seL4_Uint64)seL4_Fault_UserException & 0xfull) << 0;
+        | ((seL4_Uint64)seL4_Fault_UserException & ULL_CONST(0xf)) << 0;
     seL4_Fault_ptr->words[1] = 0
         | Code << 0;
     seL4_Fault_ptr->words[2] = 0
@@ -1694,9 +1694,9 @@ seL4_Fault_UserException_get_FaultIP(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UserException);
 
-    ret = (seL4_Fault.words[5] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[5] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1707,10 +1707,10 @@ seL4_Fault_UserException_set_FaultIP(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UserException);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[5] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[5] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[5] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[5] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -1720,9 +1720,9 @@ seL4_Fault_UserException_ptr_get_FaultIP(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UserException);
 
-    ret = (seL4_Fault_ptr->words[5] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[5] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1734,10 +1734,10 @@ seL4_Fault_UserException_ptr_set_FaultIP(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UserException);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[5] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[5] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[5] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[5] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -1746,9 +1746,9 @@ seL4_Fault_UserException_get_Stack(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UserException);
 
-    ret = (seL4_Fault.words[4] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[4] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1759,10 +1759,10 @@ seL4_Fault_UserException_set_Stack(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UserException);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[4] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[4] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[4] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[4] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -1772,9 +1772,9 @@ seL4_Fault_UserException_ptr_get_Stack(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UserException);
 
-    ret = (seL4_Fault_ptr->words[4] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[4] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1786,10 +1786,10 @@ seL4_Fault_UserException_ptr_set_Stack(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UserException);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[4] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[4] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[4] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[4] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -1798,9 +1798,9 @@ seL4_Fault_UserException_get_FLAGS(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UserException);
 
-    ret = (seL4_Fault.words[3] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[3] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1811,10 +1811,10 @@ seL4_Fault_UserException_set_FLAGS(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UserException);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[3] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[3] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[3] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[3] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -1824,9 +1824,9 @@ seL4_Fault_UserException_ptr_get_FLAGS(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UserException);
 
-    ret = (seL4_Fault_ptr->words[3] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[3] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1838,10 +1838,10 @@ seL4_Fault_UserException_ptr_set_FLAGS(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UserException);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[3] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[3] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[3] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[3] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -1850,9 +1850,9 @@ seL4_Fault_UserException_get_Number(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UserException);
 
-    ret = (seL4_Fault.words[2] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[2] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1863,10 +1863,10 @@ seL4_Fault_UserException_set_Number(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UserException);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[2] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[2] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[2] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[2] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -1876,9 +1876,9 @@ seL4_Fault_UserException_ptr_get_Number(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UserException);
 
-    ret = (seL4_Fault_ptr->words[2] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[2] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1890,10 +1890,10 @@ seL4_Fault_UserException_ptr_set_Number(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint6
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UserException);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[2] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[2] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[2] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[2] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -1902,9 +1902,9 @@ seL4_Fault_UserException_get_Code(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UserException);
 
-    ret = (seL4_Fault.words[1] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[1] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1915,10 +1915,10 @@ seL4_Fault_UserException_set_Code(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_UserException);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[1] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[1] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[1] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[1] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -1928,9 +1928,9 @@ seL4_Fault_UserException_ptr_get_Code(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UserException);
 
-    ret = (seL4_Fault_ptr->words[1] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[1] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -1942,10 +1942,10 @@ seL4_Fault_UserException_ptr_set_Code(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_UserException);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[1] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[1] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[1] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[1] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Fault_t CONST
@@ -1953,10 +1953,10 @@ seL4_Fault_VMFault_new(seL4_Uint64 IP, seL4_Uint64 Addr, seL4_Uint64 PrefetchFau
     seL4_Fault_t seL4_Fault;
 
     /* fail if user has passed bits that we will override */  
-    seL4_DebugAssert(((seL4_Uint64)seL4_Fault_VMFault & ~0xfull) == ((0 && ((seL4_Uint64)seL4_Fault_VMFault & (1ull << 63))) ? 0x0 : 0));
+    seL4_DebugAssert(((seL4_Uint64)seL4_Fault_VMFault & ~ULL_CONST(0xf)) == ((0 && ((seL4_Uint64)seL4_Fault_VMFault & (ULL_CONST(1) << 63))) ? 0x0 : 0));
 
     seL4_Fault.words[0] = 0
-        | ((seL4_Uint64)seL4_Fault_VMFault & 0xfull) << 0;
+        | ((seL4_Uint64)seL4_Fault_VMFault & ULL_CONST(0xf)) << 0;
     seL4_Fault.words[1] = 0
         | FSR << 0;
     seL4_Fault.words[2] = 0
@@ -1987,10 +1987,10 @@ seL4_Fault_VMFault_new(seL4_Uint64 IP, seL4_Uint64 Addr, seL4_Uint64 PrefetchFau
 LIBSEL4_INLINE_FUNC void
 seL4_Fault_VMFault_ptr_new(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 IP, seL4_Uint64 Addr, seL4_Uint64 PrefetchFault, seL4_Uint64 FSR) {
     /* fail if user has passed bits that we will override */  
-    seL4_DebugAssert(((seL4_Uint64)seL4_Fault_VMFault & ~0xfull) == ((0 && ((seL4_Uint64)seL4_Fault_VMFault & (1ull << 63))) ? 0x0 : 0));
+    seL4_DebugAssert(((seL4_Uint64)seL4_Fault_VMFault & ~ULL_CONST(0xf)) == ((0 && ((seL4_Uint64)seL4_Fault_VMFault & (ULL_CONST(1) << 63))) ? 0x0 : 0));
 
     seL4_Fault_ptr->words[0] = 0
-        | ((seL4_Uint64)seL4_Fault_VMFault & 0xfull) << 0;
+        | ((seL4_Uint64)seL4_Fault_VMFault & ULL_CONST(0xf)) << 0;
     seL4_Fault_ptr->words[1] = 0
         | FSR << 0;
     seL4_Fault_ptr->words[2] = 0
@@ -2022,9 +2022,9 @@ seL4_Fault_VMFault_get_IP(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_VMFault);
 
-    ret = (seL4_Fault.words[4] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[4] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2035,10 +2035,10 @@ seL4_Fault_VMFault_set_IP(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_VMFault);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[4] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[4] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[4] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[4] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -2048,9 +2048,9 @@ seL4_Fault_VMFault_ptr_get_IP(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_VMFault);
 
-    ret = (seL4_Fault_ptr->words[4] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[4] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2062,10 +2062,10 @@ seL4_Fault_VMFault_ptr_set_IP(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 v64) {
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_VMFault);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[4] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[4] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[4] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[4] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -2074,9 +2074,9 @@ seL4_Fault_VMFault_get_Addr(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_VMFault);
 
-    ret = (seL4_Fault.words[3] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[3] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2087,10 +2087,10 @@ seL4_Fault_VMFault_set_Addr(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_VMFault);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[3] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[3] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[3] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[3] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -2100,9 +2100,9 @@ seL4_Fault_VMFault_ptr_get_Addr(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_VMFault);
 
-    ret = (seL4_Fault_ptr->words[3] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[3] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2114,10 +2114,10 @@ seL4_Fault_VMFault_ptr_set_Addr(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 v64) {
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_VMFault);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[3] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[3] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[3] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[3] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -2126,9 +2126,9 @@ seL4_Fault_VMFault_get_PrefetchFault(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_VMFault);
 
-    ret = (seL4_Fault.words[2] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[2] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2139,10 +2139,10 @@ seL4_Fault_VMFault_set_PrefetchFault(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_VMFault);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[2] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[2] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[2] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[2] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -2152,9 +2152,9 @@ seL4_Fault_VMFault_ptr_get_PrefetchFault(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_VMFault);
 
-    ret = (seL4_Fault_ptr->words[2] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[2] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2166,10 +2166,10 @@ seL4_Fault_VMFault_ptr_set_PrefetchFault(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_VMFault);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[2] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[2] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[2] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[2] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 
 LIBSEL4_INLINE_FUNC seL4_Uint64 CONST
@@ -2178,9 +2178,9 @@ seL4_Fault_VMFault_get_FSR(seL4_Fault_t seL4_Fault) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_VMFault);
 
-    ret = (seL4_Fault.words[1] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault.words[1] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2191,10 +2191,10 @@ seL4_Fault_VMFault_set_FSR(seL4_Fault_t seL4_Fault, seL4_Uint64 v64) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault.words[0] >> 0) & 0xf) == seL4_Fault_VMFault);
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0 ) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0 ) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault.words[1] &= ~0xffffffffffffffffull;
-    seL4_Fault.words[1] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault.words[1] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault.words[1] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
     return seL4_Fault;
 }
 
@@ -2204,9 +2204,9 @@ seL4_Fault_VMFault_ptr_get_FSR(seL4_Fault_t *seL4_Fault_ptr) {
     /* fail if union does not have the expected tag */
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_VMFault);
 
-    ret = (seL4_Fault_ptr->words[1] & 0xffffffffffffffffull) >> 0;
+    ret = (seL4_Fault_ptr->words[1] & ULL_CONST(0xffffffffffffffff)) >> 0;
     /* Possibly sign extend */
-    if (__builtin_expect(!!(0 && (ret & (1ull << (63)))), 0)) {
+    if (__builtin_expect(!!(0 && (ret & (ULL_CONST(1) << (63)))), 0)) {
         ret |= 0x0;
     }
     return ret;
@@ -2218,9 +2218,9 @@ seL4_Fault_VMFault_ptr_set_FSR(seL4_Fault_t *seL4_Fault_ptr, seL4_Uint64 v64) {
     seL4_DebugAssert(((seL4_Fault_ptr->words[0] >> 0) & 0xf) == seL4_Fault_VMFault);
 
     /* fail if user has passed bits that we will override */
-    seL4_DebugAssert((((~0xffffffffffffffffull >> 0) | 0x0) & v64) == ((0 && (v64 & (1ull << (63)))) ? 0x0 : 0));
+    seL4_DebugAssert((((~ULL_CONST(0xffffffffffffffff) >> 0) | 0x0) & v64) == ((0 && (v64 & (ULL_CONST(1) << (63)))) ? 0x0 : 0));
 
-    seL4_Fault_ptr->words[1] &= ~0xffffffffffffffffull;
-    seL4_Fault_ptr->words[1] |= (v64 << 0) & 0xffffffffffffffffull;
+    seL4_Fault_ptr->words[1] &= ~ULL_CONST(0xffffffffffffffff);
+    seL4_Fault_ptr->words[1] |= (v64 << 0) & ULL_CONST(0xffffffffffffffff);
 }
 

--- a/preconfigured/include/arch/x86/arch/64/mode/fastpath/fastpath.h
+++ b/preconfigured/include/arch/x86/arch/64/mode/fastpath/fastpath.h
@@ -24,7 +24,7 @@
 
 static inline tcb_t *endpoint_ptr_get_epQueue_tail_fp(endpoint_t *ep_ptr)
 {
-    uint64_t ret = ep_ptr->words[0] & 0xfffffffffffcull;
+    uint64_t ret = ep_ptr->words[0] & ULL_CONST(0xfffffffffffc);
     return unlikely(ret) ? TCB_PTR(ret | PPTR_BASE) : NULL;
 }
 

--- a/preconfigured/include/arch/x86/arch/machine.h
+++ b/preconfigured/include/arch/x86/arch/machine.h
@@ -12,6 +12,7 @@
 #include <arch/machine/hardware.h>
 #include <arch/machine/pat.h>
 #include <arch/machine/cpu_registers.h>
+#include <util.h>
 #include <model/statedata.h>
 #include <arch/model/statedata.h>
 #include <object/interrupt.h>
@@ -117,7 +118,7 @@ static inline uint32_t x86_rdmsr_low(const uint32_t reg)
 
 static inline uint32_t x86_rdmsr_high(const uint32_t reg)
 {
-    return (uint32_t)(x86_rdmsr(reg) >> 32ull);
+    return (uint32_t)(x86_rdmsr(reg) >> ULL_CONST(32));
 }
 
 /* Write model specific register */
@@ -193,7 +194,7 @@ static inline uint64_t x86_rdtsc(void)
                  : "=a"(lo),
                  "=d"(hi)
                 );
-    return ((uint64_t) hi) << 32llu | (uint64_t) lo;
+    return ((uint64_t) hi) << ULL_CONST(32) | (uint64_t) lo;
 }
 
 #ifdef ENABLE_SMP_SUPPORT

--- a/preconfigured/include/util.h
+++ b/preconfigured/include/util.h
@@ -8,6 +8,10 @@
 
 #include <compiler.h>
 
+#ifndef __ASSEMBLER__
+#include <config.h>
+#endif
+
 #define PASTE(a, b) a ## b
 #define _STRINGIFY(a) #a
 #define STRINGIFY(a) _STRINGIFY(a)
@@ -21,6 +25,7 @@
  * this, as the suffix is only applied when the C compiler is used and dropped
  * when the assembler runs.
  */
+
 #define UL_CONST(x) x
 #define ULL_CONST(x) x
 #define NULL 0
@@ -32,8 +37,13 @@
  * printf() format specifiers, '%lu' is the only form that is supported. Thus
  * 'ul' is the preferred suffix to avoid confusion.
  */
+#if CONFIG_WORD_SIZE == 64
+#define UL_CONST(x) PASTE(x, ul)
+#define ULL_CONST(x) PASTE(x, ul)
+#else
 #define UL_CONST(x) PASTE(x, ul)
 #define ULL_CONST(x) PASTE(x, llu)
+#endif
 #define NULL ((void *)0)
 
 #endif /* [not] __ASSEMBLER__ */

--- a/preconfigured/libsel4/include/sel4/macros.h
+++ b/preconfigured/libsel4/include/sel4/macros.h
@@ -9,6 +9,38 @@
 #include <sel4/config.h>
 #include <sel4/compiler.h>
 
+#ifndef SEL4_PASTE
+#define SEL4_PASTE(a, b) a ## b
+#endif
+
+#ifndef SEL4_STRINGIFY_HELPER
+#define SEL4_STRINGIFY_HELPER(x) #x
+#endif
+
+#ifndef SEL4_STRINGIFY
+#define SEL4_STRINGIFY(x) SEL4_STRINGIFY_HELPER(x)
+#endif
+
+#ifdef __ASSEMBLER__
+#ifndef UL_CONST
+#define UL_CONST(x) x
+#endif
+#ifndef ULL_CONST
+#define ULL_CONST(x) x
+#endif
+#else
+#ifndef UL_CONST
+#define UL_CONST(x) SEL4_PASTE(x, ul)
+#endif
+#ifndef ULL_CONST
+#if CONFIG_WORD_SIZE == 64
+#define ULL_CONST(x) SEL4_PASTE(x, ul)
+#else
+#define ULL_CONST(x) SEL4_PASTE(x, llu)
+#endif
+#endif
+#endif
+
 #ifndef CONST
 #define CONST   SEL4_CONST_ATTR
 #endif

--- a/preconfigured/src/arch/x86/kernel/apic.c
+++ b/preconfigured/src/arch/x86/kernel/apic.c
@@ -59,7 +59,7 @@ BOOT_CODE bool_t apic_init(bool_t mask_legacy_irqs)
     uint32_t cpuid = x86_cpuid_ecx(0x1, 0x0);
     if (!(cpuid & BIT(CPUID_TSC_DEADLINE_BIT))) {
         apic_khz = apic_measure_freq();
-        x86KSapicRatio = div64((uint64_t)x86KStscMhz * 1000llu, apic_khz);
+        x86KSapicRatio = div64((uint64_t)x86KStscMhz * ULL_CONST(1000), apic_khz);
         printf("Apic Khz %lu, TSC Mhz %lu, ratio %lu\n", (long) apic_khz, (long) x86KStscMhz, (long) x86KSapicRatio);
     } else {
         /* use tsc deadline mode */

--- a/preconfigured/src/plat/pc99/machine/intel-vtd.c
+++ b/preconfigured/src/plat/pc99/machine/intel-vtd.c
@@ -150,7 +150,7 @@ void invalidate_context_cache(void)
         /* Program CIRG for Global Invalidation by setting bit 61 which
          * will be bit 29 in upper 32 bits of CCMD_REG
          */
-        ccmd = ((uint64_t)CONTEXT_GLOBAL_INVALIDATE << CIRG) | (1ull << ICC);
+        ccmd = ((uint64_t)CONTEXT_GLOBAL_INVALIDATE << CIRG) | (ULL_CONST(1) << ICC);
 
         /* Invalidate Context Cache */
         vtd_write64(i, CCMD_REG, ccmd);


### PR DESCRIPTION
## Summary
- teach the kernel and libsel4 constant helpers to include configuration data so 64-bit builds avoid `long long` suffixes
- regenerate the capability helper headers and libsel4 stubs to use `ULL_CONST` instead of raw `ULL` literals
- switch the remaining x86 machine helpers to the portable macros and document the newly surfaced C90 blockers

## Testing
- `./preconfigured/replay_preconfigured_build.sh` *(fails: strict C90 build still reports additional diagnostics)*

------
https://chatgpt.com/codex/tasks/task_e_68d33aa753e8832bbf91f67ba62b23a7