### PR TITLE
Silence ioapic warnings under pedantic C90

### DIFF
--- a/C89-PROJECT.md
+++ b/C89-PROJECT.md
@@ -157,6 +157,13 @@ helpers. Dropping the trailing comma from the DMAR enumerator list and hoisting
 the LAPIC frequency measurement temporaries satisfy the C90 rules in
 `acpi.c` and `hardware.c`, allowing the replay build to reach the next blocker.
 
+Replacing the IOAPIC initialisation diagnostic to use a literal function name
+and casting the unused configuration parameters to `(void)` quells the pedantic
+warnings in `src/plat/pc99/machine/ioapic.c`. With those changes the strict
+build runs through the platform sources until it stops in
+`preconfigured/X64_verified/src/smp/ipi_wrapper.c`, where the pedantic warning
+set now rejects the empty translation unit emitted by the generated wrapper.
+
 ### Key Diagnostic Themes
 1. **C99 integer literals**: The generated capability helpers and several x86
    machine shims still emit `ULL` and `LL` constants that trigger
@@ -265,6 +272,8 @@ the LAPIC frequency measurement temporaries satisfy the C90 rules in
         avoid C99 `for`-loop initialisers, and compare like-signed values.
   - [x] Cast the unused parameters in the x86 TLB invalidation wrappers and
         related boot helpers so the pedantic build stays quiet.
+- [x] Silence the IOAPIC initialisation helpers by avoiding `__func__` and
+  casting their unused parameters so they satisfy pedantic C90.
 - [x] Hoist declarations and add `(void)` casts in the x86 boot-time paging
         helpers (`map_temp_boot_page`, `create_mapped_it_frame_cap`, and the
         slot region initialiser) so they satisfy pedantic C90.
@@ -286,6 +295,9 @@ the LAPIC frequency measurement temporaries satisfy the C90 rules in
 - [x] Provide a benign definition in the x86 benchmarking stubs so the strict
   build no longer rejects the empty translation unit emitted by
   `src/arch/x86/benchmark/benchmark.c`.
+- [ ] Provide a benign definition in the generated SMP IPI wrapper so the
+  strict build no longer rejects the empty translation unit emitted by
+  `preconfigured/X64_verified/src/smp/ipi_wrapper.c`.
 - [x] Rewrite the syscall and exception message tables in
   `src/machine/registerset.c` so they avoid the designated initialisers that
   pedantic C90 rejects.

--- a/preconfigured/src/plat/pc99/machine/ioapic.c
+++ b/preconfigured/src/plat/pc99/machine/ioapic.c
@@ -78,9 +78,9 @@ static void single_ioapic_init(word_t ioapic, cpu_id_t delivery_cpu)
      * return a max value of 239, which means a max nirqs value of IOAPIC_IRQ_LINES.
      */
     if (nirqs > IOAPIC_IRQ_LINES) {
-        userError("%s: ioapic %lu has %u IRQs,\n"
+        userError("single_ioapic_init: ioapic %lu has %u IRQs,\n"
                   "which is greater than the max handled (%u)\n",
-                  __func__, ioapic, nirqs, IOAPIC_IRQ_LINES);
+                  ioapic, nirqs, IOAPIC_IRQ_LINES);
         halt();
     }
 
@@ -106,6 +106,7 @@ static  cpu_id_t ioapic_target_cpu = 0;
 void ioapic_init(uint32_t num_nodes, cpu_id_t *cpu_list, uint32_t num_ioapic)
 {
     uint32_t ioapic;
+    (void)num_nodes;
     num_ioapics = num_ioapic;
     ioapic_target_cpu = cpu_list[0];
 
@@ -137,6 +138,7 @@ void ioapic_mask(bool_t mask, uint32_t ioapic, uint32_t pin)
 exception_t ioapic_decode_map_pin_to_vector(word_t ioapic, word_t pin, word_t level,
                                             word_t polarity, word_t vector)
 {
+    (void)vector;
     if (num_ioapics == 0) {
         userError("System has no IOAPICs");
         current_syscall_error.type = seL4_IllegalOperation;


### PR DESCRIPTION
## Summary
- update the IOAPIC initialisation helper to log via a literal function name and mark unused inputs so it builds cleanly as C90
- note the ioapic fix and newly exposed SMP IPI wrapper failure in the C89 porting plan, adding a follow-up task for the empty translation unit

## Testing
- ./preconfigured/replay_preconfigured_build.sh *(fails: pedantic rejects preconfigured/X64_verified/src/smp/ipi_wrapper.c as an empty translation unit)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c9f1abb8832b88a39c4a9322013d