### PR TITLE
Fix cnode C90 diagnostics and update plan

### DIFF
--- a/C89-PROJECT.md
+++ b/C89-PROJECT.md
@@ -140,6 +140,12 @@ lets the strict build advance into `src/object/cnode.c`, where
 `capRemovable` still falls off the end without returning a value when the
 arch-specific cases collapse under C90.
 
+Consuming the `cteDeleteOne` finalisation result and giving `capRemovable`
+an explicit default return lets the pedantic build progress into
+`src/object/endpoint.c`. The next blocker lives in `sendIPC`, which still
+declares `replyCanGrant` after executable statements once the capability
+checks are reduced, triggering the C90 mixed-declaration warning.
+
 ### Key Diagnostic Themes
 1. **C99 integer literals**: The generated capability helpers and several x86
    machine shims still emit `ULL` and `LL` constants that trigger
@@ -320,11 +326,14 @@ arch-specific cases collapse under C90.
 - [x] Hoist the reply-path locals in `src/kernel/thread.c`
   (`doReplyTransfer`, `schedule`) so they no longer mix declarations with
   statements under C90.
-- [ ] Adjust the `src/object/cnode.c` helpers uncovered by the latest strict
+- [x] Adjust the `src/object/cnode.c` helpers uncovered by the latest strict
   build run so they satisfy pedantic C90:
-  - [ ] Consume or drop the unused `fc_ret` temporary in `cteDeleteOne` once
+  - [x] Consume or drop the unused `fc_ret` temporary in `cteDeleteOne` once
         the cap finalisation collapses.
-  - [ ] Give `capRemovable` an explicit return path when the architecture
+  - [x] Give `capRemovable` an explicit return path when the architecture
         special-cases compile away.
+- [ ] Hoist the `replyCanGrant` declaration in `src/object/endpoint.c`'s
+  `sendIPC` helper so it no longer mixes declarations with statements under
+  strict C90.
 - Continue iterating on the remaining compilation blockers (assembly helpers,
   missing returns, etc.) surfaced by the latest build.

--- a/preconfigured/src/object/cnode.c
+++ b/preconfigured/src/object/cnode.c
@@ -604,6 +604,7 @@ static inline bool_t CONST capRemovable(cap_t cap, cte_t *slot)
     }
     default:
         fail("finaliseCap should only return Zombie or NullCap");
+        return false;
     }
 }
 
@@ -729,7 +730,7 @@ void cteDeleteOne(cte_t *slot)
     word_t cap_type = cap_get_capType(slot->cap);
     if (cap_type != cap_null_cap) {
         bool_t final;
-        finaliseCap_ret_t fc_ret UNUSED;
+        finaliseCap_ret_t fc_ret;
 
         /** GHOSTUPD: "(gs_get_assn cteDeleteOne_'proc \<acute>ghost'state = (-1)
             \<or> gs_get_assn cteDeleteOne_'proc \<acute>ghost'state = \<acute>cap_type, id)" */
@@ -739,6 +740,7 @@ void cteDeleteOne(cte_t *slot)
         /* Haskell error: "cteDeleteOne: cap should be removable" */
         assert(capRemovable(fc_ret.remainder, slot) &&
                cap_get_capType(fc_ret.cleanupInfo) == cap_null_cap);
+        (void)fc_ret;
         emptySlot(slot, cap_null_cap_new());
     }
 }


### PR DESCRIPTION
## Summary
- ensure `capRemovable` returns explicitly when the default branch fires so the strict C90 build accepts the helper
- keep the `cteDeleteOne` finalisation result live under non-debug builds to avoid unused-variable diagnostics
- update the C89 porting plan to record the fix and note the new blocker in `endpoint.c`

## Testing
- `./preconfigured/replay_preconfigured_build.sh` *(fails: pedantic C90 build now stops in src/object/endpoint.c because sendIPC still mixes declarations with statements)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c2a6eb18832ba4ab7544f46c9dba