### PR TITLE
Silence switchFpuOwner CPU parameter in C89 build

### DIFF
--- a/C89-PROJECT.md
+++ b/C89-PROJECT.md
@@ -130,6 +130,12 @@ to progress into `src/kernel/thread.c`. Hoisting the reply-path locals out of
 the executable statements lets `doReplyTransfer` and `schedule` satisfy C90's
 declaration rules, so the pedantic build now runs until the next blocker.
 
+Guarding `switchFpuOwner`'s CPU argument with a `(void)` cast when SMP support
+is absent lets the strict build progress into `src/machine/registerset.c`. The
+pedantic warning set now rejects the designated initialisers that expand from
+the syscall and exception message tables, so rewriting those arrays without
+bracket designators is the next compilation blocker.
+
 ### Key Diagnostic Themes
 1. **C99 integer literals**: The generated capability helpers and several x86
    machine shims still emit `ULL` and `LL` constants that trigger
@@ -259,6 +265,9 @@ declaration rules, so the pedantic build now runs until the next blocker.
 - [x] Provide a benign definition in the x86 benchmarking stubs so the strict
   build no longer rejects the empty translation unit emitted by
   `src/arch/x86/benchmark/benchmark.c`.
+- [ ] Rewrite the syscall and exception message tables in
+  `src/machine/registerset.c` so they avoid the designated initialisers that
+  pedantic C90 rejects.
 - [ ] Provide a benign definition in the x86 EPT stubs so the strict build no
   longer rejects the empty translation unit emitted by
   `src/arch/x86/kernel/ept.c` when VT-d is disabled.

--- a/preconfigured/src/machine/fpu.c
+++ b/preconfigured/src/machine/fpu.c
@@ -34,6 +34,9 @@ void switchFpuOwner(tcb_t *new_owner, word_t cpu)
     } else
 #endif /* ENABLE_SMP_SUPPORT */
     {
+#ifndef ENABLE_SMP_SUPPORT
+        (void)cpu;
+#endif
         switchLocalFpuOwner(new_owner);
     }
 }


### PR DESCRIPTION
## Summary
- silence the unused CPU argument in `switchFpuOwner` when SMP support is compiled out
- record the new pedantic blocker in `src/machine/registerset.c` within `C89-PROJECT.md`

## Testing
- ./preconfigured/replay_preconfigured_build.sh (fails: pedantic C90 rejects designated initialisers in src/machine/registerset.c)


------
https://chatgpt.com/codex/tasks/task_e_68d3bc5b675c832b9a473b34f02b67dc