### PR TITLE
Clean up enum commas and refresh C89 build plan

### DIFF
--- a/C89-PROJECT.md
+++ b/C89-PROJECT.md
@@ -19,15 +19,20 @@ resulting compiler diagnostics.
   - [ ] Address the remaining diagnostics reported by the strict build.
     - [x] Replace the configuration helpers in `util.h` that relied on
       anonymous variadic macros.
-    - [ ] Tidy the libsel4 size/enumeration assertion macros so they no longer
+    - [x] Tidy the libsel4 size/enumeration assertion macros so they no longer
       emit pedantic diagnostics under strict C90.
     - [ ] Replace the remaining anonymous variadic logging helpers with
       explicit C89-compatible shims.
 
 ## Build Attempt Summary
 - **Command**: `./preconfigured/replay_preconfigured_build.sh`
-- **Outcome**: The build stops during preprocessing/compilation of generated and
-  header sources due to strict C90 semantics.
+- **Outcome**: The build now clears the earlier enum-related pedantic errors but
+  still stops in the shared headers. Strict C90 mode rejects the remaining
+  variadic logging shims, the packed-structure assertions, the compound literal
+  helpers in `machine.h`, the `NODE_STATE_*` macros, several unused-parameter
+  stubs (including the FS/GS base accessors), inline specifier ordering in the
+  PC99 IRQ helpers, and the lingering missing return in
+  `setMRs_lookup_failure`.
 
 ### Key Diagnostic Themes
 1. **C99 integer literals**: The generated capability helpers and several x86
@@ -62,15 +67,14 @@ resulting compiler diagnostics.
    pedantic C90 the duplicate definitions were treated as hard errors. We now
    gate the typedef blocks behind a shared `SEL4_BASIC_TYPES_DEFINED` marker so
    only the first header included in a translation unit defines the aliases.
-7. **Enumeration and macro hygiene** *(partially resolved)*: the latest pass
-   reworked the libsel4 compile-time helpers (`SEL4_SIZE_SANITY`,
-   `SEL4_FORCE_LONG_ENUM`, etc.) so they expand cleanly under strict C90
-   without trailing commas or pedantic diagnostics. We have now scrubbed the
-   obvious kernel-facing enums in `sel4/objecttype.h`, the various machine
-   register sets, and the generated syscall tables; however, the follow-up
-   build still reports dangling commas in other architecture helpers (e.g.
-   `arch/machine/hardware.h`, the PC99 IRQ tables, and the TCB update flags),
-   so the clean-up needs to continue beyond the initial touch points.
+7. **Enumeration and macro hygiene** *(progress)*: the latest pass reworked the
+   libsel4 compile-time helpers (`SEL4_SIZE_SANITY`, `SEL4_FORCE_LONG_ENUM`,
+   etc.) so they expand cleanly under strict C90 without trailing commas or
+   pedantic diagnostics. We have now scrubbed the remaining enums that the
+   previous build complained about (`X86_MappingVSpace`, the PC99 IRQ tables,
+   and the thread control update flags). The outstanding pedantic fallout now
+   centres on macro shims such as the `NODE_STATE_*` helpers and the stubbed
+   logging wrappers.
 8. **Structure packing guarantees**: strict mode exposes that the ACPI RSDP
    assertions rely on packing attributes that collapse under C89, causing the
    compile-time size check to fail.
@@ -93,22 +97,29 @@ resulting compiler diagnostics.
   follow-up fixes:
   - [x] scrub trailing commas from kernel enumerations (`sel4/objecttype.h`,
     machine register sets, generated syscall tables).
-  - extend the enumeration cleanup to the remaining pedantic offenders surfaced
-    by the latest build (e.g. `X86_MappingVSpace`, `irqInvalid`, and the
-    `thread_control_update` flags).
+  - [x] extend the enumeration cleanup to the remaining pedantic offenders
+    surfaced by the latest build (e.g. `X86_MappingVSpace`, `irqInvalid`, and
+    the `thread_control_update` flags).
   - revisit the packing assertions in the PC99 ACPI/GDT helpers now that the
     attribute shims collapse under C90.
   - replace compound literals and designated initialisers in
     `include/machine.h` with explicit temporaries to satisfy C90.
   - normalise the `NODE_STATE_*` macros so they do not expand to stray
     semicolons.
