### PR TITLE
Rework PC99 interrupt helpers for strict C90

### DIFF
--- a/C89-PROJECT.md
+++ b/C89-PROJECT.md
@@ -21,21 +21,23 @@ resulting compiler diagnostics.
       anonymous variadic macros.
     - [x] Tidy the libsel4 size/enumeration assertion macros so they no longer
       emit pedantic diagnostics under strict C90.
-    - [x] Replace the compound literal helpers in `machine.h` with explicit
-      temporaries.
-    - [x] Replace the remaining anonymous variadic logging helpers with
-      explicit C89-compatible shims.
+  - [x] Replace the compound literal helpers in `machine.h` with explicit
+    temporaries.
+  - [x] Replace the remaining anonymous variadic logging helpers with
+    explicit C89-compatible shims.
+  - [x] Rework the PC99 interrupt helpers to hoist declarations, normalise
+    inline specifiers, and tighten their predicate logic for C90.
 
 ## Build Attempt Summary
 - **Command**: `./preconfigured/replay_preconfigured_build.sh`
-- **Outcome**: The build now clears the earlier enum-related pedantic errors and
-  the node-state macro fallout. Replacing the variadic logging shims and fixing
-  `setMRs_lookup_failure` removed those diagnostics, but the strict C90 build
-  still stops in the shared headers. The current blockers are the packed-structure
-  assertions, several unused-parameter stubs (including the FS/GS base
-  accessors), declaration-after-statement violations in the interrupt helpers,
-  inline specifier ordering in the PC99 IRQ helpers, the always-true comparison
-  in `maskInterrupt`, and the inline assembly that subscripts temporaries.
+- **Outcome**: The build now clears the earlier enum-related pedantic errors,
+  the node-state fallout, and the PC99 interrupt helper issues. The strict C90
+  run currently stops on the packed-structure assertions for the GDT/IDT pointer
+  and ACPI RSDP, unused-parameter diagnostics across the interrupt stubs (e.g.
+  `handleReservedIRQ`, the APIC helpers, and the FS/GS base accessors),
+  declaration-after-statement violations in the FS/GS save/restore helpers and
+  CR3 routines, and the inline assembly that still subscripts temporaries in the
+  translation invalidation paths.
 
 ### Key Diagnostic Themes
 1. **C99 integer literals**: The generated capability helpers and several x86
@@ -109,11 +111,11 @@ resulting compiler diagnostics.
     `include/machine.h` with explicit temporaries to satisfy C90.
   - [x] normalise the `NODE_STATE_*` macros so they do not expand to stray
     semicolons.
-  - add `(void)` casts or other shims for the numerous unused parameters (e.g.
-    the FS/GS base accessors, APIC helpers, and IRQ stubs) and reorder
+  - [ ] Add `(void)` casts or other shims for the numerous unused parameters
+    (e.g. the FS/GS base accessors, APIC helpers, and IRQ stubs) and reorder
     declarations that appear after executable statements in the interrupt and
     machine helpers.
-- Rework the PC99 interrupt helpers so that the generated statements avoid
+- [x] Rework the PC99 interrupt helpers so that the generated statements avoid
   declaration-after-statement issues, inline-specifier ordering problems,
   always-true comparisons, and variadic macro misuse under strict C90.
 - Adjust the CR3 and translation invalidation helpers so that inline assembly

--- a/preconfigured/include/plat/pc99/plat/machine/interrupt.h
+++ b/preconfigured/include/plat/pc99/plat/machine/interrupt.h
@@ -24,6 +24,8 @@ void apic_ack_active_interrupt(void);
 
 static inline void handleReservedIRQ(irq_t irq)
 {
+    (void)irq;
+
 #ifdef CONFIG_IOMMU
     if (irq == irq_iommu) {
         vtd_handle_fault();
@@ -47,9 +49,11 @@ static inline void receivePendingIRQ(void)
 
 static inline interrupt_t servicePendingIRQ(void)
 {
+    interrupt_t ret;
+
     assert(ARCH_NODE_STATE(x86KScurInterrupt) == int_invalid);
     assert(ARCH_NODE_STATE(x86KSPendingInterrupt) != int_invalid);
-    interrupt_t ret = ARCH_NODE_STATE(x86KSPendingInterrupt);
+    ret = ARCH_NODE_STATE(x86KSPendingInterrupt);
     ARCH_NODE_STATE(x86KSPendingInterrupt) = int_invalid;
     return ret;
 }
@@ -108,7 +112,7 @@ static inline void handleSpuriousIRQ(void)
     /* do nothing */
 }
 
-static void inline updateIRQState(irq_t irq, x86_irq_state_t state)
+static inline void updateIRQState(irq_t irq, x86_irq_state_t state)
 {
     assert(irq <= maxIRQ);
     x86KSIRQState[irq] = state;
@@ -116,7 +120,7 @@ static void inline updateIRQState(irq_t irq, x86_irq_state_t state)
 
 static inline void maskInterrupt(bool_t disable, irq_t irq)
 {
-    if (irq >= irq_isa_min && irq <= irq_isa_max) {
+    if (irq <= irq_isa_max) {
         if (config_set(CONFIG_IRQ_PIC)) {
             pic_mask_irq(disable, irq);
         } else {


### PR DESCRIPTION
## Summary
- hoist the PC99 interrupt helper declarations, normalise inline specifiers, and tighten the legacy PIC bounds checks for strict C90 mode
- mark the reserved IRQ handler parameter as intentionally unused when logging is disabled
- refresh the C89 project log with the latest build blockers and completed interrupt-helper work

## Testing
- ./preconfigured/replay_preconfigured_build.sh *(fails: packing assertions, unused-parameter stubs, CR3/FSGS helpers)*

------
https://chatgpt.com/codex/tasks/task_e_68d3583267d8832b8012a5ca54c46db2