### PR TITLE
Fix util helpers and default domain for C90 build

### DIFF
--- a/C89-PROJECT.md
+++ b/C89-PROJECT.md
@@ -159,10 +159,11 @@ the LAPIC frequency measurement temporaries satisfy the C90 rules in
 
 Replacing the IOAPIC initialisation diagnostic to use a literal function name
 and casting the unused configuration parameters to `(void)` quells the pedantic
-warnings in `src/plat/pc99/machine/ioapic.c`. With those changes the strict
-build runs through the platform sources until it stops in
-`preconfigured/X64_verified/src/smp/ipi_wrapper.c`, where the pedantic warning
-set now rejects the empty translation unit emitted by the generated wrapper.
+warnings in `src/plat/pc99/machine/ioapic.c`. With those changes—and the new
+util/default-domain fixes—the strict build runs through the platform sources
+until it stops in `preconfigured/X64_verified/src/smp/ipi_wrapper.c`, where the
+pedantic warning set still rejects the empty translation unit emitted by the
+generated wrapper.
 
 ### Key Diagnostic Themes
 1. **C99 integer literals**: The generated capability helpers and several x86
@@ -298,6 +299,12 @@ set now rejects the empty translation unit emitted by the generated wrapper.
 - [ ] Provide a benign definition in the generated SMP IPI wrapper so the
   strict build no longer rejects the empty translation unit emitted by
   `preconfigured/X64_verified/src/smp/ipi_wrapper.c`.
+- [x] Teach `src/util.c`'s string and bit-twiddling helpers to compare against
+  like-signed bounds and declare their temporaries at the top of each block so
+  the strict C90 build accepts the translation unit.
+- [x] Replace the designated initialiser in `src/config/default_domain.c` with
+  an ordered initializer so the pedantic build accepts the default domain
+  schedule under C90.
 - [x] Rewrite the syscall and exception message tables in
   `src/machine/registerset.c` so they avoid the designated initialisers that
   pedantic C90 rejects.

--- a/preconfigured/src/config/default_domain.c
+++ b/preconfigured/src/config/default_domain.c
@@ -10,7 +10,7 @@
 
 /* Default schedule. The length is in ms */
 const dschedule_t ksDomSchedule[] = {
-    { .domain = 0, .length = 1 },
+    { 0, 1 },
 };
 
 const word_t ksDomScheduleLength = ARRAY_SIZE(ksDomSchedule);