-  - add `(void)` casts or other shims for the numerous unused parameters and
-    reorder declarations that appear after executable statements in the
-    interrupt and machine helpers.
+  - add `(void)` casts or other shims for the numerous unused parameters (e.g.
+    the FS/GS base accessors, APIC helpers, and IRQ stubs) and reorder
+    declarations that appear after executable statements in the interrupt and
+    machine helpers.
 - Replace the remaining anonymous variadic macros used for debugging/logging
   (`printf`, `userError`, etc.) with helpers that are valid in C89.
 - Rework the PC99 interrupt helpers so that the generated statements avoid
-  declaration-after-statement issues and variadic macro misuse under strict C90.
+  declaration-after-statement issues, inline-specifier ordering problems,
+  always-true comparisons, and variadic macro misuse under strict C90.
+- Adjust the CR3 and translation invalidation helpers so that inline assembly
+  operates on named temporaries instead of subscripting non-lvalue temporaries
+  under pedantic C90.
+- Make `setMRs_lookup_failure` return explicitly so the strict warnings stop
+  flagging it as falling off the end.
 - Audit architecture helpers for unused parameters and modern inline idioms
   (e.g. `static inline` placement) that now surface as errors.
 - Make the shared libsel4 macros and enum definitions pedantic-friendly so that

--- a/preconfigured/include/arch/x86/arch/machine/hardware.h
+++ b/preconfigured/include/arch/x86/arch/machine/hardware.h
@@ -40,12 +40,12 @@ enum frameSizeConstants {
 
 enum vm_page_map_type {
     X86_MappingNone = 0,
-    X86_MappingVSpace,
+    X86_MappingVSpace
 #ifdef CONFIG_IOMMU
-    X86_MappingIOSpace,
+    , X86_MappingIOSpace
 #endif
 #ifdef CONFIG_VTX
-    X86_MappingEPT
+    , X86_MappingEPT
 #endif
 };
 typedef word_t vm_page_map_type_t;

--- a/preconfigured/include/object/tcb.h
+++ b/preconfigured/include/object/tcb.h
@@ -205,21 +205,21 @@ enum thread_control_caps_flag {
     thread_control_caps_update_ipc_buffer = 0x1,
     thread_control_caps_update_space = 0x2,
     thread_control_caps_update_fault = 0x4,
-    thread_control_caps_update_timeout = 0x8,
+    thread_control_caps_update_timeout = 0x8
 };
 
 enum thread_control_sched_flag {
     thread_control_sched_update_priority = 0x1,
     thread_control_sched_update_mcp = 0x2,
     thread_control_sched_update_sc = 0x4,
-    thread_control_sched_update_fault = 0x8,
+    thread_control_sched_update_fault = 0x8
 };
 #else
 enum thread_control_flag {
     thread_control_update_priority = 0x1,
     thread_control_update_ipc_buffer = 0x2,
     thread_control_update_space = 0x4,
-    thread_control_update_mcp = 0x8,
+    thread_control_update_mcp = 0x8
 };
 #endif
 

--- a/preconfigured/include/plat/pc99/plat/machine.h
+++ b/preconfigured/include/plat/pc99/plat/machine.h
@@ -60,7 +60,7 @@ typedef enum _platform_irq_t {
     /* This is explicitly 255, instead of -1 like on some other platforms, to ensure
      * that comparisons between an irq_t (a uint8_t) and irqInvalid (some kind of signed int)
      * are well defined and behave as expected */
-    irqInvalid                  = 255,
+    irqInvalid                  = 255
 } platform_irq_t;
 
 #define KERNEL_TIMER_IRQ irq_timer


### PR DESCRIPTION
## Summary
- drop the dangling comma patterns from the x86 mapping enum, the PC99 IRQ table, and the TCB thread control flags so they compile cleanly under pedantic C90
- update the C89 project tracker to record the completed enum sweep and capture the new diagnostics from the latest strict build

## Testing
- `./preconfigured/replay_preconfigured_build.sh` *(fails: variadic macros, packing assertions, compound literals, NODE_STATE macros, unused parameters, and missing return diagnostics remain)*

------
https://chatgpt.com/codex/tasks/task_e_68d34fa82fb4832b94222299c0a90150