### PR TITLE
Fix x86 object helpers for strict C90 builds

### DIFF
--- a/preconfigured/include/arch/x86/arch/machine/hardware.h
+++ b/preconfigured/include/arch/x86/arch/machine/hardware.h
@@ -67,6 +67,8 @@ static inline word_t CONST pageBitsForSize(vm_page_size_t pagesize)
     default:
         fail("Invalid page size");
     }
+
+    return 0;
 }
 
 /* This function is a duplicate of pageBitsForSize, needed for calls that occur
@@ -89,6 +91,8 @@ static inline word_t CONST pageBitsForSize_phys(vm_page_size_t pagesize)
     default:
         fail("Invalid page size");
     }
+
+    return 0;
 }
 
 /* Returns the size of CPU's cacheline */

--- a/preconfigured/src/arch/x86/64/object/objecttype.c
+++ b/preconfigured/src/arch/x86/64/object/objecttype.c
@@ -39,6 +39,16 @@ deriveCap_ret_t Mode_deriveCap(cte_t *slot, cap_t cap)
 {
     deriveCap_ret_t ret;
 
+    /* The strict C90 build collapses the attribute shims that normally mark
+     * these parameters as intentionally unused. Hoist explicit casts so the
+     * pedantic warnings do not escalate to errors when the architecture cases
+     * fall through at compile time.
+     */
+    (void)slot;
+
+    ret.cap = cap_null_cap_new();
+    ret.status = EXCEPTION_SYSCALL_ERROR;
+
     switch (cap_get_capType(cap)) {
     case cap_pml4_cap:
         if (cap_pml4_cap_get_capPML4IsMapped(cap)) {
@@ -72,7 +82,10 @@ deriveCap_ret_t Mode_deriveCap(cte_t *slot, cap_t cap)
 
     default:
         fail("Invalid arch cap type");
+        break;
     }
+
+    return ret;
 }
 
 finaliseCap_ret_t Mode_finaliseCap(cap_t cap, bool_t final)
@@ -180,6 +193,8 @@ word_t Mode_getObjectSize(word_t t)
 
 cap_t Mode_createObject(object_t t, void *regionBase, word_t userSize, bool_t deviceMemory)
 {
+    (void)userSize;
+
     switch (t) {
 
     case seL4_X86_4K:
@@ -313,6 +328,8 @@ cap_t Mode_createObject(object_t t, void *regionBase, word_t userSize, bool_t de
          */
         fail("Arch_createObject got an API type or invalid object type");
     }
+
+    return cap_null_cap_new();
 }
 
 exception_t Mode_decodeInvocation(


### PR DESCRIPTION
## Summary
- cast the unused mode-specific parameters and initialise fallback results so the x86 cap helpers always return a value
- add explicit fallback returns to the x86 page-size helpers that previously relied on the fail() macro being noreturn
- document the progress in the C89 project plan and note the newly exposed x86 fault stub blockers

## Testing
- ./preconfigured/replay_preconfigured_build.sh (fails: pedantic warnings in src/arch/x86/api/faults.c about unused parameters and missing returns)


------
https://chatgpt.com/codex/tasks/task_e_68d3a22a8adc832bacf6175032519bcb