### PR TITLE
Silence double-fault parameter and log next C90 blockers

### DIFF
--- a/preconfigured/src/kernel/faulthandler.c
+++ b/preconfigured/src/kernel/faulthandler.c
@@ -148,6 +148,9 @@ void handleNoFaultHandler(tcb_t *tptr)
 void handleDoubleFault(tcb_t *tptr, seL4_Fault_t ex1)
 #endif
 {
+#ifndef CONFIG_PRINTING
+    (void)ex1;
+#endif
 #ifdef CONFIG_PRINTING
 #ifdef CONFIG_KERNEL_MCS
     printf("Found thread has no fault handler while trying to handle:\n");


### PR DESCRIPTION
## Summary
- silence the unused first-fault argument in `handleDoubleFault` when printing is disabled so the pedantic C90 build accepts the handler
- update the project log to mark the double-fault task complete and record the new `src/kernel/thread.c` declaration-order blockers revealed by the latest build

## Testing
- `./preconfigured/replay_preconfigured_build.sh` *(fails: src/kernel/thread.c now reports mixed declarations and code)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b95f7010832b95420d291d2ff6de