### PR TITLE
Clean up enum trailing commas for C89 builds

### DIFF
--- a/C89-PROJECT.md
+++ b/C89-PROJECT.md
@@ -65,10 +65,12 @@ resulting compiler diagnostics.
 7. **Enumeration and macro hygiene** *(partially resolved)*: the latest pass
    reworked the libsel4 compile-time helpers (`SEL4_SIZE_SANITY`,
    `SEL4_FORCE_LONG_ENUM`, etc.) so they expand cleanly under strict C90
-   without trailing commas or pedantic diagnostics. The kernel-facing enums
-   still contain dangling commas (`objecttype.h`, machine register indices,
-   generated syscall IDs), so the clean-up needs to continue beyond the
-   libsel4 headers.
+   without trailing commas or pedantic diagnostics. We have now scrubbed the
+   obvious kernel-facing enums in `sel4/objecttype.h`, the various machine
+   register sets, and the generated syscall tables; however, the follow-up
+   build still reports dangling commas in other architecture helpers (e.g.
+   `arch/machine/hardware.h`, the PC99 IRQ tables, and the TCB update flags),
+   so the clean-up needs to continue beyond the initial touch points.
 8. **Structure packing guarantees**: strict mode exposes that the ACPI RSDP
    assertions rely on packing attributes that collapse under C89, causing the
    compile-time size check to fail.
@@ -89,8 +91,11 @@ resulting compiler diagnostics.
   emit pedantic diagnostics or trailing commas in strict C90 mode.
 - Catalogue the new diagnostics from the latest strict build run and plan the
   follow-up fixes:
