### PR TITLE
Rework syscall handlers for C90 pedantic compliance

### DIFF
--- a/preconfigured/src/api/syscall.c
+++ b/preconfigured/src/api/syscall.c
@@ -207,7 +207,10 @@ exception_t handleUnknownSyscall(word_t w)
     } /* end switch(w) */
 #endif /* CONFIG_ENABLE_BENCHMARKS */
 
-    MCS_DO_IF_BUDGET({
+#ifdef CONFIG_KERNEL_MCS
+    updateTimestamp();
+    if (likely(checkBudgetRestart())) {
+#endif
 #ifdef CONFIG_SET_TLS_BASE_SELF
         if (w == SysSetTLSBase)
         {
@@ -222,7 +225,9 @@ exception_t handleUnknownSyscall(word_t w)
 #endif
         current_fault = seL4_Fault_UnknownSyscall_new(w);
         handleFault(NODE_STATE(ksCurThread));
-    })
+#ifdef CONFIG_KERNEL_MCS
+    }
+#endif
 
     schedule();
     activateThread();
@@ -519,7 +524,10 @@ exception_t handleSyscall(syscall_t syscall)
 {
     exception_t ret;
     irq_t irq;
-    MCS_DO_IF_BUDGET({
+#ifdef CONFIG_KERNEL_MCS
+    updateTimestamp();
+    if (likely(checkBudgetRestart())) {
+#endif
         switch (syscall)
         {
         case SysSend:
@@ -625,8 +633,9 @@ exception_t handleSyscall(syscall_t syscall)
         default:
             fail("Invalid syscall");
         }
-
-    })
+#ifdef CONFIG_KERNEL_MCS
+    }
+#endif
 
     schedule();
     activateThread();


### PR DESCRIPTION
## Summary
- rewrite handleUnknownSyscall and handleSyscall to avoid wrapping preprocessor directives inside the MCS budget macro
- update the C89 project log to record the resolved syscall macro issue and the remaining handleInvocation declaration ordering error

## Testing
- ./preconfigured/replay_preconfigured_build.sh *(fails: handleInvocation still declares cptr after statements under -std=c90)*

------
https://chatgpt.com/codex/tasks/task_e_68d3722ee3bc832b9629ee722b59c0e8