### PR TITLE
Fix x86 decode fallthroughs for C89 build

### DIFF
--- a/C89-PROJECT.md
+++ b/C89-PROJECT.md
@@ -39,7 +39,12 @@ resulting compiler diagnostics.
   helpers still need `(void)` casts for unused parameters, the CR3 comparison
   relies on subscripting a temporary, several boot-time mappers use compound
   literals, and a handful of decode helpers fall off the end without explicit
-  returns once the attribute shims collapse.
+  returns once the attribute shims collapse. With the decode helpers patched,
+  the latest strict build now trips on the outstanding TLB invalidation shims
+  (missing `(void)` casts), the CR3 comparison that still subscripts a
+  temporary, the boot paging helpers that retain compound literals or unused
+  parameters, and the generated `cap_get_capMappedASID` accessor that lacks an
+  explicit return value on all paths.
 
 ### Key Diagnostic Themes
 1. **C99 integer literals**: The generated capability helpers and several x86
@@ -151,7 +156,7 @@ resulting compiler diagnostics.
         related boot helpers so the pedantic build stays quiet.
   - [ ] Adjust the CR3 comparison helpers and boot-time mapping routines to
         operate on named temporaries instead of subscripting compound literals.
-  - [ ] Audit the x86 decode and mode-specific cap helpers to provide explicit
+  - [x] Audit the x86 decode and mode-specific cap helpers to provide explicit
         returns and `(void)` casts for unused parameters now that the attribute
         shims collapse under C90.
 - Continue iterating on the remaining compilation blockers (assembly helpers,

--- a/preconfigured/src/arch/x86/32/kernel/vspace.c
+++ b/preconfigured/src/arch/x86/32/kernel/vspace.c
@@ -621,6 +621,8 @@ void setVMRoot(tcb_t *tcb)
 void hwASIDInvalidate(asid_t asid, vspace_root_t *vspace)
 {
     /* 32-bit does not have PCID */
+    (void)asid;
+    (void)vspace;
     return;
 }
 
@@ -640,12 +642,17 @@ exception_t decodeX86ModeMMUInvocation(
 
     default:
         fail("Invalid arch cap type");
+        return EXCEPTION_SYSCALL_ERROR;
     }
 }
 
 
 bool_t modeUnmapPage(vm_page_size_t page_size, vspace_root_t *vroot, vptr_t vaddr, void *pptr)
 {
+    (void)page_size;
+    (void)vroot;
+    (void)vaddr;
+    (void)pptr;
     fail("Invalid page type");
     return false;
 }
@@ -653,7 +660,17 @@ bool_t modeUnmapPage(vm_page_size_t page_size, vspace_root_t *vroot, vptr_t vadd
 exception_t decodeX86ModeMapPage(word_t invLabel, vm_page_size_t page_size, cte_t *cte, cap_t cap,
                                  vspace_root_t *vroot, vptr_t vaddr, paddr_t paddr, vm_rights_t vm_rights, vm_attributes_t vm_attr)
 {
+    (void)invLabel;
+    (void)page_size;
+    (void)cte;
+    (void)cap;
+    (void)vroot;
+    (void)vaddr;
+    (void)paddr;
+    (void)vm_rights;
+    (void)vm_attr;
     fail("Invalid Page type");
+    return EXCEPTION_SYSCALL_ERROR;
 }
 
 #ifdef CONFIG_KERNEL_LOG_BUFFER

--- a/preconfigured/src/arch/x86/64/kernel/vspace.c
+++ b/preconfigured/src/arch/x86/64/kernel/vspace.c
@@ -1434,6 +1434,7 @@ exception_t decodeX86ModeMMUInvocation(
 
     default:
         fail("Invalid arch cap type");
+        return EXCEPTION_SYSCALL_ERROR;
     }
 }
 
@@ -1536,6 +1537,7 @@ exception_t decodeX86ModeMapPage(word_t label, vm_page_size_t page_size, cte_t *
         }
     }
     fail("Invalid Page type");
+    return EXCEPTION_SYSCALL_ERROR;
 }
 
 #ifdef CONFIG_PRINTING

--- a/preconfigured/src/arch/x86/64/object/objecttype.c
+++ b/preconfigured/src/arch/x86/64/object/objecttype.c
@@ -39,6 +39,8 @@ deriveCap_ret_t Mode_deriveCap(cte_t *slot, cap_t cap)
 {
     deriveCap_ret_t ret;
 
+    (void)slot;
+
     switch (cap_get_capType(cap)) {
     case cap_pml4_cap:
         if (cap_pml4_cap_get_capPML4IsMapped(cap)) {
@@ -72,6 +74,9 @@ deriveCap_ret_t Mode_deriveCap(cte_t *slot, cap_t cap)
 
     default:
         fail("Invalid arch cap type");
+        ret.cap = cap_null_cap_new();
+        ret.status = EXCEPTION_SYSCALL_ERROR;
+        return ret;
     }
 }
 
@@ -180,6 +185,8 @@ word_t Mode_getObjectSize(word_t t)
 
 cap_t Mode_createObject(object_t t, void *regionBase, word_t userSize, bool_t deviceMemory)
 {
+    (void)userSize;
+
     switch (t) {
 
     case seL4_X86_4K:
@@ -312,6 +319,7 @@ cap_t Mode_createObject(object_t t, void *regionBase, word_t userSize, bool_t de
          * passed (which is impossible in haskell).
          */
         fail("Arch_createObject got an API type or invalid object type");
+        return cap_null_cap_new();
     }
 }
 

--- a/preconfigured/src/arch/x86/kernel/ept.c
+++ b/preconfigured/src/arch/x86/kernel/ept.c
@@ -378,6 +378,7 @@ exception_t decodeX86EPTInvocation(
         return decodeX86EPTPTInvocation(invLabel, length, cte, cap, buffer);
     default:
         fail("Invalid cap type");
+        return EXCEPTION_SYSCALL_ERROR;
     }
 }
 


### PR DESCRIPTION
## Summary
- add explicit return values to the x86 EPT/MMU decode helpers when they hit fail() paths
- cast unused parameters in the 32-bit mode helpers so pedantic C89 builds stay quiet
- teach the 64-bit mode cap helpers to silence unused arguments and update the C89 project log with the new build blockers

## Testing
- ./preconfigured/replay_preconfigured_build.sh *(fails: unused parameters in TLB invalidation wrappers, CR3 helper still subscripts a temporary, boot paging routines need cleanups)*

------
https://chatgpt.com/codex/tasks/task_e_68d37b98379c832b8eeb4720a78f286b