### PR TITLE
Hoist x86 boot paging declarations for C90

### DIFF
--- a/C89-PROJECT.md
+++ b/C89-PROJECT.md
@@ -34,12 +34,14 @@ resulting compiler diagnostics.
   `__mode__(__word__)` attribute instead of depending on `__extension__`, the
   multiboot2 tag list no longer ends with a trailing comma, and the SKIM window
   mapper hoists its declarations and iterates with like-signed indices. The TLB
-  invalidation wrappers now cast their unused parameters, so the strict build
-  consequently advances into the x86 virtual memory code before failing on the
-  next wave of issues: the CR3 comparison still subscripts a temporary, several
-  boot-time mappers lean on compound literals or leave parameters unused, and a
-  handful of decode helpers fall off the end without explicit returns once the
-  attribute shims collapse.
+  invalidation wrappers now cast their unused parameters, and the boot-time x86
+  mappers have been rewritten to hoist their declarations and avoid compound
+  literals. The strict build consequently presses on to the remaining blockers
+  in the virtual memory code: the CR3 comparison still subscripts a temporary,
+  several decode helpers declare locals after executable statements, the MMU
+  invocation path leaves a handful of parameters unused and falls off the end
+  without returning, and the generated cap accessor for the mapped ASID still
+  needs an explicit return path.
 
 ### Key Diagnostic Themes
 1. **C99 integer literals**: The generated capability helpers and several x86
@@ -149,7 +151,7 @@ resulting compiler diagnostics.
         avoid C99 `for`-loop initialisers, and compare like-signed values.
   - [x] Cast the unused parameters in the x86 TLB invalidation wrappers and
         related boot helpers so the pedantic build stays quiet.
-  - [ ] Hoist declarations and add `(void)` casts in the x86 boot-time paging
+- [x] Hoist declarations and add `(void)` casts in the x86 boot-time paging
         helpers (`map_temp_boot_page`, `create_mapped_it_frame_cap`, and the
         slot region initialiser) so they satisfy pedantic C90.
   - [ ] Adjust the CR3 comparison helpers and boot-time mapping routines to

--- a/preconfigured/src/arch/x86/64/kernel/vspace.c
+++ b/preconfigured/src/arch/x86/64/kernel/vspace.c
@@ -641,6 +641,7 @@ BOOT_CODE void *map_temp_boot_page(void *entry, uint32_t large_pages)
      * collide with the kernel window. Here we just assert that the table is
      * in fact in the lower 4GiB region (which is already 1-to-1 mapped) and
      * continue */
+    (void)large_pages;
     assert((word_t)entry < BIT(32));
     return entry;
 }
@@ -702,6 +703,7 @@ BOOT_CODE cap_t create_it_address_space(cap_t root_cnode_cap, v_region_t it_v_re
     vptr_t     vptr;
     seL4_SlotPos slot_pos_before;
     seL4_SlotPos slot_pos_after;
+    seL4_SlotRegion slot_region;
 
     slot_pos_before = ndks_boot.slot_pos_cur;
     copyGlobalMappings(PML4_PTR(rootserver.vspace));
@@ -748,9 +750,9 @@ BOOT_CODE cap_t create_it_address_space(cap_t root_cnode_cap, v_region_t it_v_re
     }
 
     slot_pos_after = ndks_boot.slot_pos_cur;
-    ndks_boot.bi_frame->userImagePaging = (seL4_SlotRegion) {
-        slot_pos_before, slot_pos_after
-    };
+    slot_region.start = slot_pos_before;
+    slot_region.end = slot_pos_after;
+    ndks_boot.bi_frame->userImagePaging = slot_region;
     return vspace_cap;
 }
 
@@ -799,6 +801,8 @@ BOOT_CODE cap_t create_mapped_it_frame_cap(cap_t vspace_cap, pptr_t pptr, vptr_t
                                            bool_t executable UNUSED)
 {
     cap_t cap = create_it_frame_cap(pptr, vptr, asid, use_large, X86_MappingVSpace);
+
+    (void)executable;
     map_it_frame_cap(vspace_cap, cap);
     return cap;
 }


### PR DESCRIPTION
## Summary
- hoist the x86 boot paging locals above executable statements and cast unused boot parameters to void
- replace the boot-time slot-region compound literals with named temporaries so the structure assignments compile as C90
- note in the project tracker that the x86 boot paging helpers are now C90 compatible and describe the new build blockers

## Testing
- ./preconfigured/replay_preconfigured_build.sh *(fails: CR3 comparison still subscripts a temporary and decode helpers need C90 cleanups)*

------
https://chatgpt.com/codex/tasks/task_e_68d37c23b300832b8e1717eb1df7d508