--- a/preconfigured/src/util.c
+++ b/preconfigured/src/util.c
@@ -76,9 +76,16 @@ void *VISIBLE memcpy(void *ptr_dst, const void *ptr_src, unsigned long n)
 int PURE strncmp(const char *s1, const char *s2, int n)
 {
     word_t i;
+    word_t limit;
     int diff;
 
-    for (i = 0; i < n; i++) {
+    if (n <= 0) {
+        return 0;
+    }
+
+    limit = (word_t)n;
+
+    for (i = 0; i < limit; i++) {
         diff = ((unsigned char *)s1)[i] - ((unsigned char *)s2)[i];
         if (diff != 0 || s1[i] == '\0') {
             return diff;
@@ -209,36 +216,41 @@ static UNUSED CONST inline unsigned clz32(uint32_t x)
     /* The `if (1)` blocks make it easier to reason by chunks in the proofs. */
     if (1) {
         /* iteration 4 */
+        unsigned bits;
         mask >>= (1 << 4); /* 0x0000ffff */
-        unsigned bits = ((unsigned)(mask < x)) << 4; /* [0, 16] */
+        bits = ((unsigned)(mask < x)) << 4; /* [0, 16] */
         x >>= bits; /* <= 0x0000ffff */
         count -= bits; /* [16, 32] */
     }
     if (1) {
         /* iteration 3 */
+        unsigned bits;
         mask >>= (1 << 3); /* 0x000000ff */
-        unsigned bits = ((unsigned)(mask < x)) << 3; /* [0, 8] */
+        bits = ((unsigned)(mask < x)) << 3; /* [0, 8] */
         x >>= bits; /* <= 0x000000ff */
         count -= bits; /* [8, 16, 24, 32] */
     }
     if (1) {
         /* iteration 2 */
+        unsigned bits;
         mask >>= (1 << 2); /* 0x0000000f */
-        unsigned bits = ((unsigned)(mask < x)) << 2; /* [0, 4] */
+        bits = ((unsigned)(mask < x)) << 2; /* [0, 4] */
         x >>= bits; /* <= 0x0000000f */
         count -= bits; /* [4, 8, 12, ..., 32] */
     }
     if (1) {
         /* iteration 1 */
+        unsigned bits;
         mask >>= (1 << 1); /* 0x00000003 */
-        unsigned bits = ((unsigned)(mask < x)) << 1; /* [0, 2] */
+        bits = ((unsigned)(mask < x)) << 1; /* [0, 2] */
         x >>= bits; /* <= 0x00000003 */
         count -= bits; /* [2, 4, 6, ..., 32] */
     }
     if (1) {
         /* iteration 0 */
+        unsigned bits;
         mask >>= (1 << 0); /* 0x00000001 */
-        unsigned bits = ((unsigned)(mask < x)) << 0; /* [0, 1] */
+        bits = ((unsigned)(mask < x)) << 0; /* [0, 1] */
         x >>= bits; /* <= 0x00000001 */
         count -= bits; /* [1, 2, 3, ..., 32] */
     }
@@ -260,43 +272,49 @@ static UNUSED CONST inline unsigned clz64(uint64_t x)
     /* developed for clz32. */
     if (1) {
         /* iteration 5 */
+        unsigned bits;
         mask >>= (1 << 5); /* 0x00000000ffffffff */
-        unsigned bits = ((unsigned)(mask < x)) << 5; /* [0, 32] */
+        bits = ((unsigned)(mask < x)) << 5; /* [0, 32] */
         x >>= bits; /* <= 0x00000000ffffffff */
         count -= bits; /* [32, 64] */
     }
     if (1) {
         /* iteration 4 */
+        unsigned bits;
         mask >>= (1 << 4); /* 0x000000000000ffff */
-        unsigned bits = ((unsigned)(mask < x)) << 4; /* [0, 16] */
+        bits = ((unsigned)(mask < x)) << 4; /* [0, 16] */
         x >>= bits; /* <= 0x000000000000ffff */
         count -= bits; /* [16, 32, 48, 64] */
     }
     if (1) {
         /* iteration 3 */
+        unsigned bits;
         mask >>= (1 << 3); /* 0x00000000000000ff */
-        unsigned bits = ((unsigned)(mask < x)) << 3; /* [0, 8] */
+        bits = ((unsigned)(mask < x)) << 3; /* [0, 8] */
         x >>= bits; /* <= 0x00000000000000ff */
         count -= bits; /* [8, 16, 24, ..., 64] */
     }
     if (1) {
         /* iteration 2 */
+        unsigned bits;
         mask >>= (1 << 2); /* 0x000000000000000f */
-        unsigned bits = ((unsigned)(mask < x)) << 2; /* [0, 4] */
+        bits = ((unsigned)(mask < x)) << 2; /* [0, 4] */
         x >>= bits; /* <= 0x000000000000000f */
         count -= bits; /* [4, 8, 12, ..., 64] */
     }
     if (1) {
         /* iteration 1 */
+        unsigned bits;
         mask >>= (1 << 1); /* 0x0000000000000003 */
-        unsigned bits = ((unsigned)(mask < x)) << 1; /* [0, 2] */
+        bits = ((unsigned)(mask < x)) << 1; /* [0, 2] */
         x >>= bits; /* <= 0x0000000000000003 */
         count -= bits; /* [2, 4, 6, ..., 64] */
     }
     if (1) {
         /* iteration 0 */
+        unsigned bits;
         mask >>= (1 << 0); /* 0x0000000000000001 */
-        unsigned bits = ((unsigned)(mask < x)) << 0; /* [0, 1] */
+        bits = ((unsigned)(mask < x)) << 0; /* [0, 1] */
         x >>= bits; /* <= 0x0000000000000001 */
         count -= bits; /* [1, 2, 3, ..., 64] */
     }
@@ -331,36 +349,41 @@ static UNUSED CONST inline unsigned ctz32(uint32_t x)
 
     if (1) {
         /* iteration 4 */
+        unsigned bits;
         mask >>= (1 << 4); /* 0x0000ffff */
-        unsigned bits = ((unsigned)((x & mask) == 0)) << 4; /* [0, 16] */
+        bits = ((unsigned)((x & mask) == 0)) << 4; /* [0, 16] */
         x >>= bits; /* xi != 0 --> x & 0x0000ffff != 0 */
         count += bits; /* if xi != 0 then [0, 16] else 17 */
     }
     if (1) {
         /* iteration 3 */
+        unsigned bits;
         mask >>= (1 << 3); /* 0x000000ff */
-        unsigned bits = ((unsigned)((x & mask) == 0)) << 3; /* [0, 8] */
+        bits = ((unsigned)((x & mask) == 0)) << 3; /* [0, 8] */
         x >>= bits; /* xi != 0 --> x & 0x000000ff != 0 */
         count += bits; /* if xi != 0 then [0, 8, 16, 24] else 25 */
     }
     if (1) {
         /* iteration 2 */
+        unsigned bits;
         mask >>= (1 << 2); /* 0x0000000f */
-        unsigned bits = ((unsigned)((x & mask) == 0)) << 2; /* [0, 4] */
+        bits = ((unsigned)((x & mask) == 0)) << 2; /* [0, 4] */
         x >>= bits; /* xi != 0 --> x & 0x0000000f != 0 */
         count += bits; /* if xi != 0 then [0, 4, 8, ..., 28] else 29 */
     }
     if (1) {
         /* iteration 1 */
+        unsigned bits;
         mask >>= (1 << 1); /* 0x00000003 */
-        unsigned bits = ((unsigned)((x & mask) == 0)) << 1; /* [0, 2] */
+        bits = ((unsigned)((x & mask) == 0)) << 1; /* [0, 2] */
         x >>= bits; /* xi != 0 --> x & 0x00000003 != 0 */
         count += bits; /* if xi != 0 then [0, 2, 4, ..., 30] else 31 */
     }
     if (1) {
         /* iteration 0 */
+        unsigned bits;
         mask >>= (1 << 0); /* 0x00000001 */
-        unsigned bits = ((unsigned)((x & mask) == 0)) << 0; /* [0, 1] */
+        bits = ((unsigned)((x & mask) == 0)) << 0; /* [0, 1] */
         x >>= bits; /* xi != 0 --> x & 0x00000001 != 0 */
         count += bits; /* if xi != 0 then [0, 1, 2, ..., 31] else 32 */
     }
@@ -375,43 +398,49 @@ static UNUSED CONST inline unsigned ctz64(uint64_t x)
 
     if (1) {
         /* iteration 5 */
+        unsigned bits;
         mask >>= (1 << 5); /* 0x00000000ffffffff */
-        unsigned bits = ((unsigned)((x & mask) == 0)) << 5; /* [0, 32] */
+        bits = ((unsigned)((x & mask) == 0)) << 5; /* [0, 32] */
         x >>= bits; /* xi != 0 --> x & 0x00000000ffffffff != 0 */
         count += bits; /* if xi != 0 then [0, 32] else 33 */
     }
     if (1) {
         /* iteration 4 */
+        unsigned bits;
         mask >>= (1 << 4); /* 0x000000000000ffff */
-        unsigned bits = ((unsigned)((x & mask) == 0)) << 4; /* [0, 16] */
+        bits = ((unsigned)((x & mask) == 0)) << 4; /* [0, 16] */
         x >>= bits; /* xi != 0 --> x & 0x000000000000ffff != 0 */
         count += bits; /* if xi != 0 then [0, 16, 32, 48] else 49 */
     }
     if (1) {
         /* iteration 3 */
+        unsigned bits;
         mask >>= (1 << 3); /* 0x00000000000000ff */
-        unsigned bits = ((unsigned)((x & mask) == 0)) << 3; /* [0, 8] */
+        bits = ((unsigned)((x & mask) == 0)) << 3; /* [0, 8] */
         x >>= bits; /* xi != 0 --> x & 0x00000000000000ff != 0 */
         count += bits; /* if xi != 0 then [0, 8, 16, ..., 56] else 57 */
     }
     if (1) {
         /* iteration 2 */
+        unsigned bits;
         mask >>= (1 << 2); /* 0x000000000000000f */
-        unsigned bits = ((unsigned)((x & mask) == 0)) << 2; /* [0, 4] */
+        bits = ((unsigned)((x & mask) == 0)) << 2; /* [0, 4] */
         x >>= bits; /* xi != 0 --> x & 0x000000000000000f != 0 */
         count += bits; /* if xi != 0 then [0, 4, 8, ..., 60] else 61 */
     }
     if (1) {
         /* iteration 1 */
+        unsigned bits;
         mask >>= (1 << 1); /* 0x0000000000000003 */
-        unsigned bits = ((unsigned)((x & mask) == 0)) << 1; /* [0, 2] */
+        bits = ((unsigned)((x & mask) == 0)) << 1; /* [0, 2] */
         x >>= bits; /* xi != 0 --> x & 0x0000000000000003 != 0 */
         count += bits; /* if xi != 0 then [0, 2, 4, ..., 62] else 63 */
     }
     if (1) {
         /* iteration 0 */
+        unsigned bits;
         mask >>= (1 << 0); /* 0x0000000000000001 */
-        unsigned bits = ((unsigned)((x & mask) == 0)) << 0; /* [0, 1] */
+        bits = ((unsigned)((x & mask) == 0)) << 0; /* [0, 1] */
         x >>= bits; /* xi != 0 --> x & 0x0000000000000001 != 0 */
         count += bits; /* if xi != 0 then [0, 1, 2, ..., 63] else 64 */
     }


### PR DESCRIPTION
## Summary
- hoist the CLZ/CTZ temporaries in util.c and normalise strncmp's length check for strict C90
- replace the designated initializer in src/config/default_domain.c with an ordered initializer
- update the C89 project tracker to record the progress and remaining blocker

## Testing
- ./preconfigured/replay_preconfigured_build.sh *(fails: preconfigured/X64_verified/src/smp/ipi_wrapper.c is still an empty translation unit under -Wpedantic)*

------
https://chatgpt.com/codex/tasks/task_e_68d3cb8a9418832b89e8a5cfce9f5f3d