### PR TITLE
Fix pedantic boot table relocations

### DIFF
--- a/C89-PROJECT.md
+++ b/C89-PROJECT.md
@@ -58,16 +58,15 @@ resulting compiler diagnostics.
   through dedicated helpers removes the pedantic complaints about directives
   living inside macro arguments. Routing the x86 trap macros through explicit
   `PUSH_ERROR_CODE_*` helpers clears the empty-argument warnings, so the strict
-  build now runs through the trap assembly and halts during final linking: the
-  linker reports a series of `R_X86_64_32` relocations in
-  `src/arch/x86/64/head.S` that reference the `boot_pml4` and `boot_pdpt`
-  symbols defined in the wrapped C sources.
-
-  The new relocation failures suggest we need to revisit how the boot-time
-  assembly materialises the paging structures when building with the stricter
-  flags. Adjusting the relocation mode or loading those addresses through
-  temporaries should unblock the pedantic build so we can continue cataloguing
-  any remaining C90 incompatibilities.
+  build now runs through the trap assembly and previously halted during final
+  linking with a series of `R_X86_64_32` relocations in
+  `src/arch/x86/64/head.S`. Teaching the 32-bit boot stub to reference
+  `boot_pml4` and `boot_pdpt` via `KERNEL_ELF_BASE_OFFSET` whenever
+  `SEL4_C89_COMPAT` collapses the section attributes resolves those truncation
+  errors: the pedantic replay now links `kernel.elf` and continues compiling the
+  recorded wrapper sources without surfacing new diagnostics. The next round of
+  work can therefore focus on any remaining C90 clean-ups in the generated and
+  library code.
 
   The libsel4 enumerations now carry an explicit
   `__mode__(__word__)` attribute instead of depending on `__extension__`, the

--- a/preconfigured/src/arch/x86/64/head.S
+++ b/preconfigured/src/arch/x86/64/head.S
@@ -22,7 +22,16 @@
  * continuing. */
 
 #include <config.h>
+#include <util.h>
+#include <hardware.h>
+#include <compiler.h>
 #include <machine/assembler.h>
+
+#if SEL4_C89_COMPAT
+#define BOOT_TABLE_REF(sym) sym - KERNEL_ELF_BASE_OFFSET
+#else
+#define BOOT_TABLE_REF(sym) sym
+#endif
 
 #define IA32_EFER_MSR 0xC0000080
 #define IA32_APIC_BASE_MSR 0x01B
@@ -76,7 +85,7 @@ BEGIN_FUNC(setup_pml4)
     andl $0x7fffffff, %eax
     movl %eax, %cr0
 
-    movl $boot_pml4, %edi
+    movl $BOOT_TABLE_REF(boot_pml4), %edi
     movl $0x0, %edx
     movl $1024, %ecx
 1:
@@ -84,15 +93,15 @@ BEGIN_FUNC(setup_pml4)
     addl $4, %edi
     loop 1b
 
-    movl $boot_pdpt, %edi
+    movl $BOOT_TABLE_REF(boot_pdpt), %edi
     movl $1024, %ecx
 1:
     movl %edx, (%edi)
     addl $4, %edi
     loop 1b
 
-    movl $boot_pml4, %edi
-    movl $boot_pdpt, %ecx
+    movl $BOOT_TABLE_REF(boot_pml4), %edi
+    movl $BOOT_TABLE_REF(boot_pdpt), %ecx
     orl  $0x7, %ecx
     movl %ecx, (%edi)
     movl %ecx, 0x800(%edi)
@@ -100,7 +109,7 @@ BEGIN_FUNC(setup_pml4)
 
     movl $_boot_pd, %ecx
     orl  $0x7, %ecx
-    movl $boot_pdpt, %edi
+    movl $BOOT_TABLE_REF(boot_pdpt), %edi
     movl %ecx, (%edi)
     movl %ecx, 4080(%edi)
     addl $0x1000, %ecx
@@ -220,7 +229,7 @@ BEGIN_FUNC(enable_x64_mode)
     call invpcid_check
 #endif
     /* Put base pointer in cr3. */
-    movl $boot_pml4, %eax
+    movl $BOOT_TABLE_REF(boot_pml4), %eax
     movl %eax, %cr3
     /* Set PAE (bit 5), as this is required before switching to long mode. */
     movl %cr4, %eax


### PR DESCRIPTION
## Summary
- adjust the 32-bit boot assembly to reference the boot paging tables through `KERNEL_ELF_BASE_OFFSET` when the C89 build collapses the section attributes, preventing the pedantic linker from emitting `R_X86_64_32` truncations
- document in the C89 project log that the relocation fix lets the strict replay link `kernel.elf` and proceed with the recorded compilation steps

## Testing
- ./preconfigured/replay_preconfigured_build.sh

------
https://chatgpt.com/codex/tasks/task_e_68d3d2cba638832b905a6b803bd2df1a