### PR TITLE
Restore packed layout helpers for C89 builds

### DIFF
--- a/C89-PROJECT.md
+++ b/C89-PROJECT.md
@@ -32,15 +32,12 @@ resulting compiler diagnostics.
 - **Command**: `./preconfigured/replay_preconfigured_build.sh`
 - **Outcome**: The latest replay confirms that the wrappers remain up to date
   and that all of the earlier enum, node-state, and interrupt helper issues are
-  still resolved. The strict C90 run now halts on two fronts:
-  1. The packed-structure assertions for the GDT/IDT pointer shim and the ACPI
-     RSDP fail because the packing attributes collapse under C89, producing
-     negative-array diagnostics.
-  2. The translation invalidation helpers continue to subscript the temporary
+  still resolved. The strict C90 run now halts on one remaining front:
+  1. The translation invalidation helpers continue to subscript the temporary
      returned by `makeCR3(...)`, triggering the "subscripting non-lvalue array"
      pedantic error in the inline assembly.
   No additional warnings surfaced in this pass, so the remaining blockers are
-  confined to these packing guarantees and the inline assembly temporaries.
+  confined to the inline assembly temporaries.
 
 ### Key Diagnostic Themes
 1. **C99 integer literals**: The generated capability helpers and several x86
@@ -110,7 +107,7 @@ resulting compiler diagnostics.
   - [x] extend the enumeration cleanup to the remaining pedantic offenders
     surfaced by the latest build (e.g. `X86_MappingVSpace`, `irqInvalid`, and
     the `thread_control_update` flags).
-  - [ ] revisit the packing assertions in the PC99 ACPI/GDT helpers now that the
+  - [x] revisit the packing assertions in the PC99 ACPI/GDT helpers now that the
     attribute shims collapse under C90, so the compile-time size checks no
     longer fail under pedantic mode.
   - [x] replace compound literals and designated initialisers in

--- a/preconfigured/include/compiler.h
+++ b/preconfigured/include/compiler.h
@@ -42,7 +42,11 @@
 #define SEL4_CONST_ATTR SEL4_ATTR((__const__))
 #define SEL4_PURE_ATTR SEL4_ATTR((__pure__))
 #define SEL4_ALIGN_ATTR(n) SEL4_ATTR((__aligned__(n)))
+#if SEL4_C89_COMPAT && (defined(__GNUC__) || defined(__clang__))
+#define SEL4_PACKED_ATTR __attribute__((packed))
+#else
 #define SEL4_PACKED_ATTR SEL4_ATTR((packed))
+#endif
 #define SEL4_SECTION_ATTR(sec) SEL4_ATTR((__section__(sec)))
 #define SEL4_UNUSED_ATTR SEL4_ATTR((unused))
 #define SEL4_USED_ATTR SEL4_ATTR((used))


### PR DESCRIPTION
## Summary
- teach SEL4_PACKED_ATTR to keep using the compiler's packed attribute when we fall back to strict C89 mode on GCC/Clang
- update the C89 porting plan to record that the ACPI and descriptor pointer packing checks now pass and only the CR3 helper remains

## Testing
- ./preconfigured/replay_preconfigured_build.sh *(fails: pending makeCR3 temporary fix)*

------
https://chatgpt.com/codex/tasks/task_e_68d36ee98828832b9c8a6695a6c4d9e9