### PR TITLE
Fix x86-64 vspace C90 issues

### DIFF
--- a/C89-PROJECT.md
+++ b/C89-PROJECT.md
@@ -36,11 +36,15 @@ resulting compiler diagnostics.
   mapper hoists its declarations and iterates with like-signed indices. The TLB
   invalidation wrappers now cast their unused parameters, the boot-time x86
   mappers avoid compound literals, and the CR3 helpers compare against named
-  temporaries. The strict build consequently presses on to the remaining
-  blockers in the virtual memory code: several decode helpers declare locals
-  after executable statements, the MMU invocation path leaves a handful of
-  parameters unused and falls off the end without returning, and the generated
-  cap accessor for the mapped ASID still needs an explicit return path.
+  temporaries. The strict build consequently pressed on to the remaining
+  blockers in the virtual memory code: several decode helpers declared locals
+  after executable statements, the MMU invocation path left a handful of
+  parameters unused and fell off the end without returning, and the generated
+  cap accessor for the mapped ASID still needed an explicit return path. Those
+  shims now hoist their declarations, cast their unused arguments, and return
+  explicit errors, allowing the pedantic build to reach the next blocker: the
+  generated `capdl_wrapper.c` translation unit triggers `-Wpedantic` because it
+  compiles down to an empty source file.
 
 ### Key Diagnostic Themes
 1. **C99 integer literals**: The generated capability helpers and several x86
@@ -155,8 +159,11 @@ resulting compiler diagnostics.
         slot region initialiser) so they satisfy pedantic C90.
   - [x] Adjust the CR3 comparison helpers and boot-time mapping routines to
         operate on named temporaries instead of subscripting compound literals.
-  - [ ] Audit the x86 decode and mode-specific cap helpers to provide explicit
+  - [x] Audit the x86 decode and mode-specific cap helpers to provide explicit
         returns and `(void)` casts for unused parameters now that the attribute
         shims collapse under C90.
+  - [ ] Teach the generated capDL wrapper sources to emit a benign definition
+        when no kernel objects are present so the strict build no longer flags
+        the empty translation unit under `-Wpedantic`.
 - Continue iterating on the remaining compilation blockers (assembly helpers,
   missing returns, etc.) surfaced by the latest build.

--- a/preconfigured/include/arch/x86/arch/64/mode/object/structures.h
+++ b/preconfigured/include/arch/x86/arch/64/mode/object/structures.h
@@ -136,6 +136,8 @@ static inline asid_t PURE cap_get_capMappedASID(cap_t cap)
     default:
         fail("Invalid arch cap type");
     }
+
+    return asidInvalid;
 }
 
 static inline word_t CONST cap_get_modeCapSizeBits(cap_t cap)

--- a/preconfigured/src/arch/x86/64/kernel/vspace.c
+++ b/preconfigured/src/arch/x86/64/kernel/vspace.c
@@ -1160,14 +1160,15 @@ static exception_t decodeX64PageDirectoryInvocation(
     word_t *buffer
 )
 {
-    word_t              vaddr;
-    vm_attributes_t     vm_attr;
-    cap_t               vspaceCap;
-    vspace_root_t      *vspace;
-    pdpte_t             pdpte;
-    paddr_t             paddr;
-    asid_t              asid;
+    word_t               vaddr;
+    vm_attributes_t      vm_attr;
+    cap_t                vspaceCap;
+    vspace_root_t       *vspace;
+    pdpte_t              pdpte;
+    paddr_t              paddr;
+    asid_t               asid;
     lookupPDPTSlot_ret_t pdptSlot;
+    findVSpaceForASID_ret_t find_ret;
 
     if (label == X86PageDirectoryUnmap) {
         if (!isFinalCapability(cte)) {
@@ -1221,8 +1222,6 @@ static exception_t decodeX64PageDirectoryInvocation(
 
         return EXCEPTION_SYSCALL_ERROR;
     }
-
-    findVSpaceForASID_ret_t find_ret;
 
     find_ret = findVSpaceForASID(asid);
     if (find_ret.status != EXCEPTION_NONE) {
@@ -1331,6 +1330,7 @@ static exception_t decodeX64PDPTInvocation(
     pml4e_t                 pml4e;
     paddr_t                 paddr;
     asid_t                  asid;
+    findVSpaceForASID_ret_t find_ret;
 
     if (label == X86PDPTUnmap) {
         if (!isFinalCapability(cte)) {
@@ -1386,8 +1386,6 @@ static exception_t decodeX64PDPTInvocation(
         return EXCEPTION_SYSCALL_ERROR;
     }
 
-    findVSpaceForASID_ret_t find_ret;
-
     find_ret = findVSpaceForASID(asid);
     if (find_ret.status != EXCEPTION_NONE) {
         current_syscall_error.type = seL4_FailedLookup;
@@ -1432,6 +1430,9 @@ exception_t decodeX86ModeMMUInvocation(
     word_t *buffer
 )
 {
+    (void)cptr;
+    (void)call;
+
     switch (cap_get_capType(cap)) {
 
     case cap_pml4_cap:
@@ -1447,6 +1448,8 @@ exception_t decodeX86ModeMMUInvocation(
     default:
         fail("Invalid arch cap type");
     }
+
+    return EXCEPTION_SYSCALL_ERROR;
 }
 
 bool_t modeUnmapPage(vm_page_size_t page_size, vspace_root_t *vroot, vptr_t vaddr, void *pptr)
@@ -1548,6 +1551,7 @@ exception_t decodeX86ModeMapPage(word_t label, vm_page_size_t page_size, cte_t *
         }
     }
     fail("Invalid Page type");
+    return EXCEPTION_SYSCALL_ERROR;
 }
 
 #ifdef CONFIG_PRINTING


### PR DESCRIPTION
## Summary
- hoist the ASID lookup declarations in the x86-64 vspace decode helpers and silence unused parameters so they satisfy C90 rules
- make the mapped ASID accessor return a safe default after its fail() call to placate pedantic builds
- update the C89 project plan with the latest build status and note the new capDL wrapper blocker

## Testing
- ./preconfigured/replay_preconfigured_build.sh *(fails: capdl_wrapper.c trips -Wpedantic for an empty translation unit)*

------
https://chatgpt.com/codex/tasks/task_e_68d39b497240832bace3748f67749896