### PR TITLE
Refactor CR3 helpers and boot mappers for C90

### DIFF
--- a/C89-PROJECT.md
+++ b/C89-PROJECT.md
@@ -37,9 +37,15 @@ resulting compiler diagnostics.
   strict build consequently advances into the x86 virtual memory code before
   failing on the next wave of issues: the TLB invalidation wrappers and paging
   helpers still need `(void)` casts for unused parameters, the CR3 comparison
-  relies on subscripting a temporary, several boot-time mappers use compound
-  literals, and a handful of decode helpers fall off the end without explicit
-  returns once the attribute shims collapse.
+  relied on subscripting a temporary, several boot-time mappers used compound
+  literals, and a handful of decode helpers fell off the end without explicit
+  returns once the attribute shims collapse. With the latest pass those CR3 and
+  boot-time helpers now operate on named temporaries, so the strict build
+  continues far enough to expose the remaining blockers: the x86 TLB
+  invalidation shims still need unused-parameter casts, the verified x86 vspace
+  sources rely on compound literals, mixed declarations, and unchecked returns,
+  and several generated decode helpers still fall off the end without producing
+  a value.
 
 ### Key Diagnostic Themes
 1. **C99 integer literals**: The generated capability helpers and several x86
@@ -149,8 +155,12 @@ resulting compiler diagnostics.
         avoid C99 `for`-loop initialisers, and compare like-signed values.
   - [ ] Cast the unused parameters in the x86 TLB invalidation wrappers and
         related boot helpers so the pedantic build stays quiet.
-  - [ ] Adjust the CR3 comparison helpers and boot-time mapping routines to
+  - [x] Adjust the CR3 comparison helpers and boot-time mapping routines to
         operate on named temporaries instead of subscripting compound literals.
+  - [ ] Rework the verified x86 vspace sources to eliminate compound literals,
+        cast unused parameters to `(void)`, hoist declarations above statements,
+        and provide explicit returns now that the strict build reaches those
+        translation units.
   - [ ] Audit the x86 decode and mode-specific cap helpers to provide explicit
         returns and `(void)` casts for unused parameters now that the attribute
         shims collapse under C90.

--- a/preconfigured/include/arch/x86/arch/64/mode/fastpath/fastpath.h
+++ b/preconfigured/include/arch/x86/arch/64/mode/fastpath/fastpath.h
@@ -11,6 +11,7 @@
 #include <api/types.h>
 #include <api/syscall.h>
 #include <plat/machine/hardware.h>
+#include <mode/machine.h>
 #include <kernel/traps.h>
 #include <smp/lock.h>
 #include <model/statedata.h>
