### PR TITLE
Replace logging macros with C89 helpers

### DIFF
--- a/preconfigured/include/machine/io.h
+++ b/preconfigured/include/machine/io.h
@@ -108,22 +108,35 @@ static inline SEL4_PRINTF_ATTR(3, 4) int snprintf(
 
 #else /* not CONFIG_PRINTING */
 
-/* The verification runs on the output of the preprocessing stage of a release
- * build configuration, CONFIG_PRINTING is not enabled there. We remove all
- * calls to printf() completely from the code base, because neither printf() nor
- * the usage of a variable argument list is supported by the verification
- * toolchain. It would just reject the code if it encounters any unsupported
- * things.
- */
-#define printf(...)             ((void)(0))
+static inline void kernel_putchar(char c)
+{
+    (void)c;
+}
 
-/* Seems there is no need to define out these functions, they are use by code
- * that is active with CONFIG_PRINTING only.
- *
- *   #define kernel_putchar(...)     ((void)(0))
- *   #define putchar(...)            ((void)(0))
- *   #define puts(...)               ((void)(0))
- *   #define snprintf(...)           ((void)(0))
- */
+static inline void putchar(char c)
+{
+    (void)c;
+}
+
+static inline int puts(const char *str)
+{
+    (void)str;
+    return 0;
+}
+
+static inline SEL4_PRINTF_ATTR(1, 2) int printf(const char *format, ...)
+{
+    (void)format;
+    return 0;
+}
+
+static inline SEL4_PRINTF_ATTR(3, 4) int snprintf(char *buf, word_t size,
+                                                 const char *format, ...)
+{
+    (void)buf;
+    (void)size;
+    (void)format;
+    return 0;
+}
 
 #endif /* [not] CONFIG_PRINTING */

--- a/preconfigured/src/api/faults.c
+++ b/preconfigured/src/api/faults.c
@@ -69,6 +69,8 @@ setMRs_lookup_failure(tcb_t *receiver, word_t *receiveIPCBuffer,
     default:
         fail("Invalid lookup failure");
     }
+
+    return i;
 }
 
 static inline void copyMRsFaultReply(tcb_t *sender, tcb_t *receiver, MessageID_t id, word_t length)


### PR DESCRIPTION
## Summary
- replace the remaining variadic logging macros with C89-compatible helper functions
- provide no-op logging stubs for non-printing builds and add an explicit return to setMRs_lookup_failure
- update the project tracker to record the logging shim work and current strict-build blockers

## Testing
- ./preconfigured/replay_preconfigured_build.sh *(fails: existing strict C90 warnings about packed asserts, unused parameters, and related issues remain)*

------
https://chatgpt.com/codex/tasks/task_e_68d354958c8c832b9370e7c1a1a8a637