### PR TITLE
Fix registerset compile_assert usage for pedantic C90

### DIFF
--- a/C89-PROJECT.md
+++ b/C89-PROJECT.md
@@ -44,6 +44,13 @@ resulting compiler diagnostics.
   shims now hoist their declarations, cast their unused arguments, and return
   explicit errors, allowing the pedantic build to reach the next blocker.
 
+  The latest run also surfaced that the x86 register-set consistency checks were
+  still written in the old `compile_assert(name, expr);` style. Dropping the
+  trailing statement terminators lets the pedantic C90 build accept the
+  generated wrappers and carry on to the next failure in
+  `src/arch/x86/64/model/smp.c`, where the strict warnings now flag the empty
+  translation unit emitted when SMP support is disabled.
+
 ### Key Diagnostic Themes
 1. **C99 integer literals**: The generated capability helpers and several x86
    machine shims still emit `ULL` and `LL` constants that trigger
@@ -160,7 +167,10 @@ resulting compiler diagnostics.
   - [x] Audit the x86 decode and mode-specific cap helpers to provide explicit
         returns and `(void)` casts for unused parameters now that the attribute
         shims collapse under C90.
-  - [ ] Teach the generated capDL wrapper sources to emit a benign definition
+  - [ ] Provide a benign definition in `src/arch/x86/64/model/smp.c` so the
+        pedantic build no longer rejects the empty translation unit when SMP is
+        disabled.
+- [ ] Teach the generated capDL wrapper sources to emit a benign definition
         when no kernel objects are present so the strict build no longer flags
         the empty translation unit under `-Wpedantic`.
 - Continue iterating on the remaining compilation blockers (assembly helpers,

--- a/preconfigured/src/arch/x86/64/machine/registerset.c
+++ b/preconfigured/src/arch/x86/64/machine/registerset.c
@@ -16,7 +16,7 @@ const register_t msgRegisters[] = {
 compile_assert(
     consistent_message_registers,
     sizeof(msgRegisters) / sizeof(msgRegisters[0]) == n_msgRegisters
-);
+)
 
 const register_t frameRegisters[] = {
     FaultIP, RSP, FLAGS, RAX, RBX, RCX, RDX, RSI, RDI, RBP,
@@ -25,7 +25,7 @@ const register_t frameRegisters[] = {
 compile_assert(
     consistent_frame_registers,
     sizeof(frameRegisters) / sizeof(frameRegisters[0]) == n_frameRegisters
-);
+)
 
 const register_t gpRegisters[] = {
     FS_BASE, GS_BASE
@@ -33,7 +33,7 @@ const register_t gpRegisters[] = {
 compile_assert(
     consistent_gp_registers,
     sizeof(gpRegisters) / sizeof(gpRegisters[0]) == n_gpRegisters
-);
+)
 
 void Mode_initContext(user_context_t *context)
 {


### PR DESCRIPTION
## Summary
- drop the trailing statement terminators from the x86 register set compile_assert helpers so the pedantic C90 build accepts the translation unit
- capture the newly exposed SMP empty-translation-unit diagnostic in the C89 tracking plan

## Testing
- ./preconfigured/replay_preconfigured_build.sh *(fails: ISO C forbids an empty translation unit in src/arch/x86/64/model/smp.c)*

------
https://chatgpt.com/codex/tasks/task_e_68d39eef3ea8832b9645d55ceb09349b