### PR TITLE
Silence unused parameter warnings and hoist helper declarations

### DIFF
--- a/preconfigured/include/arch/arm/arch/32/mode/machine_pl2.h
+++ b/preconfigured/include/arch/arm/arch/32/mode/machine_pl2.h
@@ -176,11 +176,30 @@ static inline void writeHTPIDR(word_t reg)
 #else
 
 /* used in other files without guards */
-static inline void setCurrentPDPL2(paddr_t pa) {}
-static inline void invalidateHypTLB(void) {}
-static inline void writeContextIDPL2(word_t pd_val) {}
-static inline void writeContextIDAndPD(word_t id, word_t pd_val) {}
-static inline void writeHTPIDR(word_t htpidr) {}
+static inline void setCurrentPDPL2(paddr_t pa)
+{
+    (void)pa;
+}
+
+static inline void invalidateHypTLB(void)
+{
+}
+
+static inline void writeContextIDPL2(word_t pd_val)
+{
+    (void)pd_val;
+}
+
+static inline void writeContextIDAndPD(word_t id, word_t pd_val)
+{
+    (void)id;
+    (void)pd_val;
+}
+
+static inline void writeHTPIDR(word_t htpidr)
+{
+    (void)htpidr;
+}
 static inline paddr_t addressTranslateS1(vptr_t vaddr)
 {
     return vaddr;

--- a/preconfigured/include/arch/arm/arch/64/mode/machine_pl2.h
+++ b/preconfigured/include/arch/arm/arch/64/mode/machine_pl2.h
@@ -22,7 +22,10 @@ static inline word_t readTPIDR_EL2(void)
 
 #else
 
-static inline void writeTPIDR_EL2(word_t reg) {}
+static inline void writeTPIDR_EL2(word_t reg)
+{
+    (void)reg;
+}
 static inline word_t readTPIDR_EL2(void)
 {
     return 0;
@@ -31,7 +34,22 @@ static inline word_t readTPIDR_EL2(void)
 #endif /* End of CONFIG_ARM_HYPERVISOR_SUPPORT */
 
 /* used in other files without guards */
-static inline void setCurrentPDPL2(paddr_t pa) {}
-static inline void invalidateHypTLB(void) {}
-static inline void writeContextIDPL2(word_t pd_val) {}
-static inline void writeContextIDAndPD(word_t id, word_t pd_val) {}
+static inline void setCurrentPDPL2(paddr_t pa)
+{
+    (void)pa;
+}
+
+static inline void invalidateHypTLB(void)
+{
+}
+
+static inline void writeContextIDPL2(word_t pd_val)
+{
+    (void)pd_val;
+}
+
+static inline void writeContextIDAndPD(word_t id, word_t pd_val)
+{
+    (void)id;
+    (void)pd_val;
+}

--- a/preconfigured/include/arch/arm/arch/object/interrupt.h
+++ b/preconfigured/include/arch/arm/arch/object/interrupt.h
@@ -21,6 +21,7 @@ exception_t decodeSGISignalInvocation(word_t invLabel, word_t length,
 /* Handle a platform-reserved IRQ. */
 static inline void handleReservedIRQ(irq_t irq)
 {
+    (void)irq;
 
 #ifdef CONFIG_ARM_ENABLE_PMU_OVERFLOW_INTERRUPT
     if (IRQT_TO_IRQ(irq) == KERNEL_PMU_IRQ) {

--- a/preconfigured/include/arch/riscv/arch/object/interrupt.h
+++ b/preconfigured/include/arch/riscv/arch/object/interrupt.h
@@ -12,6 +12,7 @@
 
 static inline void handleReservedIRQ(irq_t irq)
 {
+    (void)irq;
 #ifdef CONFIG_IRQ_REPORTING
     printf("Received unhandled reserved IRQ: %d\n", (int)irq);
 #endif

--- a/preconfigured/include/arch/x86/arch/64/mode/machine.h
+++ b/preconfigured/include/arch/x86/arch/64/mode/machine.h
@@ -79,6 +79,8 @@ static inline paddr_t getCurrentUserVSpaceRoot(void)
 
 static inline void setCurrentCR3(cr3_t cr3, word_t preserve_translation)
 {
+    word_t cr3_word;
+
 #ifdef CONFIG_KERNEL_SKIM_WINDOW
     /* we should only ever be enabling the kernel window, as the bulk of the
      * cr3 loading when using the SKIM window will happen on kernel entry/exit
@@ -87,7 +89,7 @@ static inline void setCurrentCR3(cr3_t cr3, word_t preserve_translation)
 #else
     MODE_NODE_STATE(x64KSCurrentCR3) = cr3;
 #endif
-    word_t cr3_word = cr3.words[0];
+    cr3_word = cr3.words[0];
     if (config_set(CONFIG_SUPPORT_PCID)) {
         if (preserve_translation) {
             cr3_word |= BIT(63);
@@ -196,6 +198,7 @@ static inline void invalidateLocalPCID(word_t type, void *vaddr, asid_t asid)
 
 static inline void invalidateLocalTranslationSingle(vptr_t vptr)
 {
+    (void)vptr;
     /* As this may be used to invalidate global mappings by the kernel,
      * and as its only used in boot code, we can just invalidate
      * absolutely everything form the tlb */
@@ -284,6 +287,9 @@ static inline word_t x86_read_fs_base_impl(void)
 
 static inline void x86_save_fsgs_base(tcb_t *thread, cpu_id_t cpu)
 {
+    word_t cur_fs_base;
+    word_t cur_gs_base;
+
     /*
      * Store the FS and GS base registers.
      *
@@ -299,9 +305,9 @@ static inline void x86_save_fsgs_base(tcb_t *thread, cpu_id_t cpu)
         return;
     }
 #endif
-    word_t cur_fs_base = x86_read_fs_base(cpu);
+    cur_fs_base = x86_read_fs_base(cpu);
     setRegister(thread, FS_BASE, cur_fs_base);
-    word_t cur_gs_base = x86_read_gs_base(cpu);
+    cur_gs_base = x86_read_gs_base(cpu);
     setRegister(thread, GS_BASE, cur_gs_base);
 }
 

--- a/preconfigured/include/arch/x86/arch/kernel/thread.h
+++ b/preconfigured/include/arch/x86/arch/kernel/thread.h
@@ -13,6 +13,7 @@ word_t sanitiseRegister(register_t reg, word_t v, bool_t archInfo);
 
 static inline bool_t CONST Arch_getSanitiseRegisterInfo(tcb_t *thread)
 {
+    (void)thread;
     return 0;
 }
 

--- a/preconfigured/include/arch/x86/arch/kernel/xapic.h
+++ b/preconfigured/include/arch/x86/arch/kernel/xapic.h
@@ -58,6 +58,7 @@ static inline logical_id_t apic_get_logical_id(void)
 
 static inline word_t apic_get_cluster(logical_id_t logical_id)
 {
+    (void)logical_id;
     return 0; /* always return 0 as 'init_xapic_ldr' uses flat cluster */
 }
 

--- a/preconfigured/include/arch/x86/arch/machine.h
+++ b/preconfigured/include/arch/x86/arch/machine.h
@@ -275,21 +275,25 @@ static inline word_t x86_read_fs_base_impl(void)
 
 static inline void x86_write_fs_base(word_t base, cpu_id_t cpu)
 {
+    (void)cpu;
     x86_write_fs_base_impl(base);
 }
 
 static inline void x86_write_gs_base(word_t base, cpu_id_t cpu)
 {
+    (void)cpu;
     x86_write_gs_base_impl(base);
 }
 
 static inline word_t x86_read_fs_base(cpu_id_t cpu)
 {
+    (void)cpu;
     return x86_read_fs_base_impl();
 }
 
 static inline word_t x86_read_gs_base(cpu_id_t cpu)
 {
+    (void)cpu;
     return x86_read_gs_base_impl();
 }
 
@@ -329,15 +333,18 @@ static inline word_t x86_read_gs_base(cpu_id_t cpu)
 
 static inline void x86_load_fsgs_base(tcb_t *thread, cpu_id_t cpu)
 {
+    word_t fs_base;
+    word_t gs_base;
+
     /*
      * Restore the FS and GS base registers.
      *
      * These should only be accessed inside the kernel, between the
      * entry and exit calls to swapgs if used.
      */
-    word_t fs_base = getRegister(thread, FS_BASE);
+    fs_base = getRegister(thread, FS_BASE);
     x86_write_fs_base(fs_base, cpu);
-    word_t gs_base = getRegister(thread, GS_BASE);
+    gs_base = getRegister(thread, GS_BASE);
     x86_write_gs_base(gs_base, cpu);
 }
 

--- a/preconfigured/include/arch/x86/arch/object/objecttype.h
+++ b/preconfigured/include/arch/x86/arch/object/objecttype.h
@@ -43,6 +43,7 @@ void Arch_postCapDeletion(cap_t cap);
  */
 static inline CONST bool_t Arch_isIRQControlDescendant(cap_t cap)
 {
+    (void)cap;
     return false;
 }
 
@@ -51,5 +52,8 @@ static inline CONST bool_t Arch_isIRQControlDescendant(cap_t cap)
  */
 static inline CONST bool_t Arch_isMDBParentOf(cap_t cap_a, cap_t cap_b, bool_t firstBadged)
 {
+    (void)cap_a;
+    (void)cap_b;
+    (void)firstBadged;
     return true;
 }

--- a/preconfigured/include/machine/interrupt.h
+++ b/preconfigured/include/machine/interrupt.h
@@ -132,7 +132,10 @@ static inline void handleReservedIRQ(irq_t irq);
 
 #ifndef CONFIG_ARM_GIC_V3_SUPPORT
 
-static inline void deactivateInterrupt(irq_t irq) {}
+static inline void deactivateInterrupt(irq_t irq)
+{
+    (void)irq;
+}
 #endif
 
 #include <plat/machine/interrupt.h>


### PR DESCRIPTION
## Summary
- add explicit `(void)` casts for unused helper parameters across the architecture stubs
- hoist local variable declarations in the FS/GS loader and CR3 helpers to satisfy C90 ordering rules
- refresh the C89 project log with the latest build status and completed work

## Testing
- ./preconfigured/replay_preconfigured_build.sh *(fails: packed-structure assertions and CR3 inline assembly still pending)*

------
https://chatgpt.com/codex/tasks/task_e_68d35abe79c8832b9afcb9eb81de34e3