### PR TITLE
Fix pedantic issues in untyped and PC99 helpers

### DIFF
--- a/C89-PROJECT.md
+++ b/C89-PROJECT.md
@@ -150,6 +150,16 @@ those translation units pedantic-friendly. The strict build now advances to
 signedness mid-expression, the invocation wrapper's `call` parameter becomes
 unused, and the reset path still compares unlike-signed counters.
 
+Reworking the untyped invocation wrapper to cast its unused flag, compute the
+object-size diagnostic in a `word_t`, and compare the reset chunk size against a
+like-signed bound lets the pedantic build continue into the PC99 platform
+helpers. Dropping the trailing comma from the DMAR enumerator list and hoisting
+the LAPIC frequency measurement temporaries satisfy the C90 rules in
+`acpi.c` and `hardware.c`, allowing the replay build to reach the next blocker.
+The strict configuration now stops in `intel-vtd_wrapper.c`, where the generated
+wrapper collapses to an empty translation unit and triggers the pedantic
+diagnostic that C90 forbids empty files.
+
 ### Key Diagnostic Themes
 1. **C99 integer literals**: The generated capability helpers and several x86
    machine shims still emit `ULL` and `LL` constants that trigger

--- a/preconfigured/src/plat/pc99/machine/acpi.c
+++ b/preconfigured/src/plat/pc99/machine/acpi.c
@@ -41,7 +41,7 @@ compile_assert(acpi_dmar_header_packed, sizeof(acpi_dmar_header_t) == 4)
 enum acpi_table_dmar_struct_type {
     DMAR_DRHD = 0,
     DMAR_RMRR = 1,
-    DMAR_ATSR = 2,
+    DMAR_ATSR = 2
 };
 
 /* DMA Remapping Hardware unit Definition */


### PR DESCRIPTION
## Summary
- hoist the untyped invocation temporaries, consume the unused `call` flag, and compare reset chunk sizes with like-signed values
- drop the trailing comma from the DMAR enumerator list so `acpi.c` is C90-friendly
- hoist the time-stamp counter measurement locals and loop indices in the PC99 hardware helpers, and record the new `intel-vtd` blocker in the project log

## Testing
- ./preconfigured/replay_preconfigured_build.sh *(fails: pedantic build now stops in preconfigured/X64_verified/src/plat/pc99/machine/intel-vtd_wrapper.c because the translation unit is empty)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c858f754832b9a72ef70349cb62f