### PR TITLE
Guard shared seL4 typedefs with a common macro

### DIFF
--- a/C89-PROJECT.md
+++ b/C89-PROJECT.md
@@ -51,10 +51,11 @@ resulting compiler diagnostics.
    statement under the stricter warning set.
    - *Potential remedies*: add explicit returns or refactor the control flow so
      that the compiler can prove a value is always produced.
-6. **Kernel/libsel4 type duplication**: both the kernel headers and
-   `libsel4` publish typedefs for the fundamental seL4 types. Under pedantic
-   C90 the duplicate definitions are treated as hard errors, so we need a
-   single canonical provider.
+6. **Kernel/libsel4 type duplication** *(resolved)*: both the kernel headers
+   and `libsel4` published typedefs for the fundamental seL4 types. Under
+   pedantic C90 the duplicate definitions were treated as hard errors. We now
+   gate the typedef blocks behind a shared `SEL4_BASIC_TYPES_DEFINED` marker so
+   only the first header included in a translation unit defines the aliases.
 7. **Enumeration and macro hygiene**: verification-oriented macros such as
    `SEL4_SIZE_SANITY` and `SEL4_FORCE_LONG_ENUM` expand to trailing semicolons,
    large enumerator values, and dangling commas. GCC accepts these under
@@ -70,8 +71,11 @@ resulting compiler diagnostics.
   - [x] Drop the C++-style comments emitted in the generated wrapper sources.
   - [x] Provide C89-friendly definitions for the 64-bit typedefs and helpers in
         `stdint.h`/`util.h` so they no longer rely on `long long`.
-  - Resolve the duplicated seL4 basic types between `simple_types.h` and the
-    shared kernel headers.
+  - [x] Resolve the duplicated seL4 basic types between `simple_types.h` and
+        the shared kernel headers by coordinating on a shared
+        `SEL4_BASIC_TYPES_DEFINED` guard.
+  - [ ] Replace the configuration helpers in `util.h` that rely on anonymous
+        variadic macros with C89-compatible shims.
 - Rework the PC99 interrupt helpers so that the generated statements avoid
   declaration-after-statement issues and variadic macro misuse under strict C90.
 - Audit architecture helpers for unused parameters and modern inline idioms

--- a/preconfigured/include/basic_types.h
+++ b/preconfigured/include/basic_types.h
@@ -78,12 +78,15 @@ typedef struct v_region {
  * any other type (similar to a char pointer) */
 typedef word_t SEL4_MAY_ALIAS_ATTR word_t_may_alias;
 
+#ifndef SEL4_BASIC_TYPES_DEFINED
 /* for libsel4 headers that the kernel shares */
 typedef uint8_t seL4_Uint8;
 typedef uint16_t seL4_Uint16;
 typedef uint32_t seL4_Uint32;
 typedef word_t seL4_Word;
 typedef cptr_t seL4_CPtr;
+#define SEL4_BASIC_TYPES_DEFINED 1
+#endif
 typedef node_id_t seL4_NodeId;
 typedef paddr_t seL4_PAddr;
 typedef dom_t seL4_Domain;

--- a/preconfigured/libsel4/include/sel4/simple_types.h
+++ b/preconfigured/libsel4/include/sel4/simple_types.h
@@ -35,7 +35,9 @@
 /* C99 defines that this is at least 8-bit */
 #define _seL4_int8_type             char
 typedef signed _seL4_int8_type      seL4_Int8;
+#ifndef SEL4_BASIC_TYPES_DEFINED
 typedef unsigned _seL4_int8_type    seL4_Uint8;
+#endif
 
 seL4_integer_size_assert(seL4_Int8, 1)
 seL4_integer_size_assert(seL4_Uint8, 1)
@@ -47,7 +49,9 @@ seL4_integer_size_assert(seL4_Uint8, 1)
  */
 #define _seL4_int16_type            short int
 typedef signed _seL4_int16_type     seL4_Int16;
+#ifndef SEL4_BASIC_TYPES_DEFINED
 typedef unsigned _seL4_int16_type   seL4_Uint16;
+#endif
 
 seL4_integer_size_assert(seL4_Int16, 2)
 seL4_integer_size_assert(seL4_Uint16, 2)
@@ -58,7 +62,9 @@ seL4_integer_size_assert(seL4_Uint16, 2)
  * systems, so 'int' is 32-bits. */
 #define _seL4_int32_type            int
 typedef signed _seL4_int32_type     seL4_Int32;
+#ifndef SEL4_BASIC_TYPES_DEFINED
 typedef unsigned _seL4_int32_type   seL4_Uint32;
+#endif
 
 seL4_integer_size_assert(seL4_Int32, 4)
 seL4_integer_size_assert(seL4_Uint32, 4)
@@ -112,11 +118,19 @@ typedef seL4_Int8   seL4_Bool;
 
 /* Define seL4_Word */
 #if defined(SEL4_WORD_IS_UINT32)
+#ifndef SEL4_BASIC_TYPES_DEFINED
 typedef seL4_Uint32 seL4_Word;
+#endif
+#ifndef _seL4_word_fmt
 #define _seL4_word_fmt /* empty */
+#endif
 #elif defined(SEL4_WORD_IS_UINT64)
+#ifndef SEL4_BASIC_TYPES_DEFINED
 typedef seL4_Uint64 seL4_Word;
+#endif
+#ifndef _seL4_word_fmt
 #define _seL4_word_fmt _seL4_int64_fmt
+#endif
 #else
 #error missing definition for SEL4_WORD type
 #endif
@@ -127,7 +141,9 @@ typedef seL4_Uint64 seL4_Word;
 #define SEL4_PRIx_word  _macro_str_concat(_seL4_word_fmt, x)
 #define SEL4_PRI_word   SEL4_PRIu_word
 
+#ifndef SEL4_BASIC_TYPES_DEFINED
 typedef seL4_Word seL4_CPtr;
+#endif
 
 /* sanity check that the seL4_Word matches the definitions of the constants */
 #include <sel4/sel4_arch/constants.h>
@@ -139,3 +155,7 @@ SEL4_COMPILE_ASSERT(
 SEL4_COMPILE_ASSERT(
     seL4_WordBits_matches,
     8 * sizeof(seL4_Word) == seL4_WordBits)
+
+#ifndef SEL4_BASIC_TYPES_DEFINED
+#define SEL4_BASIC_TYPES_DEFINED 1
+#endif


### PR DESCRIPTION
## Summary
- guard the duplicated seL4 typedefs in `basic_types.h` and `libsel4` behind a shared `SEL4_BASIC_TYPES_DEFINED` flag so only one header defines them
- update `simple_types.h` to respect the new guard while still exporting formatting macros
- document the resolved duplication work and add a follow-up item for the variadic `util.h` helpers in `C89-PROJECT.md`

## Testing
- `./preconfigured/replay_preconfigured_build.sh` *(fails: strict C90 build still reports numerous diagnostics we need to address next)*

------
https://chatgpt.com/codex/tasks/task_e_68d341d14744832bba79e1ce3fc2984f