@@ -44,7 +45,11 @@ static inline void FORCE_INLINE switchToThread_fp(tcb_t *thread, vspace_root_t *
     /* the asid is the 12-bit PCID */
     asid_t asid = (asid_t)(stored_hw_asid.words[0] & 0xfff);
     cr3_t next_cr3 = makeCR3(new_vroot, asid);
-    if (likely(getCurrentUserCR3().words[0] != next_cr3.words[0])) {
+    cr3_t current_cr3 = getCurrentUserCR3();
+    word_t current_cr3_word = cr3_get_raw_word(current_cr3);
+    word_t next_cr3_word = cr3_get_raw_word(next_cr3);
+
+    if (likely(current_cr3_word != next_cr3_word)) {
         SMP_COND_STATEMENT(tlb_bitmap_set(vroot, getCurrentCPUIndex());)
         setCurrentUserCR3(next_cr3);
     }

--- a/preconfigured/include/arch/x86/arch/64/mode/machine.h
+++ b/preconfigured/include/arch/x86/arch/64/mode/machine.h
@@ -43,6 +43,11 @@ static inline cr3_t makeCR3(paddr_t addr, word_t pcid)
     return cr3_new(addr, config_set(CONFIG_SUPPORT_PCID) ? pcid : 0);
 }
 
+static inline word_t cr3_get_raw_word(cr3_t cr3)
+{
+    return cr3.words[0];
+}
+
 /* Address space control */
 static inline cr3_t getCurrentCR3(void)
 {

--- a/preconfigured/src/arch/x86/64/kernel/vspace.c
+++ b/preconfigured/src/arch/x86/64/kernel/vspace.c
@@ -485,6 +485,9 @@ void setVMRoot(tcb_t *tcb)
     pml4e_t *pml4;
     findVSpaceForASID_ret_t find_ret;
     cr3_t cr3;
+    cr3_t current_cr3;
+    word_t current_cr3_word;
+    word_t new_cr3_word;
 
     threadRoot = TCB_PTR_CTE_PTR(tcb, tcbVTable)->cap;
 
@@ -502,7 +505,10 @@ void setVMRoot(tcb_t *tcb)
         return;
     }
     cr3 = makeCR3(pptr_to_paddr(pml4), asid);
-    if (getCurrentUserCR3().words[0] != cr3.words[0]) {
+    current_cr3 = getCurrentUserCR3();
+    current_cr3_word = cr3_get_raw_word(current_cr3);
+    new_cr3_word = cr3_get_raw_word(cr3);
+    if (current_cr3_word != new_cr3_word) {
         SMP_COND_STATEMENT(tlb_bitmap_set(pml4, getCurrentCPUIndex());)
         setCurrentUserCR3(cr3);
     }

--- a/preconfigured/src/arch/x86/kernel/vspace.c
+++ b/preconfigured/src/arch/x86/kernel/vspace.c
@@ -138,14 +138,15 @@ BOOT_CODE bool_t map_kernel_window_devices(pte_t *pt, uint32_t num_ioapic, paddr
     paddr_t phys;
     pte_t pte;
     unsigned int i;
+    p_region_t region;
     /* map kernel devices: APIC */
     phys = apic_get_base_paddr();
     if (!phys) {
         return false;
     }
-    if (!reserve_region((p_region_t) {
-    phys, phys + 0x1000
-})) {
+    region.start = phys;
+    region.end = phys + 0x1000;
+    if (!reserve_region(region)) {
         return false;
     }
     pte = x86_make_device_pte(phys);
@@ -155,9 +156,9 @@ BOOT_CODE bool_t map_kernel_window_devices(pte_t *pt, uint32_t num_ioapic, paddr
     idx++;
     for (i = 0; i < num_ioapic; i++) {
         phys = ioapic_paddrs[i];
-        if (!reserve_region((p_region_t) {
-        phys, phys + 0x1000
-    })) {
+        region.start = phys;
+        region.end = phys + 0x1000;
+        if (!reserve_region(region)) {
             return false;
         }
         pte = x86_make_device_pte(phys);
@@ -179,9 +180,9 @@ BOOT_CODE bool_t map_kernel_window_devices(pte_t *pt, uint32_t num_ioapic, paddr
     /* map kernel devices: IOMMUs */
     for (i = 0; i < num_drhu; i++) {
         phys = (paddr_t)drhu_list[i];
-        if (!reserve_region((p_region_t) {
-        phys, phys + 0x1000
-    })) {
+        region.start = phys;
+        region.end = phys + 0x1000;
+        if (!reserve_region(region)) {
             return false;
         }
         pte = x86_make_device_pte(phys);

--- a/preconfigured/src/arch/x86/object/vcpu.c
+++ b/preconfigured/src/arch/x86/object/vcpu.c
@@ -15,6 +15,7 @@
 #include <kernel/thread.h>
 #include <object/objecttype.h>
 #include <arch/machine/cpu_registers.h>
+#include <arch/machine.h>
 #include <arch/model/statedata.h>
 #include <arch/object/vcpu.h>
 #include <arch/object/ioport.h>
@@ -1551,9 +1552,16 @@ void restoreVMCS(void)
     }
 
 #ifndef CONFIG_KERNEL_SKIM_WINDOW
-    if (getCurrentCR3().words[0] != expected_vmcs->last_host_cr3) {
-        expected_vmcs->last_host_cr3 = getCurrentCR3().words[0];
-        vmwrite(VMX_HOST_CR3, getCurrentCR3().words[0]);
+    {
+        cr3_t current_cr3;
+        word_t current_cr3_word;
+
+        current_cr3 = getCurrentCR3();
+        current_cr3_word = cr3_get_raw_word(current_cr3);
+        if (current_cr3_word != expected_vmcs->last_host_cr3) {
+            expected_vmcs->last_host_cr3 = current_cr3_word;
+            vmwrite(VMX_HOST_CR3, current_cr3_word);
+        }
     }
 #endif
     if (expected_vmcs->vpid == VPID_INVALID) {


### PR DESCRIPTION
## Summary
- use named temporaries for the CR3 comparisons in the fastpath, VM root switch, and VMCS restore helpers so the code no longer subscripts temporaries
- provide a shared `cr3_get_raw_word` helper and reuse it across the CR3 comparisons so the change stays aligned with the latest tree
- convert the boot-time x86 mapping helpers to populate p_region_t temporaries before calling the reservation routines for C90 compliance
- update the C89 project log to record the stricter build outcome and add follow-up tasks for the newly surfaced diagnostics

## Testing
- ./preconfigured/replay_preconfigured_build.sh *(fails: pedantic build now stops on unused parameters, compound literals, and missing returns in the remaining x86 TLB/vspace helpers)*

------
https://chatgpt.com/codex/tasks/task_e_68d37b75d49c832bb9d1a828995d6b86