### PR TITLE
Use temporaries for CR3 checks and boot mappings

### DIFF
--- a/C89-PROJECT.md
+++ b/C89-PROJECT.md
@@ -34,14 +34,13 @@ resulting compiler diagnostics.
   `__mode__(__word__)` attribute instead of depending on `__extension__`, the
   multiboot2 tag list no longer ends with a trailing comma, and the SKIM window
   mapper hoists its declarations and iterates with like-signed indices. The TLB
-  invalidation wrappers now cast their unused parameters, and the boot-time x86
-  mappers have been rewritten to hoist their declarations and avoid compound
-  literals. The strict build consequently presses on to the remaining blockers
-  in the virtual memory code: the CR3 comparison still subscripts a temporary,
-  several decode helpers declare locals after executable statements, the MMU
-  invocation path leaves a handful of parameters unused and falls off the end
-  without returning, and the generated cap accessor for the mapped ASID still
-  needs an explicit return path.
+  invalidation wrappers now cast their unused parameters, the boot-time x86
+  mappers avoid compound literals, and the CR3 helpers compare against named
+  temporaries. The strict build consequently presses on to the remaining
+  blockers in the virtual memory code: several decode helpers declare locals
+  after executable statements, the MMU invocation path leaves a handful of
+  parameters unused and falls off the end without returning, and the generated
+  cap accessor for the mapped ASID still needs an explicit return path.
 
 ### Key Diagnostic Themes
 1. **C99 integer literals**: The generated capability helpers and several x86
@@ -154,7 +153,7 @@ resulting compiler diagnostics.
 - [x] Hoist declarations and add `(void)` casts in the x86 boot-time paging
         helpers (`map_temp_boot_page`, `create_mapped_it_frame_cap`, and the
         slot region initialiser) so they satisfy pedantic C90.
-  - [ ] Adjust the CR3 comparison helpers and boot-time mapping routines to
+  - [x] Adjust the CR3 comparison helpers and boot-time mapping routines to
         operate on named temporaries instead of subscripting compound literals.
   - [ ] Audit the x86 decode and mode-specific cap helpers to provide explicit
         returns and `(void)` casts for unused parameters now that the attribute

--- a/preconfigured/include/arch/x86/arch/64/mode/fastpath/fastpath.h
+++ b/preconfigured/include/arch/x86/arch/64/mode/fastpath/fastpath.h
@@ -44,7 +44,8 @@ static inline void FORCE_INLINE switchToThread_fp(tcb_t *thread, vspace_root_t *
     /* the asid is the 12-bit PCID */
     asid_t asid = (asid_t)(stored_hw_asid.words[0] & 0xfff);
     cr3_t next_cr3 = makeCR3(new_vroot, asid);
-    if (likely(getCurrentUserCR3().words[0] != next_cr3.words[0])) {
+    cr3_t current_cr3 = getCurrentUserCR3();
+    if (likely(current_cr3.words[0] != next_cr3.words[0])) {
         SMP_COND_STATEMENT(tlb_bitmap_set(vroot, getCurrentCPUIndex());)
         setCurrentUserCR3(next_cr3);
     }

--- a/preconfigured/src/arch/riscv/machine/hardware.c
+++ b/preconfigured/src/arch/riscv/machine/hardware.c
@@ -35,14 +35,14 @@ BOOT_CODE void map_kernel_devices(void)
      * NULL. Thus we can't use ARRAY_SIZE(kernel_device_frames) here directly,
      * but have to use NUM_KERNEL_DEVICE_FRAMES that is defined accordingly.
      */
+    p_region_t region;
     for (int i = 0; i < NUM_KERNEL_DEVICE_FRAMES; i++) {
         const kernel_frame_t *frame = &kernel_device_frames[i];
         map_kernel_frame(frame->paddr, frame->pptr, VMKernelOnly);
         if (!frame->userAvailable) {
-            reserve_region((p_region_t) {
-                .start = frame->paddr,
-                .end   = frame->paddr + BIT(seL4_LargePageBits)
-            });
+            region.start = frame->paddr;
+            region.end = frame->paddr + BIT(seL4_LargePageBits);
+            reserve_region(region);
         }
     }
 }

--- a/preconfigured/src/arch/x86/64/kernel/vspace.c
+++ b/preconfigured/src/arch/x86/64/kernel/vspace.c
@@ -485,6 +485,8 @@ void setVMRoot(tcb_t *tcb)
     pml4e_t *pml4;
     findVSpaceForASID_ret_t find_ret;
     cr3_t cr3;
+    cr3_t current_cr3;
+    word_t current_cr3_word;
 
     threadRoot = TCB_PTR_CTE_PTR(tcb, tcbVTable)->cap;
 
@@ -502,7 +504,9 @@ void setVMRoot(tcb_t *tcb)
         return;
     }
     cr3 = makeCR3(pptr_to_paddr(pml4), asid);