-  - scrub trailing commas from kernel enumerations (`sel4/objecttype.h`,
+  - [x] scrub trailing commas from kernel enumerations (`sel4/objecttype.h`,
     machine register sets, generated syscall tables).
+  - extend the enumeration cleanup to the remaining pedantic offenders surfaced
+    by the latest build (e.g. `X86_MappingVSpace`, `irqInvalid`, and the
+    `thread_control_update` flags).
   - revisit the packing assertions in the PC99 ACPI/GDT helpers now that the
     attribute shims collapse under C90.
   - replace compound literals and designated initialisers in

--- a/preconfigured/X64_verified/gen_headers/arch/api/syscall.h
+++ b/preconfigured/X64_verified/gen_headers/arch/api/syscall.h
@@ -39,47 +39,47 @@ enum syscall {
     SysRecv = -5,
     SysReply = -6,
     SysYield = -7,
-    SysNBRecv = -8,
+    SysNBRecv = -8
 #if defined(CONFIG_PRINTING)
-    SysDebugPutChar = -9,
-    SysDebugDumpScheduler = -10,
+    , SysDebugPutChar = -9
+    , SysDebugDumpScheduler = -10
 #endif /* defined(CONFIG_PRINTING) */
 #if defined(CONFIG_DEBUG_BUILD)
-    SysDebugHalt = -11,
-    SysDebugCapIdentify = -12,
-    SysDebugSnapshot = -13,
-    SysDebugNameThread = -14,
+    , SysDebugHalt = -11
+    , SysDebugCapIdentify = -12
+    , SysDebugSnapshot = -13
+    , SysDebugNameThread = -14
 #endif /* defined(CONFIG_DEBUG_BUILD) */
 #if defined(CONFIG_DEBUG_BUILD)
-    SysDebugSendIPI = -15,
+    , SysDebugSendIPI = -15
 #endif /* defined(CONFIG_DEBUG_BUILD) */
 #if defined(CONFIG_DANGEROUS_CODE_INJECTION)
-    SysDebugRun = -16,
+    , SysDebugRun = -16
 #endif /* defined(CONFIG_DANGEROUS_CODE_INJECTION) */
 #if defined(CONFIG_ENABLE_BENCHMARKS)
-    SysBenchmarkFlushCaches = -17,
-    SysBenchmarkResetLog = -18,
-    SysBenchmarkFinalizeLog = -19,
-    SysBenchmarkSetLogBuffer = -20,
-    SysBenchmarkNullSyscall = -21,
+    , SysBenchmarkFlushCaches = -17
+    , SysBenchmarkResetLog = -18
+    , SysBenchmarkFinalizeLog = -19
+    , SysBenchmarkSetLogBuffer = -20
+    , SysBenchmarkNullSyscall = -21
 #endif /* defined(CONFIG_ENABLE_BENCHMARKS) */
 #if defined(CONFIG_BENCHMARK_TRACK_UTILISATION)
-    SysBenchmarkGetThreadUtilisation = -22,
-    SysBenchmarkResetThreadUtilisation = -23,
+    , SysBenchmarkGetThreadUtilisation = -22
+    , SysBenchmarkResetThreadUtilisation = -23
 #endif /* defined(CONFIG_BENCHMARK_TRACK_UTILISATION) */
 #if (defined(CONFIG_DEBUG_BUILD) && defined(CONFIG_BENCHMARK_TRACK_UTILISATION))
-    SysBenchmarkDumpAllThreadsUtilisation = -24,
-    SysBenchmarkResetAllThreadsUtilisation = -25,
+    , SysBenchmarkDumpAllThreadsUtilisation = -24
+    , SysBenchmarkResetAllThreadsUtilisation = -25
 #endif /* (defined(CONFIG_DEBUG_BUILD) && defined(CONFIG_BENCHMARK_TRACK_UTILISATION)) */
 #if defined(CONFIG_KERNEL_X86_DANGEROUS_MSR)
-    SysX86DangerousWRMSR = -26,
-    SysX86DangerousRDMSR = -27,
+    , SysX86DangerousWRMSR = -26
+    , SysX86DangerousRDMSR = -27
 #endif /* defined(CONFIG_KERNEL_X86_DANGEROUS_MSR) */
 #if defined(CONFIG_VTX)
-    SysVMEnter = -28,
+    , SysVMEnter = -28
 #endif /* defined(CONFIG_VTX) */
 #if defined(CONFIG_SET_TLS_BASE_SELF)
-    SysSetTLSBase = -29,
+    , SysSetTLSBase = -29
 #endif /* defined(CONFIG_SET_TLS_BASE_SELF) */
 };
 typedef word_t syscall_t;

--- a/preconfigured/include/arch/arm/arch/32/mode/machine/registerset.h
+++ b/preconfigured/include/arch/arm/arch/32/mode/machine/registerset.h
@@ -132,9 +132,9 @@ enum messageSizes {
     n_frameRegisters = 10,
     n_gpRegisters = 9,
     n_exceptionMessage = 3,
-    n_syscallMessage = 12,
+    n_syscallMessage = 12
 #ifdef CONFIG_KERNEL_MCS
-    n_timeoutMessage = 17,
+    , n_timeoutMessage = 17
 #endif
 };
 

--- a/preconfigured/include/arch/arm/arch/64/mode/machine/registerset.h
+++ b/preconfigured/include/arch/arm/arch/64/mode/machine/registerset.h
@@ -166,9 +166,9 @@ enum messageSizes {
     n_frameRegisters = 17,
     n_gpRegisters = 19,
     n_exceptionMessage = 3,
-    n_syscallMessage = 12,
+    n_syscallMessage = 12
 #ifdef CONFIG_KERNEL_MCS
-    n_timeoutMessage = 34,
+    , n_timeoutMessage = 34
 #endif
 };
 

--- a/preconfigured/include/arch/riscv/arch/machine/registerset.h
+++ b/preconfigured/include/arch/riscv/arch/machine/registerset.h
@@ -79,9 +79,9 @@ enum messageSizes {
     n_frameRegisters = 16,
     n_gpRegisters = 16,
     n_exceptionMessage = 2,
-    n_syscallMessage = 10,
+    n_syscallMessage = 10
 #ifdef CONFIG_KERNEL_MCS
-    n_timeoutMessage = 32,
+    , n_timeoutMessage = 32
 #endif
 };
 

--- a/preconfigured/include/arch/x86/arch/32/mode/machine/registerset.h
+++ b/preconfigured/include/arch/x86/arch/32/mode/machine/registerset.h
@@ -67,9 +67,9 @@ enum messageSizes {
     n_frameRegisters = 10,
     n_gpRegisters = 2,
     n_exceptionMessage = 3,
-    n_syscallMessage = 10,
+    n_syscallMessage = 10
 #ifdef CONFIG_KERNEL_MCS
-    n_timeoutMessage = 13,
+    , n_timeoutMessage = 13
 #endif
 };
 

--- a/preconfigured/include/arch/x86/arch/64/mode/machine/registerset.h
+++ b/preconfigured/include/arch/x86/arch/64/mode/machine/registerset.h
@@ -79,9 +79,9 @@ enum messageSizes {
     n_frameRegisters = 18,
     n_gpRegisters = 2,
     n_exceptionMessage = 3,
-    n_syscallMessage = 18,
+    n_syscallMessage = 18
 #ifdef CONFIG_KERNEL_MCS
-    n_timeoutMessage = 19,
+    , n_timeoutMessage = 19
 #endif
 };
 

--- a/preconfigured/include/machine/registerset.h
+++ b/preconfigured/include/machine/registerset.h
@@ -14,9 +14,9 @@
 
 typedef enum {
     MessageID_Syscall,
-    MessageID_Exception,
+    MessageID_Exception
 #ifdef CONFIG_KERNEL_MCS
-    MessageID_TimeoutReply,
+    , MessageID_TimeoutReply
 #endif
 } MessageID_t;
 

--- a/preconfigured/libsel4/include/sel4/objecttype.h
+++ b/preconfigured/libsel4/include/sel4/objecttype.h
@@ -17,7 +17,7 @@ typedef enum api_object {
     seL4_SchedContextObject,
     seL4_ReplyObject,
 #endif
-    seL4_NonArchObjectTypeCount,
+    seL4_NonArchObjectTypeCount
 } seL4_ObjectType;
 
 SEL4_ATTR((deprecated("use seL4_NotificationObject"))) static const seL4_ObjectType seL4_AsyncEndpointObject =

--- a/preconfigured/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/objecttype.h
+++ b/preconfigured/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/objecttype.h
@@ -8,5 +8,5 @@
 
 typedef enum _mode_object {
     seL4_ARM_PageDirectoryObject = seL4_NonArchObjectTypeCount,
-    seL4_ModeObjectTypeCount,
+    seL4_ModeObjectTypeCount
 } seL4_ModeObjectType;

--- a/preconfigured/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/objecttype.h
+++ b/preconfigured/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/objecttype.h
@@ -9,7 +9,7 @@
 #include <sel4/config.h>
 
 typedef enum _mode_object {
-    seL4_ModeObjectTypeCount = seL4_NonArchObjectTypeCount,
+    seL4_ModeObjectTypeCount = seL4_NonArchObjectTypeCount
 } seL4_ModeObjectType;
 
 #define seL4_IA32_PDPTObject 0xffffffff


### PR DESCRIPTION
## Summary
- remove trailing commas from the common and architecture-specific seL4 object type enums so they are valid under C89
- adjust the kernel machine register-set message size enums to avoid dangling commas when optional entries are excluded
- rewrite the generated syscall enumeration to use leading commas and update the project plan with the remaining pedantic cleanups highlighted by the latest build

## Testing
- ./preconfigured/replay_preconfigured_build.sh *(fails: existing C89 diagnostics about variadic macros, packing asserts, unused parameters, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68d34cdf7500832b89207cfc958024ab