### PR TITLE
Replace config helpers with C89-safe shims

### DIFF
--- a/C89-PROJECT.md
+++ b/C89-PROJECT.md
@@ -17,6 +17,12 @@ resulting compiler diagnostics.
   - [x] Route the generated capability tables and x86 helpers through the new
     portable constant macros.
   - [ ] Address the remaining diagnostics reported by the strict build.
+    - [x] Replace the configuration helpers in `util.h` that relied on
+      anonymous variadic macros.
+    - [ ] Tidy the libsel4 size/enumeration assertion macros so they no longer
+      emit pedantic diagnostics under strict C90.
+    - [ ] Replace the remaining anonymous variadic logging helpers with
+      explicit C89-compatible shims.
 
 ## Build Attempt Summary
 - **Command**: `./preconfigured/replay_preconfigured_build.sh`
@@ -33,11 +39,11 @@ resulting compiler diagnostics.
      `unsigned long` arithmetic, or provide custom constructors that avoid
      `long long` suffixes when C99 is unavailable, and teach the code
      generators to use them.
-2. **Preprocessor usage assumes variadic macros**: The PC99 interrupt helpers
-   expand `config_set(...)` in contexts that result in empty `__VA_ARGS__`,
-   provoking "requires at least one argument" diagnostics.
-   - *Potential remedies*: restructure the macros/helpers to avoid empty
-     expansions or introduce wrappers that are C89-safe.
+2. **Preprocessor usage assumes variadic macros**: The stubbed logging macros
+   (`printf(...)`, `userError(...)`, etc.) still rely on anonymous
+   `__VA_ARGS__`, triggering strict C90 diagnostics.
+   - *Potential remedies*: provide explicit helper functions or fixed-argument
+     shims that preserve the current behaviour without anonymous varargs.
 3. **Modern C layout rules**: Several functions declare variables mid-block,
    causing "mixed declarations and code" errors with C90.
    - *Potential remedies*: hoist declarations to the top of the scope.
@@ -74,8 +80,13 @@ resulting compiler diagnostics.
   - [x] Resolve the duplicated seL4 basic types between `simple_types.h` and
         the shared kernel headers by coordinating on a shared
         `SEL4_BASIC_TYPES_DEFINED` guard.
-  - [ ] Replace the configuration helpers in `util.h` that rely on anonymous
+  - [x] Replace the configuration helpers in `util.h` that rely on anonymous
         variadic macros with C89-compatible shims.
+- Tidy the libsel4 size/enumeration assertion macros so that
+  `SEL4_SIZE_SANITY`, `SEL4_FORCE_LONG_ENUM`, and related helpers no longer
+  emit pedantic diagnostics or trailing commas in strict C90 mode.
+- Replace the remaining anonymous variadic macros used for debugging/logging
+  (`printf`, `userError`, etc.) with helpers that are valid in C89.
 - Rework the PC99 interrupt helpers so that the generated statements avoid
   declaration-after-statement issues and variadic macro misuse under strict C90.
 - Audit architecture helpers for unused parameters and modern inline idioms

--- a/preconfigured/include/util.h
+++ b/preconfigured/include/util.h
@@ -124,18 +124,16 @@ static inline int wrap_config_set(int x)
 }
 
 /* Evaluate a CMake configuration setting at compile-time. */
-#define config_set(macro) wrap_config_set(_is_set_(macro))
-#define _macrotest_1 ,
-#define _is_set_(value) _is_set__(_macrotest_##value)
-#define _is_set__(comma) _is_set___(comma 1, 0)
-#define _is_set___(_, v, ...) v
+#define _config_option_to_string(option) STRINGIFY(option)
+#define _config_option_is_set(option_string) \
+    ((sizeof(option_string) == sizeof("1")) && ((option_string)[0] == '1'))
+#define _config_is_set(option) _config_option_is_set(_config_option_to_string(option))
+#define config_set(macro) wrap_config_set(_config_is_set(macro))
 
 /* Check the existence of a configuration setting, returning one value if it
  * exists and a different one if it does not */
-#define config_ternary(macro, true, false) _config_ternary(macro, true, false)
-#define _config_ternary(value, true, false) _config_ternary_(_macrotest_##value, true, false)
-#define _config_ternary_(comma, true, false) _config_ternary__(comma true, false)
-#define _config_ternary__(_, v, ...) v
+#define config_ternary(macro, true_value, false_value) \
+    (config_set(macro) ? (true_value) : (false_value))
 
 /** MODIFIES:
     FNSPEC


### PR DESCRIPTION
## Summary
- replace the config helper macros with C89-friendly string-based shims
- refresh the C89 project plan to record the completed helper work and log the latest build issues

## Testing
- ./preconfigured/replay_preconfigured_build.sh *(fails: current C90 build still stops on pedantic errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d3458e5498832ba6439e83b820c855