### PR TITLE
Rework CR3 invalidation helpers for C90

### DIFF
--- a/preconfigured/X64_verified/kernel_all.i
+++ b/preconfigured/X64_verified/kernel_all.i
@@ -7698,18 +7698,22 @@ static inline void invalidateLocalPageStructureCacheASID(paddr_t root, asid_t as
 {
     if (wrap_config_set(1)) {
 
-        cr3_t cr3 = getCurrentCR3();
-
-
-
+        cr3_t cr3;
+        cr3_t new_cr3;
+        word_t new_cr3_word;
+        word_t old_cr3_word;
+        cr3 = getCurrentCR3();
+        new_cr3 = makeCR3(root, asid);
+        new_cr3_word = new_cr3.words[0];
+        old_cr3_word = cr3.words[0] | (1ul << (63));
 
 
         __asm__ volatile(
             "mov %[new_cr3], %%cr3\n"
             "mov %[old_cr3], %%cr3\n"
             ::
-            [new_cr3] "r"(makeCR3(root, asid).words[0]),
-            [old_cr3] "r"(cr3.words[0] | (1ul << (63)))
+            [new_cr3] "r"(new_cr3_word),
+            [old_cr3] "r"(old_cr3_word)
         );
     } else {
 

--- a/preconfigured/X64_verified/kernel_all_pp_prune_wrapper_temp.c
+++ b/preconfigured/X64_verified/kernel_all_pp_prune_wrapper_temp.c
@@ -12440,7 +12440,13 @@ void vcpu_init(vcpu_t *vcpu)
 #ifdef CONFIG_KERNEL_SKIM_WINDOW
     /* if we have a skim window then our host cr3 is a constant and is always the
      * the kernel address space, so we set it here instead of lazily in restoreVMCS */
-    vmwrite(VMX_HOST_CR3, makeCR3(kpptr_to_paddr(x64KSKernelPML4), 0).words[0]);
+    {
+        cr3_t host_cr3;
+        word_t host_cr3_word;
+        host_cr3 = makeCR3(kpptr_to_paddr(x64KSKernelPML4), 0);
+        host_cr3_word = host_cr3.words[0];
+        vmwrite(VMX_HOST_CR3, host_cr3_word);
+    }
 #endif /* CONFIG_KERNEL_SKIM_WINDOW */
 
     vmwrite(VMX_HOST_ES_SELECTOR, SEL_DS_0);

--- a/preconfigured/include/arch/x86/arch/64/mode/machine.h
+++ b/preconfigured/include/arch/x86/arch/64/mode/machine.h
@@ -219,7 +219,14 @@ static inline void invalidateLocalPageStructureCacheASID(paddr_t root, asid_t as
 {
     if (config_set(CONFIG_SUPPORT_PCID)) {
         /* store our previous cr3 */
-        cr3_t cr3 = getCurrentCR3();
+        cr3_t cr3;
+        cr3_t new_cr3;
+        word_t new_cr3_word;
+        word_t old_cr3_word;
+        cr3 = getCurrentCR3();
+        new_cr3 = makeCR3(root, asid);
+        new_cr3_word = new_cr3.words[0];
+        old_cr3_word = cr3.words[0] | BIT(63);
         /* we load the new vspace root, invalidating translation for it
          * and then switch back to the old CR3. We do this in a single
          * asm block to ensure we only rely on the code being mapped in
@@ -229,8 +236,8 @@ static inline void invalidateLocalPageStructureCacheASID(paddr_t root, asid_t as
             "mov %[new_cr3], %%cr3\n"
             "mov %[old_cr3], %%cr3\n"
             ::
-            [new_cr3] "r"(makeCR3(root, asid).words[0]),
-            [old_cr3] "r"(cr3.words[0] | BIT(63))
+            [new_cr3] "r"(new_cr3_word),
+            [old_cr3] "r"(old_cr3_word)
         );
     } else {
         /* just invalidate the page structure cache as per normal, by

--- a/preconfigured/src/arch/x86/object/vcpu.c
+++ b/preconfigured/src/arch/x86/object/vcpu.c
@@ -480,7 +480,13 @@ void vcpu_init(vcpu_t *vcpu)
 #ifdef CONFIG_KERNEL_SKIM_WINDOW
     /* if we have a skim window then our host cr3 is a constant and is always the
      * the kernel address space, so we set it here instead of lazily in restoreVMCS */
-    vmwrite(VMX_HOST_CR3, makeCR3(kpptr_to_paddr(x64KSKernelPML4), 0).words[0]);
+    {
+        cr3_t host_cr3;
+        word_t host_cr3_word;
+        host_cr3 = makeCR3(kpptr_to_paddr(x64KSKernelPML4), 0);
+        host_cr3_word = host_cr3.words[0];
+        vmwrite(VMX_HOST_CR3, host_cr3_word);
+    }
 #endif /* CONFIG_KERNEL_SKIM_WINDOW */
 
     vmwrite(VMX_HOST_ES_SELECTOR, SEL_DS_0);


### PR DESCRIPTION
## Summary
- route the translation invalidation helpers through named CR3 temporaries so the inline assembly no longer subscripts rvalue arrays
- apply the same CR3 temporary handling to the aggregated X64 sources and the VMCS host CR3 update used by vcpu_init
- refresh the C89 project log with the new build results and follow-up tasks for the syscall helpers

## Testing
- `./preconfigured/replay_preconfigured_build.sh` *(fails: pedantic errors in src/api/syscall.c surfaced after the CR3 fixes)*

------
https://chatgpt.com/codex/tasks/task_e_68d37056ae3c832bb3ca2d4a79a11c33