### PR TITLE
Hoist syscall cptr declaration and update C89 plan

### DIFF
--- a/preconfigured/src/api/syscall.c
+++ b/preconfigured/src/api/syscall.c
@@ -276,12 +276,15 @@ static exception_t handleInvocation(bool_t isCall, bool_t isBlocking)
     exception_t status;
     word_t length;
     tcb_t *thread;
+#ifndef CONFIG_KERNEL_MCS
+    cptr_t cptr;
+#endif
 
     thread = NODE_STATE(ksCurThread);
 
     info = messageInfoFromWord(getRegister(thread, msgInfoRegister));
 #ifndef CONFIG_KERNEL_MCS
-    cptr_t cptr = getRegister(thread, capRegister);
+    cptr = getRegister(thread, capRegister);
 #endif
 
     /* faulting section */

--- a/preconfigured/src/arch/x86/64/kernel/thread.c
+++ b/preconfigured/src/arch/x86/64/kernel/thread.c
@@ -60,6 +60,7 @@ void Arch_switchToIdleThread(void)
 
 void Arch_activateIdleThread(tcb_t *tcb)
 {
+    (void)tcb;
     /* Don't need to do anything */
 }
 


### PR DESCRIPTION
## Summary
- hoist the `handleInvocation` capability pointer declaration so the syscall path honours C90 layout rules
- lift the x86 trap helper temporaries and silence the idle thread parameter to keep pedantic builds clean
- refresh the C89 project plan with the latest strict build diagnostics and follow-up tasks

## Testing
- ./preconfigured/replay_preconfigured_build.sh *(fails: pedantic C90 now stops in the x86 vspace build due to libsel4 enum macros, SKIM window helpers, and related warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68d37393ad6c832ba13667dd540c6053