### PR TITLE
Cast unused parameters in x86 TLB helpers for C89

### DIFF
--- a/preconfigured/include/arch/x86/arch/32/mode/kernel/tlb.h
+++ b/preconfigured/include/arch/x86/arch/32/mode/kernel/tlb.h
@@ -11,18 +11,21 @@
 
 static inline void invalidateTLBEntry(vptr_t vptr, word_t mask)
 {
+    (void)mask;
     invalidateLocalTLBEntry(vptr);
     SMP_COND_STATEMENT(doRemoteInvalidateTLBEntry(vptr, mask));
 }
 
 static inline void invalidatePageStructureCache(word_t mask)
 {
+    (void)mask;
     invalidateLocalPageStructureCache();
     SMP_COND_STATEMENT(doRemoteInvalidatePageStructureCache(mask));
 }
 
 static inline void invalidateTLB(word_t mask)
 {
+    (void)mask;
     invalidateLocalTLB();
     SMP_COND_STATEMENT(doRemoteInvalidateTLB(mask));
 }

--- a/preconfigured/include/arch/x86/arch/32/mode/machine.h
+++ b/preconfigured/include/arch/x86/arch/32/mode/machine.h
@@ -50,6 +50,8 @@ static inline void invalidateLocalPageStructureCache(void)
 
 static inline void invalidateLocalPageStructureCacheASID(paddr_t root, asid_t asid)
 {
+    (void)root;
+    (void)asid;
     /* ignore asid */
     invalidateLocalPageStructureCache();
 }
@@ -68,6 +70,7 @@ static inline void invalidateLocalTranslationSingle(vptr_t vptr)
 
 static inline void invalidateLocalTranslationSingleASID(vptr_t vptr, asid_t asid)
 {
+    (void)asid;
     /* no asid support in 32-bit, just invalidate TLB */
     invalidateLocalTLBEntry(vptr);
 }

--- a/preconfigured/include/arch/x86/arch/64/mode/kernel/tlb.h
+++ b/preconfigured/include/arch/x86/arch/64/mode/kernel/tlb.h
@@ -18,6 +18,7 @@
  */
 static inline void invalidateLocalASID(vspace_root_t *vspace, asid_t asid)
 {
+    (void)vspace;
     invalidateLocalPCID(INVPCID_TYPE_SINGLE, (void *)0, asid);
 #ifdef ENABLE_SMP_SUPPORT
     if (pptr_to_paddr(vspace) != getCurrentUserVSpaceRoot()) {
@@ -28,12 +29,14 @@ static inline void invalidateLocalASID(vspace_root_t *vspace, asid_t asid)
 
 static inline void invalidatePCID(word_t type, void *vaddr, asid_t asid, word_t mask)
 {
+    (void)mask;
     invalidateLocalPCID(type, vaddr, asid);
     SMP_COND_STATEMENT(doRemoteInvalidatePCID(type, vaddr, asid, mask));
 }
 
 static inline void invalidateASID(vspace_root_t *vspace, asid_t asid, word_t mask)
 {
+    (void)mask;
     invalidateLocalASID(vspace, asid);
     SMP_COND_STATEMENT(doRemoteInvalidateASID(vspace, asid, mask));
 }

--- a/preconfigured/include/arch/x86/arch/64/mode/machine.h
+++ b/preconfigured/include/arch/x86/arch/64/mode/machine.h
@@ -176,6 +176,7 @@ static inline void invalidateLocalPCID(word_t type, void *vaddr, asid_t asid)
         desc.addr = (uint64_t)vaddr;
         asm volatile("invpcid %1, %0" :: "r"(type), "m"(desc));
     } else {
+        (void)asid;
         switch (type) {
         case INVPCID_TYPE_ADDR:
             asm volatile("invlpg (%[vptr])" :: [vptr] "r"(vaddr));
@@ -240,6 +241,8 @@ static inline void invalidateLocalPageStructureCacheASID(paddr_t root, asid_t as
             [old_cr3] "r"(old_cr3_word)
         );
     } else {
+        (void)root;
+        (void)asid;
         /* just invalidate the page structure cache as per normal, by
          * doing a dummy invalidation of a tlb entry */
         asm volatile("invlpg (%[vptr])" :: [vptr] "r"(0));

--- a/preconfigured/include/arch/x86/arch/kernel/tlb.h
+++ b/preconfigured/include/arch/x86/arch/kernel/tlb.h
@@ -12,24 +12,28 @@
 
 static inline void invalidatePageStructureCacheASID(paddr_t root, asid_t asid, word_t mask)
 {
+    (void)mask;
     invalidateLocalPageStructureCacheASID(root, asid);
     SMP_COND_STATEMENT(doRemoteInvalidatePageStructureCacheASID(root, asid, mask));
 }
 
 static inline void invalidateTranslationSingle(vptr_t vptr, word_t mask)
 {
+    (void)mask;
     invalidateLocalTranslationSingle(vptr);
     SMP_COND_STATEMENT(doRemoteInvalidateTranslationSingle(vptr, mask));
 }
 
 static inline void invalidateTranslationSingleASID(vptr_t vptr, asid_t asid, word_t mask)
 {
+    (void)mask;
     invalidateLocalTranslationSingleASID(vptr, asid);
     SMP_COND_STATEMENT(doRemoteInvalidateTranslationSingleASID(vptr, asid, mask));
 }
 
 static inline void invalidateTranslationAll(word_t mask)
 {
+    (void)mask;
     invalidateLocalTranslationAll();
     SMP_COND_STATEMENT(doRemoteInvalidateTranslationAll(mask));
 }

--- a/preconfigured/src/arch/x86/32/kernel/vspace.c
+++ b/preconfigured/src/arch/x86/32/kernel/vspace.c
@@ -620,6 +620,8 @@ void setVMRoot(tcb_t *tcb)
 
 void hwASIDInvalidate(asid_t asid, vspace_root_t *vspace)
 {
+    (void)asid;
+    (void)vspace;
     /* 32-bit does not have PCID */
     return;
 }

--- a/preconfigured/src/arch/x86/64/kernel/vspace.c
+++ b/preconfigured/src/arch/x86/64/kernel/vspace.c
@@ -1060,6 +1060,8 @@ lookupPDSlot_ret_t lookupPDSlot(vspace_root_t *pml4, vptr_t vptr)
 
 static void flushPD(vspace_root_t *vspace, word_t vptr, pde_t *pd, asid_t asid)
 {
+    (void)vptr;
+    (void)pd;
     /* clearing the entire PCID vs flushing the virtual addresses
      * one by one using invplg.
      * choose the easy way, invalidate the PCID
@@ -1070,6 +1072,8 @@ static void flushPD(vspace_root_t *vspace, word_t vptr, pde_t *pd, asid_t asid)
 
 static void flushPDPT(vspace_root_t *vspace, word_t vptr, pdpte_t *pdpt, asid_t asid)
 {
+    (void)vptr;
+    (void)pdpt;
     /* similar here */
     invalidateASID(vspace, asid, SMP_TERNARY(tlb_bitmap_get(vspace), 0));
     return;


### PR DESCRIPTION
## Summary
- Cast unused parameters in the x86 TLB and page-structure invalidation wrappers so they compile cleanly under strict C90
- Add `(void)` casts to the 32-bit and 64-bit paging helper shims to silence unused-parameter diagnostics
- Update the C89 porting plan with the new build status and the outstanding boot-time paging cleanup work

## Testing
- ./preconfigured/replay_preconfigured_build.sh

------
https://chatgpt.com/codex/tasks/task_e_68d37a743620832bbdc4a474774f00c5