-    if (getCurrentUserCR3().words[0] != cr3.words[0]) {
+    current_cr3 = getCurrentUserCR3();
+    current_cr3_word = current_cr3.words[0];
+    if (current_cr3_word != cr3.words[0]) {
         SMP_COND_STATEMENT(tlb_bitmap_set(pml4, getCurrentCPUIndex());)
         setCurrentUserCR3(cr3);
     }

--- a/preconfigured/src/arch/x86/kernel/vspace.c
+++ b/preconfigured/src/arch/x86/kernel/vspace.c
@@ -138,14 +138,15 @@ BOOT_CODE bool_t map_kernel_window_devices(pte_t *pt, uint32_t num_ioapic, paddr
     paddr_t phys;
     pte_t pte;
     unsigned int i;
+    p_region_t region;
     /* map kernel devices: APIC */
     phys = apic_get_base_paddr();
     if (!phys) {
         return false;
     }
-    if (!reserve_region((p_region_t) {
-    phys, phys + 0x1000
-})) {
+    region.start = phys;
+    region.end = phys + 0x1000;
+    if (!reserve_region(region)) {
         return false;
     }
     pte = x86_make_device_pte(phys);
@@ -155,9 +156,9 @@ BOOT_CODE bool_t map_kernel_window_devices(pte_t *pt, uint32_t num_ioapic, paddr
     idx++;
     for (i = 0; i < num_ioapic; i++) {
         phys = ioapic_paddrs[i];
-        if (!reserve_region((p_region_t) {
-        phys, phys + 0x1000
-    })) {
+        region.start = phys;
+        region.end = phys + 0x1000;
+        if (!reserve_region(region)) {
             return false;
         }
         pte = x86_make_device_pte(phys);
@@ -179,9 +180,9 @@ BOOT_CODE bool_t map_kernel_window_devices(pte_t *pt, uint32_t num_ioapic, paddr
     /* map kernel devices: IOMMUs */
     for (i = 0; i < num_drhu; i++) {
         phys = (paddr_t)drhu_list[i];
-        if (!reserve_region((p_region_t) {
-        phys, phys + 0x1000
-    })) {
+        region.start = phys;
+        region.end = phys + 0x1000;
+        if (!reserve_region(region)) {
             return false;
         }
         pte = x86_make_device_pte(phys);

--- a/preconfigured/src/arch/x86/object/vcpu.c
+++ b/preconfigured/src/arch/x86/object/vcpu.c
@@ -1544,6 +1544,8 @@ void restoreVMCS(void)
 {
     tcb_t *cur_thread = NODE_STATE(ksCurThread);
     vcpu_t *expected_vmcs = cur_thread->tcbArch.tcbVCPU;
+    cr3_t current_cr3;
+    word_t current_cr3_word;
 
     /* Check that the right VMCS is active and current. */
     if (ARCH_NODE_STATE(x86KSCurrentVCPU) != expected_vmcs) {
@@ -1551,9 +1553,11 @@ void restoreVMCS(void)
     }
 
 #ifndef CONFIG_KERNEL_SKIM_WINDOW
-    if (getCurrentCR3().words[0] != expected_vmcs->last_host_cr3) {
-        expected_vmcs->last_host_cr3 = getCurrentCR3().words[0];
-        vmwrite(VMX_HOST_CR3, getCurrentCR3().words[0]);
+    current_cr3 = getCurrentCR3();
+    current_cr3_word = current_cr3.words[0];
+    if (current_cr3_word != expected_vmcs->last_host_cr3) {
+        expected_vmcs->last_host_cr3 = current_cr3_word;
+        vmwrite(VMX_HOST_CR3, current_cr3_word);
     }
 #endif
     if (expected_vmcs->vpid == VPID_INVALID) {

--- a/preconfigured/src/plat/pc99/machine/hardware.c
+++ b/preconfigured/src/plat/pc99/machine/hardware.c
@@ -21,13 +21,14 @@
 
 BOOT_CODE bool_t platAddDevices(void)
 {
+    p_region_t region;
     /* remove the MSI region as poking at this is undefined and may allow for
      * the user to generate arbitrary MSI interrupts. Only need to consider
      * this if it would actually be in the user device region */
     if (CONFIG_PADDR_USER_DEVICE_TOP > 0xFFFFFFF8) {
-        if (!reserve_region((p_region_t) {
-        (word_t)0xFFFFFFF8, (word_t)0xFFFFFFF8 + 8
-        })) {
+        region.start = (paddr_t)0xFFFFFFF8;
+        region.end = (paddr_t)0xFFFFFFF8 + 8;
+        if (!reserve_region(region)) {
             return false;
         }
     }


### PR DESCRIPTION
## Summary
- compare CR3 values through named temporaries in the fastpath, VM root, and VMCS helpers
- replace boot-time reserve_region compound literals with explicit p_region_t temporaries across the x86 and RISC-V mappers
- refresh the C89 project log to capture the new state of the build and mark the CR3 task complete

## Testing
- `./preconfigured/replay_preconfigured_build.sh` *(fails: pending declaration-order, unused parameter, and missing return fixes)*

------
https://chatgpt.com/codex/tasks/task_e_68d3977feedc832b92cd0f418e53d7ec