### PR TITLE
Fix x86 fault stubs for C89 build

### DIFF
--- a/preconfigured/src/arch/x86/api/faults.c
+++ b/preconfigured/src/arch/x86/api/faults.c
@@ -12,6 +12,9 @@
 
 bool_t Arch_handleFaultReply(tcb_t *receiver, tcb_t *sender, word_t faultType)
 {
+    (void)receiver;
+    (void)sender;
+
     switch (faultType) {
     case seL4_Fault_VMFault:
         return true;
@@ -19,6 +22,8 @@ bool_t Arch_handleFaultReply(tcb_t *receiver, tcb_t *sender, word_t faultType)
     default:
         fail("Invalid fault");
     }
+
+    return false;
 }
 
 word_t Arch_setMRs_fault(tcb_t *sender, tcb_t *receiver, word_t *receiveIPCBuffer, word_t faultType)
@@ -36,6 +41,8 @@ word_t Arch_setMRs_fault(tcb_t *sender, tcb_t *receiver, word_t *receiveIPCBuffe
     default:
         fail("Invalid fault");
     }
+
+    return 0;
 }
 
 word_t handleKernelException(


### PR DESCRIPTION
## Summary
- cast the x86 fault reply stubs' unused parameters to `(void)` and provide explicit return values
- update the C89 project log to record the resolved fault warnings and the new benchmark empty-translation-unit error

## Testing
- ./preconfigured/replay_preconfigured_build.sh *(fails: x86 benchmark wrapper empty translation unit)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a366dcf4832b926d1a7e83e8dccc